### PR TITLE
fix: correct Claude Code plugin install commands and add marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "socraticode",
+  "owner": {
+    "name": "Giancarlo Erra",
+    "email": "giancarlo@altaire.com"
+  },
+  "metadata": {
+    "description": "SocratiCode — codebase intelligence plugin for Claude Code"
+  },
+  "plugins": [
+    {
+      "name": "socraticode",
+      "source": "./",
+      "description": "Codebase intelligence — semantic search workflows, dependency graph analysis, and context artifact exploration",
+      "category": "development"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ The first Qdrant‑based MCP/Claude Plugin/Skill that pairs auto‑managed, zero
 
 **Claude Code** — install the plugin (recommended, includes workflow skills for best results):
 
-```bash
-claude plugin add --from-github giancarloerra/socraticode
+```
+/plugin marketplace add giancarloerra/socraticode
+/plugin install socraticode@socraticode
 ```
 
 Or as MCP only (without skills):
@@ -296,8 +297,9 @@ before reading any files directly.
 
 The SocratiCode plugin bundles both the MCP server and workflow skills that teach Claude how to use the tools effectively. One install gives you everything:
 
-```bash
-claude plugin add --from-github giancarloerra/socraticode
+```
+/plugin marketplace add giancarloerra/socraticode
+/plugin install socraticode@socraticode
 ```
 
 The plugin includes:


### PR DESCRIPTION
## Summary

Fix incorrect Claude Code plugin install commands and add the missing `marketplace.json` required for marketplace-based plugin distribution.

## Changes

- Replace non-existent `claude plugin add --from-github` command with correct marketplace commands in README (both Quick Start and Configuration sections)
- Add `.claude-plugin/marketplace.json` — required for users to install the plugin via `/plugin marketplace add`
- Remove unsupported `$schema` key and fix relative source path (`"."` → `"./"`) per Claude Code validator

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Testing

- [x] `claude plugin validate .` passes
- [x] Verified no remaining occurrences of `claude plugin add --from-github` in README

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have updated documentation (README.md) if needed
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

## Related issues

Fixes incorrect install instructions shipped in v1.1.0.