### PR TITLE
fix: correct hooks.json format, remove explicit hooks path, and improve install docs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,6 +18,5 @@
     "semantic-search",
     "mcp"
   ],
-  "mcpServers": "./.mcp.json",
-  "hooks": "./hooks/hooks.json"
+  "mcpServers": "./.mcp.json"
 }

--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ The first Qdrant‑based MCP/Claude Plugin/Skill that pairs auto‑managed, zero
 
 **Claude Code** — install the plugin (recommended, includes workflow skills for best results):
 
+From your shell:
+
+```bash
+claude plugin marketplace add giancarloerra/socraticode
+claude plugin install socraticode@socraticode
+```
+
+Or from within Claude Code:
+
 ```
 /plugin marketplace add giancarloerra/socraticode
 /plugin install socraticode@socraticode
@@ -296,6 +305,15 @@ before reading any files directly.
 #### Claude Code plugin (recommended for Claude Code users)
 
 The SocratiCode plugin bundles both the MCP server and workflow skills that teach Claude how to use the tools effectively. One install gives you everything:
+
+From your shell:
+
+```bash
+claude plugin marketplace add giancarloerra/socraticode
+claude plugin install socraticode@socraticode
+```
+
+Or from within Claude Code:
 
 ```
 /plugin marketplace add giancarloerra/socraticode

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,14 +1,16 @@
 {
-  "SessionStart": [
-    {
-      "matcher": ".*",
-      "hooks": [
-        {
-          "type": "prompt",
-          "prompt": "IMPORTANT: If you notice that SocratiCode MCP tools appear with BOTH a plugin prefix (e.g. mcp__plugin_socraticode_socraticode__codebase_search) AND a standalone prefix (e.g. mcp__socraticode__codebase_search), the user has a duplicate configuration. Advise them to remove the standalone MCP by running: claude mcp remove socraticode — the plugin already provides the MCP server.",
-          "timeout": 5
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "IMPORTANT: If you notice that SocratiCode MCP tools appear with BOTH a plugin prefix (e.g. mcp__plugin_socraticode_socraticode__codebase_search) AND a standalone prefix (e.g. mcp__socraticode__codebase_search), the user has a duplicate configuration. Advise them to remove the standalone MCP by running: claude mcp remove socraticode — the plugin already provides the MCP server.",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Fix the plugin hooks loading error reported by `/doctor` and improve Claude Code install instructions in README.

## Changes

- Wrap `hooks/hooks.json` events under a `"hooks"` key as required by Claude Code's plugin loader
- Remove explicit `"hooks": "./hooks/hooks.json"` path from `plugin.json` (auto-discovered from default location)
- Add shell commands (`claude plugin marketplace add` / `claude plugin install`) alongside the in-Claude `/plugin` commands in both Quick Start and Configuration sections

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Testing

- [x] `claude plugin validate .` passes
- [x] `claude --plugin-dir .` loads without hook errors
- [x] `/doctor` shows no socraticode errors for the inline plugin

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have updated documentation (README.md) if needed
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

## Related issues

Fixes hook load error: "Invalid input: expected record, received undefined"