### PR TITLE
fix: only call ensureOllamaReady() when using Ollama embedding provider

### DIFF
--- a/src/tools/query-tools.ts
+++ b/src/tools/query-tools.ts
@@ -6,6 +6,8 @@ import { SEARCH_DEFAULT_LIMIT, SEARCH_MIN_SCORE } from "../constants.js";
 import { getGraphStatus } from "../services/code-graph.js";
 import { getArtifactStatusSummary } from "../services/context-artifacts.js";
 import { ensureQdrantReady } from "../services/docker.js";
+import { getEmbeddingConfig } from "../services/embedding-config.js";
+import { getEmbeddingProvider } from "../services/embedding-provider.js";
 import type { IndexingProgress } from "../services/indexer.js";
 import { getIndexingProgress, getLastCompleted, isIndexingInProgress } from "../services/indexer.js";
 import { getLockHolderPid, } from "../services/lock.js";
@@ -57,7 +59,13 @@ export async function handleQueryTool(
   switch (name) {
     case "codebase_search": {
       await ensureQdrantReady();
-      await ensureOllamaReady();
+      // Only ensure Ollama infrastructure when using the Ollama embedding provider.
+      // For OpenAI/Google providers, just ensure the provider is initialized.
+      if (getEmbeddingConfig().embeddingProvider === "ollama") {
+        await ensureOllamaReady();
+      } else {
+        await getEmbeddingProvider();
+      }
 
       const query = args.query as string;
       const limit = (args.limit as number) || SEARCH_DEFAULT_LIMIT;


### PR DESCRIPTION
## Summary

- Fixes `codebase_search` failing for OpenAI and Google embedding users
- `ensureOllamaReady()` was called unconditionally on every search, regardless of `EMBEDDING_PROVIDER`
- Now only called when `embeddingProvider === "ollama"`; otherwise initializes the configured provider via `getEmbeddingProvider()`

Fixes #7

## Test plan

- [ ] Verify `codebase_search` works with `EMBEDDING_PROVIDER=openai` without Ollama installed
- [ ] Verify `codebase_search` still works with `EMBEDDING_PROVIDER=ollama` (no regression)
- [ ] Verify no Ollama Docker container is created when using OpenAI/Google providers