### PR TITLE
fix: add prepublishOnly to keep dist/ in sync with source

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "biome check src/ tests/",
     "lint:fix": "biome check --write src/ tests/",
     "release": "release-it",
+    "prepublishOnly": "tsc",
     "release:dry": "release-it --dry-run",
     "test": "vitest run",
     "test:unit": "vitest run tests/unit/",


### PR DESCRIPTION
## Problem

The `SOCRATICODE_PROJECT_ID` environment variable support exists in the TypeScript source (`src/config.ts`) but is missing from the published `dist/config.js` in npm v1.3.0. This means the env var is silently ignored when installed via `npx -y socraticode`.

This affects users working with **git worktrees** or **Copy-on-Write clone environments** (like Polyscope) who need multiple directory paths to share the same Socraticode index.

## Root cause

The `dist/` folder was committed from a build that predates the `SOCRATICODE_PROJECT_ID` feature. Subsequent releases (v1.1.0–v1.3.0) published without rebuilding.

## Fix

- Add `"prepublishOnly": "tsc"` to `package.json` so `dist/` is automatically rebuilt before every `npm publish`
- Rebuild `dist/` to include all current source changes

## Verification

After this fix, `dist/config.js` contains the `SOCRATICODE_PROJECT_ID` logic:
```js
const explicit = process.env.SOCRATICODE_PROJECT_ID?.trim();
if (explicit && /^[a-zA-Z0-9_-]+$/.test(explicit)) return explicit;
```