### PR TITLE
fix(docker): include api-key header in external Qdrant readiness probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,7 +1095,7 @@ The rest of this section documents the variables themselves. Pass them using whi
 | `QDRANT_PORT` | `16333` | Qdrant REST API port (managed mode, or external without `QDRANT_URL`) |
 | `QDRANT_GRPC_PORT` | `16334` | Qdrant gRPC port (managed mode only) |
 | `QDRANT_HOST` | `localhost` | Qdrant hostname (alternative to `QDRANT_URL` for non-HTTPS external instances) |
-| `QDRANT_API_KEY` | *(none)* | Qdrant API key (required for Qdrant Cloud and other authenticated deployments) |
+| `QDRANT_API_KEY` | *(none)* | Qdrant API key (required for Qdrant Cloud and other authenticated deployments). When set, the URL must be `https://...` so the key is not transmitted over plain HTTP. Loopback URLs (`localhost`, `127.0.0.1`, `[::1]`) are accepted on `http://` for local development. |
 
 ### Indexing Behaviour
 

--- a/src/services/docker.ts
+++ b/src/services/docker.ts
@@ -201,6 +201,32 @@ async function ensureExternalQdrantReady(onProgress?: InfraProgressCallback): Pr
   const baseUrl = QDRANT_URL ? QDRANT_URL.replace(/\/$/, "") : `http://${QDRANT_HOST}:${QDRANT_PORT}`;
   const healthUrl = `${baseUrl}/healthz`;
 
+  // If an api-key is configured, refuse to send it over a non-TLS connection.
+  // Localhost loopback URLs are accepted because some users run authenticated
+  // Qdrant locally during development. The URL is parsed (rather than checked
+  // with startsWith) so that hostnames like "http://localhost.evil.com" are
+  // not mistaken for loopback. Placed before the try/catch so the specific
+  // error is not masked by the generic "Cannot reach" message below.
+  if (QDRANT_API_KEY) {
+    let parsed: URL | null = null;
+    try {
+      parsed = new URL(baseUrl);
+    } catch {
+      /* fall through: the unparseable URL will fail the reachability check */
+    }
+    const isHttps = parsed?.protocol === "https:";
+    const isLoopback = parsed
+      ? ["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname)
+      : false;
+    if (parsed && !isHttps && !isLoopback) {
+      throw new Error(
+        `QDRANT_API_KEY is set but ${baseUrl} is not HTTPS. ` +
+        "Refusing to send the API key over a non-TLS connection. " +
+        "Use https://... for remote or cloud Qdrant (a localhost URL is also accepted for local development).",
+      );
+    }
+  }
+
   onProgress?.(`Checking external Qdrant at ${baseUrl}...`);
   logger.info("Checking external Qdrant", { url: baseUrl });
 

--- a/src/services/docker.ts
+++ b/src/services/docker.ts
@@ -7,6 +7,7 @@ import {
   OLLAMA_HOST,
   OLLAMA_IMAGE,
   OLLAMA_PORT,
+  QDRANT_API_KEY,
   QDRANT_CONTAINER_NAME,
   QDRANT_GRPC_PORT,
   QDRANT_HOST,
@@ -203,13 +204,20 @@ async function ensureExternalQdrantReady(onProgress?: InfraProgressCallback): Pr
   onProgress?.(`Checking external Qdrant at ${baseUrl}...`);
   logger.info("Checking external Qdrant", { url: baseUrl });
 
+  // Qdrant Cloud requires authentication on every endpoint, including /healthz
+  // (returns 403 without an api-key header). Locally run Qdrant typically does
+  // not, so the header is sent only when QDRANT_API_KEY is configured.
+  const init: RequestInit | undefined = QDRANT_API_KEY
+    ? { headers: { "api-key": QDRANT_API_KEY } }
+    : undefined;
+
   try {
     // 5 retries × 1 s — fast fail for misconfiguration, brief grace for transient flakiness
-    await waitForService(healthUrl, "Qdrant", 5, 1000);
+    await waitForService(healthUrl, "Qdrant", 5, 1000, init);
   } catch {
     throw new Error(
       `Cannot reach external Qdrant at ${baseUrl}.\n` +
-      "Verify that QDRANT_URL (or QDRANT_HOST/QDRANT_PORT) is correct and the server is reachable.",
+      "Verify that QDRANT_URL (or QDRANT_HOST/QDRANT_PORT) and QDRANT_API_KEY (if required) are correct and the server is reachable.",
     );
   }
 
@@ -348,12 +356,16 @@ export async function ensureOllamaContainerReady(onProgress?: InfraProgressCallb
 
 // ── Shared ────────────────────────────────────────────────────────────────
 
-/** Wait for an HTTP service to respond with 200 */
-async function waitForService(url: string, serviceName: string, retries = 30, delayMs = 1000): Promise<void> {
+/** Wait for an HTTP service to respond with 200.
+ *
+ * `init` is forwarded to fetch(), allowing callers to attach headers (e.g. an
+ * `api-key` header for Qdrant Cloud, whose /healthz endpoint requires auth).
+ */
+async function waitForService(url: string, serviceName: string, retries = 30, delayMs = 1000, init?: RequestInit): Promise<void> {
   logger.info(`Waiting for ${serviceName} to be ready`, { url });
   for (let i = 0; i < retries; i++) {
     try {
-      const resp = await fetch(url);
+      const resp = await fetch(url, init);
       if (resp.ok) {
         logger.info(`${serviceName} is ready`);
         return;

--- a/tests/unit/docker.test.ts
+++ b/tests/unit/docker.test.ts
@@ -397,4 +397,49 @@ describe("ensureQdrantReady external mode", () => {
 
     fetchSpy.mockRestore();
   }, 30_000);
+
+  it("sends api-key header to /healthz when QDRANT_API_KEY is configured", async () => {
+    const docker = await loadDockerWithExternalMode({
+      QDRANT_URL: "https://cloud-qdrant.example:6333",
+      QDRANT_HOST: "cloud-qdrant.example",
+      QDRANT_API_KEY: "secret-key-xyz",
+    });
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({ ok: true } as Response);
+
+    const result = await docker.ensureQdrantReady();
+    expect(result).toEqual({ started: false, pulled: false });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://cloud-qdrant.example:6333/healthz",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "api-key": "secret-key-xyz" }),
+      }),
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("omits api-key header when QDRANT_API_KEY is not set", async () => {
+    const docker = await loadDockerWithExternalMode({
+      QDRANT_URL: "http://local-qdrant:6333",
+      QDRANT_HOST: "local-qdrant",
+      // QDRANT_API_KEY intentionally undefined (matches local self-hosted Qdrant)
+    });
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({ ok: true } as Response);
+
+    await docker.ensureQdrantReady();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://local-qdrant:6333/healthz",
+      undefined,
+    );
+
+    fetchSpy.mockRestore();
+  });
 });

--- a/tests/unit/docker.test.ts
+++ b/tests/unit/docker.test.ts
@@ -426,7 +426,9 @@ describe("ensureQdrantReady external mode", () => {
     const docker = await loadDockerWithExternalMode({
       QDRANT_URL: "http://local-qdrant:6333",
       QDRANT_HOST: "local-qdrant",
-      // QDRANT_API_KEY intentionally undefined (matches local self-hosted Qdrant)
+      // Explicitly undefined so the test does not pick up a real
+      // QDRANT_API_KEY from the developer's shell environment.
+      QDRANT_API_KEY: undefined,
     });
 
     const fetchSpy = vi
@@ -438,6 +440,51 @@ describe("ensureQdrantReady external mode", () => {
     expect(fetchSpy).toHaveBeenCalledWith(
       "http://local-qdrant:6333/healthz",
       undefined,
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("rejects QDRANT_API_KEY over plain HTTP for non-loopback hosts", async () => {
+    const docker = await loadDockerWithExternalMode({
+      QDRANT_URL: "http://remote-qdrant.example:6333",
+      QDRANT_HOST: "remote-qdrant.example",
+      QDRANT_API_KEY: "secret-key-xyz",
+    });
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({ ok: true } as Response);
+
+    await expect(docker.ensureQdrantReady()).rejects.toThrow(
+      /QDRANT_API_KEY is set but .* is not HTTPS/,
+    );
+    // The guard runs before the readiness probe, so fetch is never called.
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("allows QDRANT_API_KEY over plain HTTP when host is localhost (local dev)", async () => {
+    const docker = await loadDockerWithExternalMode({
+      QDRANT_URL: "http://localhost:6333",
+      QDRANT_HOST: "localhost",
+      QDRANT_API_KEY: "secret-key-xyz",
+    });
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({ ok: true } as Response);
+
+    await expect(docker.ensureQdrantReady()).resolves.toEqual({
+      started: false,
+      pulled: false,
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:6333/healthz",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "api-key": "secret-key-xyz" }),
+      }),
     );
 
     fetchSpy.mockRestore();


### PR DESCRIPTION
Fixes #35.

## What

Forward `QDRANT_API_KEY` as an `api-key` request header from `ensureExternalQdrantReady()` by extending `waitForService()` with an optional `RequestInit` argument.

## Why

Qdrant Cloud requires authentication on **every** endpoint, including `/healthz`. The current readiness probe sends no headers, so it always receives `403 forbidden` and throws "Cannot reach external Qdrant" — even though `codebase_health` (qdrant-js client, sends api-key) reports the same endpoint as Reachable.

## How

- `src/services/docker.ts`
  - Add `QDRANT_API_KEY` to the constants import.
  - In `ensureExternalQdrantReady`, build `init?: RequestInit` carrying `{ headers: { "api-key": QDRANT_API_KEY } }` when the env var is configured.
  - Pass `init` through `waitForService(...)`.
  - Mention `QDRANT_API_KEY` in the failure message so misconfiguration surfaces quickly.
- `waitForService` gains an optional 5th parameter `init?: RequestInit` forwarded to `fetch()`. All existing call sites (Docker-managed Qdrant, Ollama) remain unchanged → backwards compatible.

## Tests

`tests/unit/docker.test.ts` adds two cases (using the existing external-mode `vi.doMock` harness):

- `sends api-key header to /healthz when QDRANT_API_KEY is configured`
- `omits api-key header when QDRANT_API_KEY is not set`

`npm run lint` clean. `npm run test:unit` 704 pass (702 baseline + 2 new). `npm run build` clean.

## Compatibility

| Mode | Behavior |
| --- | --- |
| Docker-managed Qdrant | Unchanged — no `init` forwarded → no headers sent. |
| External Qdrant without auth | Unchanged — `QDRANT_API_KEY` unset → `init` is `undefined`. |
| External Qdrant with auth (Qdrant Cloud, self-hosted with auth) | Works — `api-key` header attached. |

## Manual verification

Reproduced the original failure against a Qdrant Cloud cluster (us-west-2), then ran the patched build through the same MCP `codebase_index` invocation: indexing now proceeds and completes (10625 chunks across 3040 files in ~5min, OpenAI text-embedding-3-small). `codebase_search` returns expected results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API-key authenticated readiness checks for external Qdrant endpoints.

* **Bug Fixes**
  * Clearer error when Qdrant is unreachable, mentioning QDRANT_API_KEY as a possible missing config.
  * Prevents using an API key with plain HTTP on non-local hosts to avoid insecure key transmission.

* **Documentation**
  * Notes that QDRANT_API_KEY requires HTTPS except for loopback addresses (localhost/127.0.0.1/[::1]).

* **Tests**
  * Added unit tests covering API-key behavior for readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->