### PR TITLE
fix: extract JVM symbol names from declarations

### DIFF
--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -470,10 +470,8 @@ function extractFromJvm(
     : ["class_declaration", "interface_declaration", "enum_declaration", "object_declaration"];
   for (const k of classKinds) {
     for (const cls of safeFindAll(root, k)) {
-      const nameNode = cls.find({ rule: { kind: "type_identifier" } })
-        ?? cls.find({ rule: { kind: "identifier" } });
-      if (!nameNode) continue;
-      const name = nameNode.text();
+      const name = extractJvmTypeName(cls.text(), langKey);
+      if (!name) continue;
       const r = cls.range();
       const startLine = r.start.line + 1;
       const endLine = r.end.line + 1;
@@ -496,10 +494,8 @@ function extractFromJvm(
       : ["method_declaration", "constructor_declaration"];
   for (const k of methodKinds) {
     for (const m of safeFindAll(root, k)) {
-      const nameNode = m.find({ rule: { kind: "identifier" } })
-        ?? m.find({ rule: { kind: "simple_identifier" } });
-      if (!nameNode) continue;
-      const name = nameNode.text();
+      const name = extractJvmCallableName(m.text());
+      if (!name) continue;
       const r = m.range();
       const startLine = r.start.line + 1;
       const endLine = r.end.line + 1;
@@ -531,6 +527,32 @@ function extractFromJvm(
     }
   }
   return { symbols, rawCalls };
+}
+
+function stripJvmAnnotations(text: string): string {
+  return text
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("@"))
+    .join("\n");
+}
+
+function extractJvmTypeName(text: string, langKey: string): string | null {
+  const withoutAnnotations = stripJvmAnnotations(text);
+  const header = withoutAnnotations.split("{", 1)[0] ?? withoutAnnotations;
+  const pattern = langKey === "scala"
+    ? /\b(?:class|object|trait)\s+([A-Za-z_$][\w$]*)\b/
+    : /\b(?:class|interface|enum|object)\s+([A-Za-z_$][\w$]*)\b/;
+  return header.match(pattern)?.[1] ?? null;
+}
+
+function extractJvmCallableName(text: string): string | null {
+  const withoutAnnotations = stripJvmAnnotations(text);
+  const signature = withoutAnnotations
+    .split("{", 1)[0]
+    .split("=", 1)[0]
+    .trim();
+  const matches = Array.from(signature.matchAll(/([A-Za-z_$][\w$]*)\s*\(/g));
+  return matches.length > 0 ? matches[matches.length - 1][1] : null;
 }
 
 // ── C# ──────────────────────────────────────────────────────────────────

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -532,7 +532,9 @@ function extractFromJvm(
 function stripJvmAnnotations(text: string): string {
   return text
     .split("\n")
-    .filter((line) => !line.trim().startsWith("@"))
+    .map((line) =>
+      line.replace(/^\s*(?:@(?:[\w$]+:)?[\w$.]+(?:\([^)]*\))?\s*)+/, "")
+    )
     .join("\n");
 }
 
@@ -551,6 +553,10 @@ function extractJvmCallableName(text: string): string | null {
     .split("{", 1)[0]
     .split("=", 1)[0]
     .trim();
+  const scalaDefMatches = Array.from(signature.matchAll(/\bdef\s+([A-Za-z_$][\w$]*)\b/g));
+  if (scalaDefMatches.length > 0) {
+    return scalaDefMatches[scalaDefMatches.length - 1][1];
+  }
   const matches = Array.from(signature.matchAll(/([A-Za-z_$][\w$]*)\s*\(/g));
   return matches.length > 0 ? matches[matches.length - 1][1] : null;
 }

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -149,6 +149,41 @@ public class Foo {
       expect(names).toContain("baz");
     });
 
+    it("prefers the declared Java class name over parameter types in Spring Boot entrypoints", () => {
+      const src = `
+@SpringBootApplication
+public class WorkflowFlowableApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(WorkflowFlowableApplication.class, args);
+    }
+}
+`;
+      const out = extractSymbolsAndCalls(src, "java" as unknown as Lang, ".java", "WorkflowFlowableApplication.java");
+      const names = out.symbols.map((s) => s.name);
+      expect(names).toContain("WorkflowFlowableApplication");
+      expect(names).not.toContain("String");
+      expect(names).toContain("main");
+    });
+
+    it("does not treat Java test annotations as method names", () => {
+      const src = `
+class SecurityAuthClientRequireSubjectTest {
+    @AfterEach
+    void cleanup() {}
+
+    @Test
+    void requireSubjectThrows() {}
+}
+`;
+      const out = extractSymbolsAndCalls(src, "java" as unknown as Lang, ".java", "SecurityAuthClientRequireSubjectTest.java");
+      const names = out.symbols.map((s) => s.name);
+      expect(names).toContain("SecurityAuthClientRequireSubjectTest");
+      expect(names).toContain("cleanup");
+      expect(names).toContain("requireSubjectThrows");
+      expect(names).not.toContain("AfterEach");
+      expect(names).not.toContain("Test");
+    });
+
     it("extracts Kotlin top-level fun and class methods", () => {
       const src = `
 fun greet(name: String): String = "Hi"

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -184,6 +184,19 @@ class SecurityAuthClientRequireSubjectTest {
       expect(names).not.toContain("Test");
     });
 
+    it("preserves Java declarations when annotations share the same line", () => {
+      const src = `
+class InlineAnnotationTest {
+    @Test void cleanup() {}
+}
+`;
+      const out = extractSymbolsAndCalls(src, "java" as unknown as Lang, ".java", "InlineAnnotationTest.java");
+      const names = out.symbols.map((s) => s.name);
+      expect(names).toContain("InlineAnnotationTest");
+      expect(names).toContain("cleanup");
+      expect(names).not.toContain("Test");
+    });
+
     it("extracts Kotlin top-level fun and class methods", () => {
       const src = `
 fun greet(name: String): String = "Hi"
@@ -203,6 +216,8 @@ class Bar {
       const src = `
 class Foo {
   def bar(): Int = 1
+  def size: Int = 1
+  def now = Instant.now()
 }
 
 object Main {
@@ -212,6 +227,8 @@ object Main {
       const out = extractSymbolsAndCalls(src, "scala" as unknown as Lang, ".scala", "Main.scala");
       const names = out.symbols.map((s) => s.name);
       expect(names).toContain("bar");
+      expect(names).toContain("size");
+      expect(names).toContain("now");
       expect(names).toContain("main");
     });
   });

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -173,6 +173,9 @@ class SecurityAuthClientRequireSubjectTest {
 
     @Test
     void requireSubjectThrows() {}
+
+    @Test(timeout = 1000)
+    void fastTest() {}
 }
 `;
       const out = extractSymbolsAndCalls(src, "java" as unknown as Lang, ".java", "SecurityAuthClientRequireSubjectTest.java");
@@ -180,6 +183,7 @@ class SecurityAuthClientRequireSubjectTest {
       expect(names).toContain("SecurityAuthClientRequireSubjectTest");
       expect(names).toContain("cleanup");
       expect(names).toContain("requireSubjectThrows");
+      expect(names).toContain("fastTest");
       expect(names).not.toContain("AfterEach");
       expect(names).not.toContain("Test");
     });


### PR DESCRIPTION
## Summary
- fix JVM symbol extraction so Java/Kotlin/Scala declarations use the declaration name instead of the first subtree identifier
- avoid treating Java annotations like @Test / @AfterEach as method symbols
- add regression tests for Spring Boot entrypoints and annotated Java test methods

## Problem
Java symbol extraction was walking the whole declaration subtree and taking the first identifier or type_identifier. In real Spring Boot code this caused class symbols like WorkflowFlowableApplication and CamundaApplication to be indexed as String, and annotated test methods to be indexed as Test / AfterEach.

## Verification
- npm run test:unit -- tests/unit/graph-symbols.test.ts
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbol extraction for JVM languages (Java, Kotlin, Scala).
  * Strip annotations from identifiers so annotations aren’t emitted as method names; methods still extracted when annotation and method share a line.
  * Prefer declared class name for Spring Boot entrypoint detection over parameter type names.

* **Tests**
  * Added JVM unit tests for annotation handling, entrypoint selection, and expanded Scala symbol coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->