### PR TITLE
fix(graph): resolve Python sibling-flat imports in service-style monorepos

### DIFF
--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -189,6 +189,19 @@ export function resolveImport(
         );
         if (inSrc) return inSrc;
       }
+
+      // Sibling-flat fallback (issue #46). Common in service-style monorepos
+      // where each top-level directory is a runnable Python application root
+      // and `import config` from `service-a/main.py` means
+      // `service-a/config.py` because the file is run via `python main.py`
+      // from inside its own directory. Tried last to preserve existing
+      // project-root precedence: any layout that already resolved before
+      // this PR continues to resolve to the same file. resolveRelativePath
+      // also handles the `<sourceDir>/<module>/__init__.py` package case
+      // via its built-in Python init fallback.
+      const sibling = resolveRelativePath(modulePath, sourceDir, projectPath, fileSet, [".py"]);
+      if (sibling) return sibling;
+
       return null;
     }
 

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -268,6 +268,103 @@ describe("graph-resolution", () => {
 
       expect(result).toBe("src/mypackage/utils.py");
     });
+
+    it("resolves sibling-flat imports in service-style monorepos (#46)", () => {
+      // service-a/main.py runs as `python main.py` from inside service-a/,
+      // so `import config` resolves to service-a/config.py at runtime.
+      project = createTempProject({
+        "service-a/main.py": "",
+        "service-a/config.py": "",
+        "service-b/main.py": "",
+        "service-b/config.py": "",
+      });
+
+      const result = resolveImport(
+        "config",
+        path.join(project.root, "service-a/main.py"),
+        project.root,
+        project.fileSet,
+        "python",
+      );
+
+      expect(result).toBe("service-a/config.py");
+    });
+
+    it("resolves sibling-flat imports for dotted module paths", () => {
+      // `import shared.utils` from service-a/main.py with shared/utils.py
+      // sitting next to main.py.
+      project = createTempProject({
+        "service-a/main.py": "",
+        "service-a/shared/utils.py": "",
+      });
+
+      const result = resolveImport(
+        "shared.utils",
+        path.join(project.root, "service-a/main.py"),
+        project.root,
+        project.fileSet,
+        "python",
+      );
+
+      expect(result).toBe("service-a/shared/utils.py");
+    });
+
+    it("resolves sibling packages via __init__.py", () => {
+      // `import config` resolves to service-a/config/__init__.py when no
+      // bare service-a/config.py exists.
+      project = createTempProject({
+        "service-a/main.py": "",
+        "service-a/config/__init__.py": "",
+      });
+
+      const result = resolveImport(
+        "config",
+        path.join(project.root, "service-a/main.py"),
+        project.root,
+        project.fileSet,
+        "python",
+      );
+
+      expect(result).toBe("service-a/config/__init__.py");
+    });
+
+    it("preserves project-root precedence when the same name exists at root and as a sibling", () => {
+      // Backward-compat guarantee: `import config` from service-a/main.py
+      // still resolves to the project-root config.py if one exists, so
+      // existing layouts do not change after this PR. The sibling fallback
+      // only fires when the project-root lookup fails.
+      project = createTempProject({
+        "config.py": "",
+        "service-a/main.py": "",
+        "service-a/config.py": "",
+      });
+
+      const result = resolveImport(
+        "config",
+        path.join(project.root, "service-a/main.py"),
+        project.root,
+        project.fileSet,
+        "python",
+      );
+
+      expect(result).toBe("config.py");
+    });
+
+    it("returns null when neither project-root, src/, lib/, nor sibling have the module", () => {
+      project = createTempProject({
+        "service-a/main.py": "",
+      });
+
+      const result = resolveImport(
+        "config",
+        path.join(project.root, "service-a/main.py"),
+        project.root,
+        project.fileSet,
+        "python",
+      );
+
+      expect(result).toBeNull();
+    });
   });
 
   describe("Rust resolution", () => {


### PR DESCRIPTION
Resolves #46. Reported by @mrsuit92.

## What this fixes

Python projects where each top-level directory is a runnable application root (a common service-style monorepo layout) had `import config` from `service-a/main.py` produce 0 dependency edges, even when `service-a/config.py` sits next to the importer. At runtime Python resolves this correctly because the importer's directory is `sys.path[0]` when the file is run as `python main.py` from inside its own directory. The static resolver did not check that path.

## Mechanism

`graph-resolution.ts` Python case (lines 168-192 on main) only tried:

```
<projectPath>/<module>.py
<projectPath>/src/<module>.py
<projectPath>/lib/<module>.py
```

It did not try `<sourceDir>/<module>.py`, so non-relative sibling imports never resolved. Relative imports (`from .config import ...`) already used `sourceDir` via the existing relative-import branch and worked correctly.

## The fix

Add `<sourceDir>/<module>.py` as the **last** fallback, after the existing project-root and src/lib checks. Tried last to preserve project-root precedence, so any layout that resolved before this PR continues to resolve to the same file: there is no behaviour change for projects that already worked.

```typescript
// Sibling-flat fallback (issue #46). Common in service-style monorepos
// where each top-level directory is a runnable Python application root
// and `import config` from `service-a/main.py` means
// `service-a/config.py` because the file is run via `python main.py`
// from inside its own directory. Tried last to preserve existing
// project-root precedence: any layout that already resolved before
// this PR continues to resolve to the same file. resolveRelativePath
// also handles the `<sourceDir>/<module>/__init__.py` package case
// via its built-in Python init fallback.
const sibling = resolveRelativePath(modulePath, sourceDir, projectPath, fileSet, [".py"]);
if (sibling) return sibling;
```

`resolveRelativePath` already has Python `__init__.py` support, so `import config` resolves to either `service-a/config.py` or `service-a/config/__init__.py`, whichever exists.

## Backward compatibility

The fix is strictly additive: it only resolves to a sibling when the existing project-root, `src/`, and `lib/` lookups all fail. No previously-resolving import will resolve differently.

The one design tradeoff: when both `<projectPath>/config.py` AND `<sourceDir>/config.py` exist, project-root wins (preserves existing behaviour). This is the safest default. A more accurate "closest wins" heuristic was discussed in the issue and could come later if real reports surface; this PR sticks to the minimum-risk change.

## Tests

5 new tests in `tests/unit/graph-resolution.test.ts` covering:

1. Sibling-flat resolution in a multi-service layout (`import config` from `service-a/main.py` resolves to `service-a/config.py` when no project-root `config.py` exists, even though `service-b/config.py` exists too)
2. Dotted module paths (`import shared.utils` resolves to `service-a/shared/utils.py`)
3. Sibling packages via `__init__.py` (`import config` resolves to `service-a/config/__init__.py`)
4. Project-root precedence preservation (when both root and sibling have the same name, root still wins)
5. Negative case (returns null when neither project-root, src/, lib/, nor sibling have the module)

Existing 730 unit tests continue to pass unchanged. Total: **735 pass**.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check src tests` clean
- [x] `npm run test:unit` 735/735 pass
- [x] `coderabbit review --plain` no findings
- [x] `snyk code test` only the pre-existing finding in `provider-lmstudio.ts:65` (unrelated)

## Credit

@mrsuit92 filed a clean bug report with accurate file/line citations, a precise reproduction, the exact mechanism, and a sensible proposed fix that mirrors the existing pattern. Implementation here matches their proposal directly.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] Breaking change
- [x] Test coverage improvement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Python import resolution to support sibling module imports in monorepo projects, including flat and package-based patterns.

* **Tests**
  * Added comprehensive test coverage for Python import resolution in service-style monorepo scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->