### PR TITLE
feat(startup): opt-in auto-resume of all indexed projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1216,6 +1216,8 @@ The rest of this section documents the variables themselves. Pass them using whi
 | `SOCRATICODE_PROJECT_ID` | *(none)* | Override the auto-generated project ID. When set, all paths resolve to the same Qdrant collections, allowing multiple directories (e.g. git worktrees of the same repo) to share a single index. Must match `[a-zA-Z0-9_-]+`. Takes precedence over the `projectId` field in `.socraticode.json`. |
 | `SOCRATICODE_BRANCH_AWARE` | `false` | When `true`, append the current git branch name to the project ID, creating separate Qdrant collections per branch. Ignored when `SOCRATICODE_PROJECT_ID` is set or when `projectId` is set in `.socraticode.json`. |
 | `SOCRATICODE_LINKED_PROJECTS` | *(none)* | Comma-separated list of additional project paths to include in cross-project search. Merged with paths from `.socraticode.json`. Non-existent paths are silently skipped. |
+| `SOCRATICODE_AUTO_RESUME` | *(none)* | When set to `all`, server startup auto-resumes the file watcher plus an incremental catch-up update for **every** indexed project that has a stored path, not just the current working directory. Projects resume one at a time (sequentially) to avoid overloading the embedding provider. Skipped projects (directory no longer exists, or indexed before path tracking was added) are logged at warn level. Useful when one MCP server session should keep many canonical checkouts fresh. |
+| `SOCRATICODE_AUTO_RESUME_PROJECTS` | *(none)* | Comma-separated list of project paths to auto-resume on server startup (sequentially), e.g. `/repos/api,/repos/web`. Takes precedence over `SOCRATICODE_AUTO_RESUME`. Paths that do not exist or are not indexed are skipped with a warning. |
 | `SOCRATICODE_LOG_LEVEL` | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
 | `SOCRATICODE_LOG_FILE` | *(none)* | Absolute path to a log file. When set, all log entries are appended to this file (a session separator is written on each server start). Useful for debugging when the MCP host doesn't surface log notifications. |
 
@@ -1382,6 +1384,11 @@ then start watching.
 The watcher will not auto-start if a full index or incremental update is currently in
 progress, if the project has not been indexed yet, or if another MCP process is already
 watching the same project.
+
+If you work across many indexed repos and want all of them resumed at server startup
+(watcher plus catch-up update), not just the one you opened, see the
+`SOCRATICODE_AUTO_RESUME` and `SOCRATICODE_AUTO_RESUME_PROJECTS` environment variables
+in the [Indexing Behaviour](#indexing-behaviour) table.
 
 ### Can multiple AI agents work on the same codebase at the same time?
 

--- a/src/services/startup.ts
+++ b/src/services/startup.ts
@@ -8,31 +8,46 @@
  * of the MCP stdio transport.
  */
 
+import fs from "node:fs";
+import path from "node:path";
 import { collectionName, projectIdFromPath } from "../config.js";
-import { QDRANT_MODE } from "../constants.js";
+import { QDRANT_COLLECTION_PREFIX, QDRANT_MODE } from "../constants.js";
 import { isDockerAvailable, isQdrantRunning } from "./docker.js";
 import { getIndexingInProgressProjects, getPersistedIndexingStatus, indexProject, requestCancellation, updateProjectIndex } from "./indexer.js";
 import { getLockHolderPid, releaseAllLocks } from "./lock.js";
 import { logger } from "./logger.js";
-import { listCodebaseCollections } from "./qdrant.js";
+import { getProjectMetadata, listCodebaseCollections } from "./qdrant.js";
 import { isWatching, startWatching, stopAllWatchers } from "./watcher.js";
 
 /**
- * Auto-resume for the current project (process.cwd()) on server startup.
+ * Auto-resume indexed projects on server startup.
  *
- * If the project has a completed index:
- *   - Start file watcher
- *   - Run incremental update to catch changes made while the MCP was down
+ * Which projects are resumed is controlled by two opt-in environment
+ * variables (issue #70). Default (both unset) keeps the original behavior:
+ * only the project at process.cwd() is considered.
  *
- * If the project has an incomplete (interrupted) index:
- *   - Run indexProject which skips already-hashed files and embeds the rest,
- *     correctly resuming the full index (supports codebase_stop cancellation)
- *   - Watcher starts automatically after indexProject completes
+ *   - SOCRATICODE_AUTO_RESUME_PROJECTS: comma-separated list of project
+ *     paths to resume. Takes precedence over SOCRATICODE_AUTO_RESUME.
+ *   - SOCRATICODE_AUTO_RESUME=all: resume every indexed project that has a
+ *     stored path in its Qdrant metadata.
+ *
+ * Multi-project modes resume strictly sequentially: each project's catch-up
+ * (incremental update or interrupted-index recovery) completes before the
+ * next starts, so N projects never stampede the embedding provider. Skipped
+ * projects (missing directory, no stored path, not indexed) are logged at
+ * warn level so misconfiguration is visible.
+ *
+ * Per project, if the index is complete: start the file watcher and run an
+ * incremental update to catch changes made while the MCP was down. If the
+ * index is incomplete (interrupted): resume it via indexProject, which skips
+ * already-hashed files and honours codebase_stop cancellation; the watcher
+ * starts after recovery completes.
  *
  * Runs in the background after server startup — non-blocking, non-fatal.
  *
- * @param projectPath - Override project path (defaults to process.cwd()).
- *   Only used by tests — production always uses process.cwd().
+ * @param projectPath - Override project path for the default single-project
+ *   mode (defaults to process.cwd()). Only used by tests — production always
+ *   uses process.cwd().
  */
 export async function autoResumeIndexedProjects(projectPath?: string): Promise<void> {
   try {
@@ -49,7 +64,28 @@ export async function autoResumeIndexedProjects(projectPath?: string): Promise<v
       }
     }
 
-    // Only consider the current project
+    // Read at call time (not module load) so tests and MCP host configs
+    // that set the variables after import are honoured.
+    const explicitList = process.env.SOCRATICODE_AUTO_RESUME_PROJECTS?.trim();
+    const resumeMode = process.env.SOCRATICODE_AUTO_RESUME?.trim();
+
+    if (explicitList) {
+      await resumeProjectList(explicitList);
+      return;
+    }
+
+    if (resumeMode) {
+      if (resumeMode.toLowerCase() === "all") {
+        await resumeAllIndexedProjects();
+        return;
+      }
+      logger.warn("Auto-resume: unrecognized SOCRATICODE_AUTO_RESUME value, using default behavior (current project only)", {
+        value: resumeMode,
+      });
+      // Fall through to the default single-project behavior below.
+    }
+
+    // Default: only consider the current project
     const resolvedPath = projectPath ?? process.cwd();
 
     // If CWD is root or home, the MCP host hasn't opened a specific project yet — skip
@@ -58,92 +94,208 @@ export async function autoResumeIndexedProjects(projectPath?: string): Promise<v
       return;
     }
 
-    const projectId = projectIdFromPath(resolvedPath);
-    const collection = collectionName(projectId);
-
     const collections = await listCodebaseCollections();
-    if (!collections.includes(collection)) {
-      logger.info("Auto-resume: current project not yet indexed, skipping", { projectPath: resolvedPath });
-      return;
-    }
-
-    // Check persisted indexing status to detect interrupted indexing
-    const persistedStatus = await getPersistedIndexingStatus(resolvedPath);
-
-    if (persistedStatus === "in-progress") {
-      // Check if another process is already indexing (orphan from previous session)
-      const orphanPid = await getLockHolderPid(resolvedPath, "index");
-      if (orphanPid !== null) {
-        logger.info("Auto-resume: skipping — another process is still indexing this project", {
-          projectPath: resolvedPath, orphanPid,
-        });
-        return;
-      }
-
-      // Index was interrupted — resume it via indexProject.
-      // indexProject skips already-hashed files, embeds the rest, and honours
-      // codebase_stop cancellation requests (unlike updateProjectIndex's incremental diff).
-      // Do NOT start watcher yet — it will start after indexing completes.
-      logger.info("Auto-resume: detected incomplete index, resuming indexing", { projectPath: resolvedPath });
-      const resumeOnProgress = (msg: string) => logger.info(msg, { tool: "auto-resume", projectPath: resolvedPath });
-      indexProject(resolvedPath, resumeOnProgress)
-        .then(async (result) => {
-          logger.info("Auto-resume: incomplete index recovery completed", {
-            projectPath: resolvedPath,
-            filesIndexed: result.filesIndexed,
-            chunksCreated: result.chunksCreated,
-            cancelled: result.cancelled,
-          });
-          // Now start the watcher after recovery — only if not cancelled
-          if (!result.cancelled && !isWatching(resolvedPath)) {
-            const started = await startWatching(resolvedPath);
-            if (started) {
-              logger.info("Auto-resume: started file watcher after recovery", { projectPath: resolvedPath });
-            }
-          }
-        })
-        .catch((err) => {
-          logger.warn("Auto-resume: incomplete index recovery failed (non-fatal)", {
-            projectPath: resolvedPath,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        });
-      return;
-    }
-
-    // Index is complete — start watcher and do incremental catch-up
-    if (!isWatching(resolvedPath)) {
-      const started = await startWatching(resolvedPath);
-      if (started) {
-        logger.info("Auto-resume: started file watcher", { projectPath: resolvedPath });
-      }
-    }
-
-    // Incremental update in the background — only re-embeds actually changed files
-    // Note: updateProjectIndex now handles code graph rebuild internally
-    updateProjectIndex(resolvedPath)
-      .then(async (result) => {
-        const changed = result.added + result.updated + result.removed;
-        if (changed > 0) {
-          logger.info("Auto-resume: incremental update completed", {
-            projectPath: resolvedPath,
-            added: result.added,
-            updated: result.updated,
-            removed: result.removed,
-            filesChanged: changed,
-          });
-        } else {
-          logger.info("Auto-resume: index is up to date", { projectPath: resolvedPath });
-        }
-      })
-      .catch((err) => {
-        logger.warn("Auto-resume: incremental update failed (non-fatal)", {
-          projectPath: resolvedPath,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
+    await resumeProject(resolvedPath, collections, "info");
   } catch (err) {
     logger.warn("Auto-resume failed (non-fatal)", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Resume the explicit comma-separated project list from
+ * SOCRATICODE_AUTO_RESUME_PROJECTS, sequentially. Paths are resolved to
+ * absolute and deduplicated; entries whose directory does not exist are
+ * skipped with a warning. One project failing does not stop the rest.
+ */
+async function resumeProjectList(rawList: string): Promise<void> {
+  const targets = [...new Set(
+    rawList
+      .split(",")
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0)
+      .map((p) => path.resolve(p)),
+  )];
+
+  if (targets.length === 0) {
+    logger.warn("Auto-resume: SOCRATICODE_AUTO_RESUME_PROJECTS is set but contains no paths");
+    return;
+  }
+
+  logger.info("Auto-resume: resuming explicit project list sequentially", { count: targets.length });
+  const collections = await listCodebaseCollections();
+
+  for (const target of targets) {
+    if (!fs.existsSync(target)) {
+      logger.warn("Auto-resume: listed project directory does not exist, skipping", { projectPath: target });
+      continue;
+    }
+    try {
+      await resumeProject(target, collections, "warn");
+    } catch (err) {
+      logger.warn("Auto-resume: project resume failed, continuing with remaining projects", {
+        projectPath: target,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/**
+ * Resume every indexed project found in Qdrant (SOCRATICODE_AUTO_RESUME=all),
+ * sequentially. Project paths come from each collection's stored metadata;
+ * collections without a stored path (indexed before path tracking) and paths
+ * that no longer exist on disk are skipped with a warning.
+ */
+async function resumeAllIndexedProjects(): Promise<void> {
+  const collections = await listCodebaseCollections();
+  const codebasePrefix = `${QDRANT_COLLECTION_PREFIX}codebase_`;
+  const codebaseCollections = collections.filter((c) => c.startsWith(codebasePrefix));
+
+  if (codebaseCollections.length === 0) {
+    logger.info("Auto-resume: no indexed projects found, nothing to resume");
+    return;
+  }
+
+  const targets: string[] = [];
+  const seen = new Set<string>();
+  for (const coll of codebaseCollections) {
+    const metadata = await getProjectMetadata(coll);
+    if (!metadata?.projectPath) {
+      logger.warn("Auto-resume: project has no stored path (indexed before path tracking), cannot auto-resume. Re-index it once to fix this permanently.", {
+        collection: coll,
+      });
+      continue;
+    }
+    const resolved = path.resolve(metadata.projectPath);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    if (!fs.existsSync(resolved)) {
+      logger.warn("Auto-resume: indexed project directory no longer exists, skipping", {
+        projectPath: resolved,
+        collection: coll,
+      });
+      continue;
+    }
+    targets.push(resolved);
+  }
+
+  logger.info("Auto-resume: resuming all indexed projects sequentially", { count: targets.length });
+
+  for (const target of targets) {
+    try {
+      await resumeProject(target, collections, "warn");
+    } catch (err) {
+      logger.warn("Auto-resume: project resume failed, continuing with remaining projects", {
+        projectPath: target,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/**
+ * Resume a single project: start its watcher and catch up its index.
+ * Awaits the catch-up work to completion so callers can sequence multiple
+ * projects without overlapping embedding load.
+ *
+ * @param resolvedPath - Absolute project path.
+ * @param collections - Pre-fetched Qdrant collection names (fetched once per
+ *   startup so multi-project modes do not re-query per project).
+ * @param skipLogLevel - "warn" in multi-project modes so misconfigured
+ *   entries are visible; "info" for the default cwd mode (an unindexed cwd
+ *   is normal, not a misconfiguration).
+ */
+async function resumeProject(
+  resolvedPath: string,
+  collections: string[],
+  skipLogLevel: "info" | "warn",
+): Promise<void> {
+  const projectId = projectIdFromPath(resolvedPath);
+  const collection = collectionName(projectId);
+
+  if (!collections.includes(collection)) {
+    if (skipLogLevel === "warn") {
+      logger.warn("Auto-resume: project not yet indexed, skipping", { projectPath: resolvedPath });
+    } else {
+      logger.info("Auto-resume: current project not yet indexed, skipping", { projectPath: resolvedPath });
+    }
+    return;
+  }
+
+  // Check persisted indexing status to detect interrupted indexing
+  const persistedStatus = await getPersistedIndexingStatus(resolvedPath);
+
+  if (persistedStatus === "in-progress") {
+    // Check if another process is already indexing (orphan from previous session)
+    const orphanPid = await getLockHolderPid(resolvedPath, "index");
+    if (orphanPid !== null) {
+      logger.info("Auto-resume: skipping — another process is still indexing this project", {
+        projectPath: resolvedPath, orphanPid,
+      });
+      return;
+    }
+
+    // Index was interrupted — resume it via indexProject.
+    // indexProject skips already-hashed files, embeds the rest, and honours
+    // codebase_stop cancellation requests (unlike updateProjectIndex's incremental diff).
+    // Do NOT start watcher yet — it will start after indexing completes.
+    logger.info("Auto-resume: detected incomplete index, resuming indexing", { projectPath: resolvedPath });
+    const resumeOnProgress = (msg: string) => logger.info(msg, { tool: "auto-resume", projectPath: resolvedPath });
+    try {
+      const result = await indexProject(resolvedPath, resumeOnProgress);
+      logger.info("Auto-resume: incomplete index recovery completed", {
+        projectPath: resolvedPath,
+        filesIndexed: result.filesIndexed,
+        chunksCreated: result.chunksCreated,
+        cancelled: result.cancelled,
+      });
+      // Now start the watcher after recovery — only if not cancelled
+      if (!result.cancelled && !isWatching(resolvedPath)) {
+        const started = await startWatching(resolvedPath);
+        if (started) {
+          logger.info("Auto-resume: started file watcher after recovery", { projectPath: resolvedPath });
+        }
+      }
+    } catch (err) {
+      logger.warn("Auto-resume: incomplete index recovery failed (non-fatal)", {
+        projectPath: resolvedPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return;
+  }
+
+  // Index is complete — start watcher and do incremental catch-up
+  if (!isWatching(resolvedPath)) {
+    const started = await startWatching(resolvedPath);
+    if (started) {
+      logger.info("Auto-resume: started file watcher", { projectPath: resolvedPath });
+    }
+  }
+
+  // Incremental update: only re-embeds actually changed files. Awaited so
+  // multi-project resume stays sequential (auto-resume as a whole already
+  // runs in the background, so this blocks nothing user-facing).
+  // Note: updateProjectIndex handles code graph rebuild internally.
+  try {
+    const result = await updateProjectIndex(resolvedPath);
+    const changed = result.added + result.updated + result.removed;
+    if (changed > 0) {
+      logger.info("Auto-resume: incremental update completed", {
+        projectPath: resolvedPath,
+        added: result.added,
+        updated: result.updated,
+        removed: result.removed,
+        filesChanged: changed,
+      });
+    } else {
+      logger.info("Auto-resume: index is up to date", { projectPath: resolvedPath });
+    }
+  } catch (err) {
+    logger.warn("Auto-resume: incremental update failed (non-fatal)", {
+      projectPath: resolvedPath,
       error: err instanceof Error ? err.message : String(err),
     });
   }

--- a/src/services/startup.ts
+++ b/src/services/startup.ts
@@ -267,11 +267,21 @@ async function resumeProject(
     return;
   }
 
-  // Index is complete — start watcher and do incremental catch-up
+  // Index is complete — start watcher and do incremental catch-up.
+  // Watcher startup failure must not skip the catch-up below: a project
+  // without a live watcher is degraded, but a project with a stale index
+  // is broken for search.
   if (!isWatching(resolvedPath)) {
-    const started = await startWatching(resolvedPath);
-    if (started) {
-      logger.info("Auto-resume: started file watcher", { projectPath: resolvedPath });
+    try {
+      const started = await startWatching(resolvedPath);
+      if (started) {
+        logger.info("Auto-resume: started file watcher", { projectPath: resolvedPath });
+      }
+    } catch (err) {
+      logger.warn("Auto-resume: failed to start watcher, continuing with incremental catch-up", {
+        projectPath: resolvedPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 // All external service dependencies are mocked so these tests run without Docker.
@@ -12,6 +15,7 @@ vi.mock("../../src/services/docker.js", () => ({
 
 vi.mock("../../src/services/qdrant.js", () => ({
   listCodebaseCollections: vi.fn(),
+  getProjectMetadata: vi.fn(),
 }));
 
 vi.mock("../../src/services/indexer.js", () => ({
@@ -56,7 +60,7 @@ import { isDockerAvailable, isQdrantRunning } from "../../src/services/docker.js
 import { getIndexingInProgressProjects, getPersistedIndexingStatus, indexProject, requestCancellation, updateProjectIndex } from "../../src/services/indexer.js";
 import { getLockHolderPid, releaseAllLocks } from "../../src/services/lock.js";
 import { logger } from "../../src/services/logger.js";
-import { listCodebaseCollections } from "../../src/services/qdrant.js";
+import { getProjectMetadata, listCodebaseCollections } from "../../src/services/qdrant.js";
 import { autoResumeIndexedProjects, awaitActiveIndexing, gracefulShutdown } from "../../src/services/startup.js";
 import { isWatching, startWatching, stopAllWatchers } from "../../src/services/watcher.js";
 
@@ -64,6 +68,7 @@ import { isWatching, startWatching, stopAllWatchers } from "../../src/services/w
 const mockIsDockerAvailable = vi.mocked(isDockerAvailable);
 const mockIsQdrantRunning = vi.mocked(isQdrantRunning);
 const mockListCollections = vi.mocked(listCodebaseCollections);
+const mockGetProjectMetadata = vi.mocked(getProjectMetadata);
 const mockGetPersistedStatus = vi.mocked(getPersistedIndexingStatus);
 const mockIndexProject = vi.mocked(indexProject);
 const mockUpdateProjectIndex = vi.mocked(updateProjectIndex);
@@ -84,6 +89,10 @@ beforeEach(() => {
   mockIsDockerAvailable.mockResolvedValue(true);
   mockIsQdrantRunning.mockResolvedValue(true);
   mockGetIndexingInProgress.mockReturnValue([]);
+  // Auto-resume mode env vars must never leak between tests (or in from the
+  // shell): default-mode tests below assume both are unset.
+  delete process.env.SOCRATICODE_AUTO_RESUME;
+  delete process.env.SOCRATICODE_AUTO_RESUME_PROJECTS;
 });
 
 // ── autoResumeIndexedProjects ────────────────────────────────────────────
@@ -315,6 +324,249 @@ describe("autoResumeIndexedProjects", () => {
       "Auto-resume failed (non-fatal)",
       expect.objectContaining({ error: "Docker daemon gone" }),
     );
+  });
+});
+
+// ── autoResumeIndexedProjects: multi-project modes (issue #70) ───────────
+
+describe("autoResumeIndexedProjects (multi-project modes)", () => {
+  // Real directories: the multi-project modes check fs.existsSync before
+  // resuming, so mocked paths are not enough.
+  let dirA: string;
+  let dirB: string;
+  let collA: string;
+  let collB: string;
+
+  const noChanges = { added: 0, updated: 0, removed: 0, chunksCreated: 0, cancelled: false };
+
+  /** Minimal valid metadata for a collection whose project lives at `projectPath`. */
+  const metadataFor = (projectPath: string) => ({
+    projectPath,
+    lastIndexedAt: "2026-01-01T00:00:00.000Z",
+    filesTotal: 1,
+    filesIndexed: 1,
+    indexingStatus: "completed" as const,
+  });
+
+  beforeEach(() => {
+    dirA = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-resume-a-"));
+    dirB = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-resume-b-"));
+    collA = collectionName(projectIdFromPath(dirA));
+    collB = collectionName(projectIdFromPath(dirB));
+
+    mockListCollections.mockResolvedValue([collA, collB]);
+    mockGetPersistedStatus.mockResolvedValue("completed");
+    mockIsWatching.mockReturnValue(false);
+    mockStartWatching.mockResolvedValue(true);
+    mockUpdateProjectIndex.mockResolvedValue(noChanges);
+  });
+
+  afterEach(() => {
+    for (const dir of [dirA, dirB]) {
+      try {
+        fs.rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  // ── SOCRATICODE_AUTO_RESUME_PROJECTS (explicit list) ───────────────────
+
+  it("resumes each listed project strictly sequentially (no embedding stampede)", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME_PROJECTS = `${dirA},${dirB}`;
+
+    // Project A's catch-up is held open: B must not start until it resolves.
+    let resolveA!: (v: typeof noChanges) => void;
+    const deferredA = new Promise<typeof noChanges>((res) => {
+      resolveA = res;
+    });
+    mockUpdateProjectIndex.mockImplementation((p) =>
+      p === dirA ? deferredA : Promise.resolve(noChanges),
+    );
+
+    const run = autoResumeIndexedProjects();
+
+    await vi.waitFor(() => {
+      expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirA);
+    });
+    // The whole point of sequential resume: B has not been touched while A's
+    // update is still in flight.
+    expect(mockUpdateProjectIndex).not.toHaveBeenCalledWith(dirB);
+    expect(mockStartWatching).not.toHaveBeenCalledWith(dirB);
+
+    resolveA(noChanges);
+    await run;
+
+    expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirB);
+    expect(mockStartWatching).toHaveBeenCalledWith(dirA);
+    expect(mockStartWatching).toHaveBeenCalledWith(dirB);
+  });
+
+  it("skips list entries whose directory does not exist, with a warning, and resumes the rest", async () => {
+    const missing = path.join(os.tmpdir(), "socraticode-resume-missing-does-not-exist");
+    process.env.SOCRATICODE_AUTO_RESUME_PROJECTS = `${missing},${dirB}`;
+
+    await autoResumeIndexedProjects();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Auto-resume: listed project directory does not exist, skipping",
+      expect.objectContaining({ projectPath: missing }),
+    );
+    expect(mockUpdateProjectIndex).not.toHaveBeenCalledWith(missing);
+    expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirB);
+  });
+
+  it("warns (not info) when an explicitly listed project is not indexed", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME_PROJECTS = dirA;
+    mockListCollections.mockResolvedValue([]); // nothing indexed
+
+    await autoResumeIndexedProjects();
+
+    // An unindexed cwd is normal (info), but an unindexed explicit entry is a
+    // misconfiguration the user asked for: it must be visible at warn level.
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Auto-resume: project not yet indexed, skipping",
+      expect.objectContaining({ projectPath: dirA }),
+    );
+    expect(mockUpdateProjectIndex).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates repeated list entries", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME_PROJECTS = `${dirA},${dirA}, ${dirA}`;
+
+    await autoResumeIndexedProjects();
+
+    const callsForA = mockUpdateProjectIndex.mock.calls.filter(([p]) => p === dirA);
+    expect(callsForA).toHaveLength(1);
+  });
+
+  it("warns when the list contains no usable paths", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME_PROJECTS = " , ,";
+
+    await autoResumeIndexedProjects();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Auto-resume: SOCRATICODE_AUTO_RESUME_PROJECTS is set but contains no paths",
+    );
+    expect(mockListCollections).not.toHaveBeenCalled();
+  });
+
+  it("explicit list takes precedence over SOCRATICODE_AUTO_RESUME=all", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME = "all";
+    process.env.SOCRATICODE_AUTO_RESUME_PROJECTS = dirA;
+
+    await autoResumeIndexedProjects();
+
+    // =all mode would have read per-collection metadata; the explicit list
+    // must win, so metadata is never consulted.
+    expect(mockGetProjectMetadata).not.toHaveBeenCalled();
+    expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirA);
+    expect(mockUpdateProjectIndex).not.toHaveBeenCalledWith(dirB);
+  });
+
+  // ── SOCRATICODE_AUTO_RESUME=all ─────────────────────────────────────────
+
+  it("=all resumes every indexed project with a stored path, sequentially", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME = "all";
+    mockGetProjectMetadata.mockImplementation(async (coll) =>
+      coll === collA ? metadataFor(dirA) : metadataFor(dirB),
+    );
+
+    await autoResumeIndexedProjects();
+
+    expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirA);
+    expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirB);
+    // Sequential: A's update was invoked before B's.
+    const orderA = mockUpdateProjectIndex.mock.invocationCallOrder[
+      mockUpdateProjectIndex.mock.calls.findIndex(([p]) => p === dirA)
+    ];
+    const orderB = mockUpdateProjectIndex.mock.invocationCallOrder[
+      mockUpdateProjectIndex.mock.calls.findIndex(([p]) => p === dirB)
+    ];
+    expect(orderA).toBeLessThan(orderB);
+  });
+
+  it("=all warns and skips collections without a stored path (indexed before path tracking)", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME = "all";
+    mockGetProjectMetadata.mockImplementation(async (coll) =>
+      coll === collA ? null : metadataFor(dirB),
+    );
+
+    await autoResumeIndexedProjects();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("no stored path"),
+      expect.objectContaining({ collection: collA }),
+    );
+    expect(mockUpdateProjectIndex).not.toHaveBeenCalledWith(dirA);
+    expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirB);
+  });
+
+  it("=all warns and skips stored paths that no longer exist on disk", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME = "all";
+    const gone = path.join(os.tmpdir(), "socraticode-resume-gone-does-not-exist");
+    mockGetProjectMetadata.mockImplementation(async (coll) =>
+      coll === collA ? metadataFor(gone) : metadataFor(dirB),
+    );
+
+    await autoResumeIndexedProjects();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Auto-resume: indexed project directory no longer exists, skipping",
+      expect.objectContaining({ projectPath: gone }),
+    );
+    expect(mockUpdateProjectIndex).not.toHaveBeenCalledWith(gone);
+    expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirB);
+  });
+
+  it("=all continues with remaining projects when one resume fails", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME = "all";
+    mockGetProjectMetadata.mockImplementation(async (coll) =>
+      coll === collA ? metadataFor(dirA) : metadataFor(dirB),
+    );
+    // A failure outside resumeProject's internal non-fatal handling: the
+    // status lookup itself blows up for A.
+    mockGetPersistedStatus.mockImplementation(async (p) => {
+      if (p === dirA) throw new Error("Qdrant hiccup");
+      return "completed";
+    });
+
+    await autoResumeIndexedProjects();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Auto-resume: project resume failed, continuing with remaining projects",
+      expect.objectContaining({ projectPath: dirA, error: "Qdrant hiccup" }),
+    );
+    expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirB);
+  });
+
+  it("=all logs and does nothing when no projects are indexed", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME = "all";
+    mockListCollections.mockResolvedValue([]);
+
+    await autoResumeIndexedProjects();
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "Auto-resume: no indexed projects found, nothing to resume",
+    );
+    expect(mockGetProjectMetadata).not.toHaveBeenCalled();
+    expect(mockUpdateProjectIndex).not.toHaveBeenCalled();
+  });
+
+  it("unrecognized SOCRATICODE_AUTO_RESUME value warns and falls back to default cwd behavior", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME = "yes";
+    mockListCollections.mockResolvedValue([collA]);
+
+    await autoResumeIndexedProjects(dirA);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("unrecognized SOCRATICODE_AUTO_RESUME value"),
+      expect.objectContaining({ value: "yes" }),
+    );
+    // Default behavior still runs for the provided (cwd) project.
+    expect(mockStartWatching).toHaveBeenCalledWith(dirA);
+    expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirA);
   });
 });
 

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -554,6 +554,21 @@ describe("autoResumeIndexedProjects (multi-project modes)", () => {
     expect(mockUpdateProjectIndex).not.toHaveBeenCalled();
   });
 
+  it("still runs the incremental catch-up when watcher startup throws", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME_PROJECTS = dirA;
+    mockStartWatching.mockRejectedValue(new Error("inotify limit reached"));
+
+    await autoResumeIndexedProjects();
+
+    // A project without a live watcher is degraded; a project with a stale
+    // index is broken for search. The catch-up must survive watcher failure.
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Auto-resume: failed to start watcher, continuing with incremental catch-up",
+      expect.objectContaining({ projectPath: dirA, error: "inotify limit reached" }),
+    );
+    expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirA);
+  });
+
   it("unrecognized SOCRATICODE_AUTO_RESUME value warns and falls back to default cwd behavior", async () => {
     process.env.SOCRATICODE_AUTO_RESUME = "yes";
     mockListCollections.mockResolvedValue([collA]);


### PR DESCRIPTION
## Summary

On server startup, auto-resume (file watcher plus incremental catch-up update) can now cover every indexed project instead of only the one at `process.cwd()`. Two opt-in environment variables control it; with both unset, behavior is unchanged. This closes the gap where per-session MCP clients (Claude Code and similar) lose the watchers of every project not opened in the current session, leaving their indexes stale until a manual `codebase_watch start`.

## Changes

- `autoResumeIndexedProjects` (src/services/startup.ts) now supports three modes:
  - Default (unchanged): resume only the current working directory.
  - `SOCRATICODE_AUTO_RESUME_PROJECTS=path1,path2`: resume an explicit comma-separated list (comma matches the existing `SOCRATICODE_LINKED_PROJECTS` convention). Takes precedence over `SOCRATICODE_AUTO_RESUME`.
  - `SOCRATICODE_AUTO_RESUME=all`: resume every indexed project whose Qdrant metadata has a stored path.
- Multi-project resume is strictly sequential: each project's catch-up (incremental update or interrupted-index recovery) completes before the next project starts, so N projects never stampede the embedding provider with concurrent re-embeds.
- Every skipped project is logged loudly at warn level: directory does not exist, path not indexed, collection has no stored path (indexed before path tracking), or an unrecognized `SOCRATICODE_AUTO_RESUME` value (which falls back to the default mode with a warning).
- The single-project resume logic is extracted into a `resumeProject` helper; all existing log messages, guard ordering, and the default-mode flow are preserved verbatim. Qdrant collections are fetched once per startup instead of per project.
- One project failing to resume does not stop the remaining projects.
- README: two new rows in the Indexing Behaviour env table plus a pointer from the watcher FAQ entry.

Existing safety machinery is reused, not duplicated: cross-process watch locks prevent concurrent sessions from double-watching a repo, a failed watcher subscribe on a stale path logs and releases its lock, and repeatedly erroring watchers self-stop.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement

## Testing

- [x] Unit tests pass (`npm run test:unit`): 840/840, including 12 new tests
- [ ] Integration tests pass (`npm run test:integration`) — if applicable
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] New tests added for new/changed functionality

The 12 new tests in tests/unit/startup.test.ts encode the contract, not just coverage: strict sequencing is proven by holding project A's catch-up promise open and asserting project B is untouched until it resolves; precedence of the explicit list over `=all` is asserted via metadata never being consulted; each skip path (missing directory, unindexed explicit entry at warn level, no stored path, vanished stored path, empty list, unrecognized mode value) asserts its specific warn log; failure isolation is proven by making one project's status lookup throw and asserting the next still resumes. The 25 pre-existing startup tests pass unchanged, pinning the default mode exactly.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate
- [x] I have updated documentation (README.md / DEVELOPER.md) if needed
- [x] I have addressed all [CodeRabbit](https://coderabbit.ai) review comments (or marked as resolved with explanation)
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

## Related issues

Fixes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-project auto-resume at startup: opt-in via two new environment variables, resumes indexed projects sequentially, skips missing/invalid paths, deduplicates entries, and logs progress/warnings.

* **Documentation**
  * README and FAQ updated with guidance on the new environment variables and how to resume all indexed repositories at startup.

* **Tests**
  * Added unit tests covering multi-project resume scenarios and failure/skip behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->