### PR TITLE
feat(graph): full Dart support via tree-sitter AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -959,13 +959,15 @@ SocratiCode supports languages at three levels:
 
 ### Full Support (indexing + code graph + AST chunking)
 
-JavaScript, TypeScript, TSX, Python, Java, Kotlin, Scala, C, C++, C#, Go, Rust, Ruby, PHP, Swift, Bash/Shell, HTML, CSS/SCSS, Svelte, Vue
+JavaScript, TypeScript, TSX, Python, Java, Kotlin, Scala, C, C++, C#, Go, Rust, Ruby, PHP, Swift, Dart, Bash/Shell, HTML, CSS/SCSS, Svelte, Vue
 
 Svelte and Vue: imports extracted from `<script>` blocks (re-parsed as TypeScript) and CSS `@import`/`@require` from `<style>` blocks (any combination of `lang`, `scoped`, `module`, `global` attributes). Path aliases from `tsconfig.json`/`jsconfig.json` `compilerOptions.paths` are resolved (including `extends` chains). SCSS partial resolution (`_` prefix convention) is supported.
 
+Dart: symbols (classes, mixins, enums, extensions, typedefs, functions, getters/setters, constructors including named and factory), call sites (method calls, cascades, constructor invocations), `main()` entry-point detection, and AST chunking are all tree-sitter based; import/export/part edges are extracted via regex.
+
 ### Code Graph via Regex + Indexing
 
-Dart (import/export/part), Lua (require/dofile/loadfile), SASS, LESS (CSS `@import` extraction)
+Lua (require/dofile/loadfile), SASS, LESS (CSS `@import` extraction)
 
 ### Indexing Only (hybrid search, line-based chunking)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@ast-grep/lang-c": "^0.0.5",
         "@ast-grep/lang-cpp": "^0.0.5",
         "@ast-grep/lang-csharp": "^0.0.5",
+        "@ast-grep/lang-dart": "^0.0.7",
         "@ast-grep/lang-go": "^0.0.5",
         "@ast-grep/lang-java": "^0.0.6",
         "@ast-grep/lang-kotlin": "^0.0.6",
@@ -112,6 +113,24 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@ast-grep/lang-csharp/-/lang-csharp-0.0.5.tgz",
       "integrity": "sha512-qEOvcOJy+FhbQ/Zz2hsBXaN4BHK0sJFnp06YPBxRttWG+JGHDS/FlAlLCgCMoSmYKHx5nWtB6a7hqiApTZo6pQ==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "@ast-grep/setup-lang": "0.0.6"
+      },
+      "peerDependencies": {
+        "tree-sitter-cli": "0.25.8"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ast-grep/lang-dart": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@ast-grep/lang-dart/-/lang-dart-0.0.7.tgz",
+      "integrity": "sha512-9tTkOnw10g+/cgt8jw1XqZ0AKLDXoKYP1HoY3reZPQLhk4IWs8mNAu4Yd6E80CdQ2sJ10+L7wv1C16jTt4Yirw==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@ast-grep/lang-c": "^0.0.5",
     "@ast-grep/lang-cpp": "^0.0.5",
     "@ast-grep/lang-csharp": "^0.0.5",
+    "@ast-grep/lang-dart": "^0.0.7",
     "@ast-grep/lang-go": "^0.0.5",
     "@ast-grep/lang-java": "^0.0.6",
     "@ast-grep/lang-kotlin": "^0.0.6",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -163,6 +163,7 @@ export const ENTRY_POINT_NAMES: Record<string, Set<string>> = {
   swift: new Set(["main"]),
   ruby: new Set(["main"]),
   php: new Set(["main"]),
+  dart: new Set(["main"]),
 };
 
 // ── Path normalization ──────────────────────────────────────────────────

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -493,6 +493,7 @@ export function ensureDynamicLanguages(): void {
       ["bash",    "@ast-grep/lang-bash"],
       ["php",     "@ast-grep/lang-php"],
       ["lua",     "@ast-grep/lang-lua"],
+      ["dart",    "@ast-grep/lang-dart"],
     ];
 
     for (const [name, pkg] of langPackages) {

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -145,7 +145,10 @@ export function extractSymbolsAndCalls(
     if (langKey === "lua") {
       return extractFromLua(source, relativePath, language, moduleSymbol);
     }
-    // Dart, Svelte, Vue and others fall through to the regex fallback.
+    if (langKey === "dart") {
+      return extractFromDart(source, relativePath, language, moduleSymbol);
+    }
+    // Svelte, Vue and others fall through to the regex fallback.
     return extractFromRegex(source, relativePath, language, moduleSymbol);
   } catch (err) {
     if (!symbolExtractionWarned.has(langKey)) {
@@ -266,6 +269,211 @@ function extractFromLua(
           : null;
     if (!callee || KW.has(callee)) continue;
     const line = call.range().start.line + 1;
+    rawCalls.push({
+      callerId: findCallerId(scopes, line, moduleSym.id),
+      calleeName: callee,
+      callSite: { file, line },
+    });
+  }
+
+  return { symbols, rawCalls };
+}
+
+// ── Dart (type-first signatures, sibling signature/body pairs, selector calls) ──
+
+/**
+ * Dart previously fell through to the regex fallback, which cannot match
+ * type-first signatures (`void foo()`, `Future<int> baz() async`), so
+ * classes, methods, and call sites were invisible to the symbol graph.
+ * This walks the ast-grep Dart tree instead. Grammar quirks handled here:
+ * class/mixin/enum/extension nodes span their bodies, but a function is a
+ * `function_signature` followed by a SIBLING `function_body`, so scope
+ * ranges are stitched from each pair; plain constructors live inside a
+ * generic `declaration` wrapper; and there is no call_expression kind, so
+ * calls are recovered from `argument_part` nodes (callee = the preceding
+ * identifier or selector chain, or the `cascade_selector` for `..` calls).
+ */
+function extractFromDart(
+  source: string,
+  file: string,
+  language: string,
+  moduleSym: SymbolNode,
+): ExtractedSymbols {
+  const root = parse("dart" as unknown as Lang, source).root();
+  const symbols: SymbolNode[] = [moduleSym];
+  const scopes: ScopeFrame[] = [];
+
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  const kidsOf = (n: any): any[] => {
+    try {
+      return n.children();
+    } catch {
+      return [];
+    }
+  };
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  const childOfKind = (n: any, kind: string): any | null =>
+    // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+    kidsOf(n).find((c: any) => c.kind() === kind) ?? null;
+  // Direct identifier children only — the name slot. Type annotations are
+  // `type_identifier`/`void_type` and parameter names are nested deeper, so
+  // they never appear here.
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  const idChildren = (n: any): any[] =>
+    // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+    kidsOf(n).filter((c: any) => c.kind() === "identifier");
+
+  const addSym = (
+    name: string,
+    qualifiedName: string,
+    kind: SymbolKind,
+    startLine: number,
+    endLine: number,
+  ): void => {
+    const sym: SymbolNode = {
+      id: makeId(file, qualifiedName, startLine),
+      name,
+      qualifiedName,
+      kind,
+      file,
+      line: startLine,
+      endLine,
+      language,
+    };
+    symbols.push(sym);
+    scopes.push({ name: qualifiedName, startLine, endLine, symbolId: sym.id });
+  };
+
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  const lineOf = (n: any): number => n.range().start.line + 1;
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  const endLineOf = (n: any): number => n.range().end.line + 1;
+
+  /**
+   * Emit the member symbols of a class-like body. Members come in ordered
+   * sibling pairs: a `method_signature` (wrapping function/getter/setter/
+   * factory signatures) or a `declaration` (fields and plain constructors),
+   * optionally followed by its `function_body`.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  const walkMembers = (bodyNode: any, owner: string): void => {
+    const members = kidsOf(bodyNode);
+    for (let i = 0; i < members.length; i++) {
+      const member = members[i];
+      const memberKind = member.kind();
+      const next = members[i + 1];
+      const scopeEnd = next && next.kind() === "function_body" ? endLineOf(next) : endLineOf(member);
+
+      if (memberKind === "method_signature") {
+        const inner = kidsOf(member)[0];
+        if (!inner) continue;
+        const innerKind = inner.kind();
+        if (innerKind === "factory_constructor_signature") {
+          const ids = idChildren(inner);
+          if (ids.length === 0) continue;
+          // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+          const qn = ids.map((c: any) => c.text()).join(".");
+          addSym(ids[ids.length - 1].text(), qn, "constructor", lineOf(member), scopeEnd);
+        } else if (
+          innerKind === "function_signature" ||
+          innerKind === "getter_signature" ||
+          innerKind === "setter_signature"
+        ) {
+          const ids = idChildren(inner);
+          if (ids.length === 0) continue;
+          const name = ids[ids.length - 1].text();
+          addSym(name, `${owner}.${name}`, "method", lineOf(member), scopeEnd);
+        }
+      } else if (memberKind === "declaration") {
+        // Plain (possibly named) constructors: `Foo(this.c);` / `Foo.named(...)`.
+        // Field declarations have no constructor_signature child and are skipped.
+        const ctor = childOfKind(member, "constructor_signature");
+        if (!ctor) continue;
+        const ids = idChildren(ctor);
+        if (ids.length === 0) continue;
+        // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+        const qn = ids.map((c: any) => c.text()).join(".");
+        addSym(ids[ids.length - 1].text(), qn, "constructor", lineOf(member), scopeEnd);
+      }
+    }
+  };
+
+  // ── Top-level declarations (ordered walk so signature/body pairs line up) ──
+  const topLevel = kidsOf(root);
+  for (let i = 0; i < topLevel.length; i++) {
+    const node = topLevel[i];
+    const nodeKind = node.kind();
+
+    if (nodeKind === "class_definition" || nodeKind === "mixin_declaration" || nodeKind === "extension_declaration") {
+      const nameNode = childOfKind(node, "identifier");
+      if (!nameNode) continue;
+      const name = nameNode.text();
+      const kind: SymbolKind = nodeKind === "mixin_declaration" ? "trait" : "class";
+      addSym(name, name, kind, lineOf(node), endLineOf(node));
+      const body = childOfKind(node, "class_body") ?? childOfKind(node, "extension_body");
+      if (body) walkMembers(body, name);
+    } else if (nodeKind === "enum_declaration") {
+      const nameNode = childOfKind(node, "identifier");
+      if (nameNode) addSym(nameNode.text(), nameNode.text(), "enum", lineOf(node), endLineOf(node));
+    } else if (nodeKind === "type_alias") {
+      const nameNode = childOfKind(node, "type_identifier");
+      if (nameNode) addSym(nameNode.text(), nameNode.text(), "interface", lineOf(node), endLineOf(node));
+    } else if (nodeKind === "function_signature" || nodeKind === "getter_signature" || nodeKind === "setter_signature") {
+      const ids = idChildren(node);
+      if (ids.length === 0) continue;
+      const name = ids[ids.length - 1].text();
+      const next = topLevel[i + 1];
+      const scopeEnd = next && next.kind() === "function_body" ? endLineOf(next) : endLineOf(node);
+      addSym(name, name, "function", lineOf(node), scopeEnd);
+    }
+  }
+
+  // ── Calls — every invocation wraps an `argument_part` node ──────────────
+  const rawCalls: ExtractedSymbols["rawCalls"] = [];
+  for (const ap of safeFindAll(root, "argument_part")) {
+    const holder = ap.parent();
+    if (!holder) continue;
+    const holderKind = holder.kind();
+    let callee: string | null = null;
+
+    if (holderKind === "cascade_section") {
+      // `obj..method(args)` — the callee lives in the cascade_selector.
+      const cs = childOfKind(holder, "cascade_selector");
+      const id = cs ? childOfKind(cs, "identifier") : null;
+      callee = id ? id.text() : null;
+    } else if (holderKind === "selector") {
+      // `name(args)` / `expr.name(args)` — the callee is the previous
+      // sibling: a bare identifier, or a selector whose trailing identifier
+      // is the method name (`f.bar(…)`, `mat.runApp(…)`, `Foo.create(…)`).
+      const parent = holder.parent();
+      if (!parent) continue;
+      const siblings = kidsOf(parent);
+      const hr = holder.range();
+      const idx = siblings.findIndex(
+        // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+        (c: any) => {
+          if (c.kind() !== "selector") return false;
+          const r = c.range();
+          return (
+            r.start.line === hr.start.line &&
+            r.start.column === hr.start.column &&
+            r.end.line === hr.end.line &&
+            r.end.column === hr.end.column
+          );
+        },
+      );
+      if (idx <= 0) continue;
+      const prev = siblings[idx - 1];
+      if (prev.kind() === "identifier") {
+        callee = prev.text();
+      } else if (prev.kind() === "selector") {
+        const ids = safeFindAll(prev, "identifier");
+        callee = ids.length > 0 ? ids[ids.length - 1].text() : null;
+      }
+    }
+
+    if (!callee) continue;
+    const line = ap.range().start.line + 1;
     rawCalls.push({
       callerId: findCallerId(scopes, line, moduleSym.id),
       calleeName: callee,

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -399,6 +399,11 @@ function extractFromDart(
   };
 
   // ── Top-level declarations (ordered walk so signature/body pairs line up) ──
+  // Dart 3.3 `extension type` is NOT handled: the vendored grammar
+  // (@ast-grep/lang-dart 0.0.7) predates the syntax and parses it to ERROR
+  // nodes (no extension_type_declaration kind exists), so such declarations
+  // degrade to "not extracted" while the rest of the file extracts normally.
+  // Revisit when the upstream grammar adds the kind.
   const topLevel = kidsOf(root);
   for (let i = 0; i < topLevel.length; i++) {
     const node = topLevel[i];

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -272,6 +272,11 @@ const TOP_LEVEL_KINDS: Record<string, string[]> = {
   php:        ["function_definition", "class_declaration", "method_declaration", "trait_declaration"],
   swift:      ["function_declaration", "class_declaration", "struct_declaration", "protocol_declaration", "extension_declaration"],
   bash:       ["function_definition"],
+  // Dart: class/mixin/enum/extension nodes span their bodies, but a top-level
+  // function is a `function_signature` followed by a SIBLING `function_body`
+  // starting on the same line. Both kinds are listed so the overlap-merge in
+  // findAstBoundaries fuses each signature/body pair into one region.
+  dart:       ["class_definition", "mixin_declaration", "enum_declaration", "extension_declaration", "type_alias", "function_signature", "function_body"],
 };
 
 /** Minimum lines for a chunk to stand on its own (otherwise merge with neighbors) */

--- a/tests/unit/graph-entrypoints.test.ts
+++ b/tests/unit/graph-entrypoints.test.ts
@@ -96,6 +96,28 @@ describe("graph-entrypoints", () => {
     expect(entries.some((e) => e.name === "main")).toBe(true);
   });
 
+  it("detects Dart main() as a conventional entry point", () => {
+    const graph: CodeGraph = {
+      nodes: [
+        {
+          relativePath: "lib/main.dart",
+          imports: [],
+          exports: [],
+          dependencies: [],
+          dependents: ["lib/app.dart"], // not an orphan — name heuristic must fire
+        },
+      ],
+      edges: [],
+    };
+    const payloads: SymbolGraphFilePayload[] = [
+      { ...mkPayload("lib/main.dart", [{ name: "main", line: 3 }]), language: "dart" },
+    ];
+    const entries = detectEntryPoints(graph, payloads);
+    const main = entries.find((e) => e.name === "main");
+    expect(main).toBeDefined();
+    expect(main?.reason).toBe("well-known-name:main");
+  });
+
   it("returns empty array when nothing matches", () => {
     const graph: CodeGraph = { nodes: [], edges: [] };
     const entries = detectEntryPoints(graph, []);

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -472,25 +472,123 @@ end
     });
   });
 
-  describe("Regex fallback (Dart, Svelte, Vue, unknown)", () => {
-    it("handles Dart via regex fallback", () => {
+  describe("Dart", () => {
+    it("extracts type-first declarations the regex fallback could never match", () => {
       const src = `
-String greet(String name) {
-  return 'Hi $name';
+class Foo {
+  Foo(int c);
+  Foo.named(int c);
+  factory Foo.create() => Foo(1);
+  void bar(int x) {
+    helper(x);
+  }
+  String get name => 'foo';
+  set name(String v) {}
 }
 
-class Foo {
-  int bar() => 1;
+mixin Loggable {
+  void log(String msg) {}
+}
+
+enum Color { red, green }
+
+extension StrExt on String {
+  int len() => length;
+}
+
+typedef Callback = void Function(int);
+
+Future<int> fetchCount() async {
+  return 1;
 }
 `;
-      const out = extractSymbolsAndCalls(src, "dart" as unknown as Lang, ".dart", "main.dart");
-      // regex fallback should at least produce <module> and not throw
-      expect(out.symbols.some((s) => s.name === "<module>")).toBe(true);
-      const names = out.symbols.map((s) => s.name);
-      // best-effort detection: should find at least one named symbol
-      expect(names.length).toBeGreaterThanOrEqual(1);
+      const out = extractSymbolsAndCalls(src, "dart" as unknown as Lang, ".dart", "lib/foo.dart");
+      const has = (qn: string, kind: string) =>
+        out.symbols.some((s) => s.qualifiedName === qn && s.kind === kind);
+
+      expect(has("Foo", "class")).toBe(true);
+      // Constructors: plain, named, and factory all resolve as constructors
+      // with dotted qualified names — the regex fallback saw none of these.
+      // The plain constructor deliberately shares the class's qualified name
+      // (that is how call sites reference it); they differ by kind and line.
+      expect(has("Foo", "constructor")).toBe(true);
+      expect(has("Foo.named", "constructor")).toBe(true);
+      expect(has("Foo.create", "constructor")).toBe(true);
+      expect(has("Foo.bar", "method")).toBe(true);
+      // Getter and setter share a name but live on different lines (distinct ids)
+      const nameSyms = out.symbols.filter((s) => s.qualifiedName === "Foo.name");
+      expect(nameSyms).toHaveLength(2);
+      expect(has("Loggable", "trait")).toBe(true);
+      expect(has("Loggable.log", "method")).toBe(true);
+      expect(has("Color", "enum")).toBe(true);
+      expect(has("StrExt.len", "method")).toBe(true);
+      expect(has("Callback", "interface")).toBe(true);
+      // Type-first top-level signature (`Future<int> fetchCount()`)
+      expect(has("fetchCount", "function")).toBe(true);
     });
 
+    it("stitches a top-level function's scope from its sibling signature and body", () => {
+      const src = `
+void helper(int x) {
+  print(x);
+  print(x + 1);
+}
+`;
+      const out = extractSymbolsAndCalls(src, "dart" as unknown as Lang, ".dart", "lib/h.dart");
+      const helper = out.symbols.find((s) => s.qualifiedName === "helper");
+      // The signature node alone ends on line 2; the scope must reach the
+      // body's closing brace, otherwise calls inside attribute to <module>.
+      expect(helper?.line).toBe(2);
+      expect(helper?.endLine).toBe(5);
+      const printCall = out.rawCalls.find((c) => c.calleeName === "print");
+      expect(printCall?.callerId).toContain("::helper#");
+    });
+
+    it("attributes method calls, cascades, and constructor invocations to the enclosing scope", () => {
+      const src = `
+class Foo {
+  void bar(int x) {}
+  Future<void> load() async {}
+}
+
+void main() {
+  final f = Foo(1);
+  f.bar(2);
+  f..bar(3)..load();
+  mat.runApp();
+  helper(5);
+}
+`;
+      const out = extractSymbolsAndCalls(src, "dart" as unknown as Lang, ".dart", "lib/main.dart");
+      const fromMain = out.rawCalls.filter((c) => c.callerId.includes("::main#"));
+      const callees = fromMain.map((c) => c.calleeName);
+
+      // Constructor invocation (`Foo(1)`, no `new` keyword in modern Dart)
+      expect(callees).toContain("Foo");
+      // Plain method call `f.bar(2)`
+      expect(callees).toContain("bar");
+      // Cascade `..load()` — a Dart-only form with its own grammar shape
+      expect(callees).toContain("load");
+      // Prefixed call `mat.runApp()` resolves to the trailing identifier
+      expect(callees).toContain("runApp");
+      // Bare call
+      expect(callees).toContain("helper");
+    });
+
+    it("detects main() so Dart apps get a conventional entry point", () => {
+      const src = `
+void main() {
+  runApp();
+}
+`;
+      const out = extractSymbolsAndCalls(src, "dart" as unknown as Lang, ".dart", "bin/app.dart");
+      const main = out.symbols.find((s) => s.name === "main");
+      expect(main).toBeDefined();
+      expect(main?.kind).toBe("function");
+    });
+  });
+
+  describe("Regex fallback (Svelte, Vue, unknown)", () => {
     it("handles unknown language without throwing", () => {
       const src = "some random text\nwith no recognizable structure";
       const out = extractSymbolsAndCalls(

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -575,6 +575,26 @@ void main() {
       expect(callees).toContain("helper");
     });
 
+    it("degrades gracefully on Dart 3.3 extension types (unsupported by grammar 0.0.7)", () => {
+      // The vendored tree-sitter grammar predates `extension type` and parses
+      // it to ERROR nodes. The contract: no throw, no bogus symbols from the
+      // ERROR region, and the rest of the file still extracts normally.
+      const src = `
+extension type Meters(int value) {
+  int get inKm => value ~/ 1000;
+}
+
+class Real {
+  void work() {}
+}
+`;
+      const out = extractSymbolsAndCalls(src, "dart" as unknown as Lang, ".dart", "lib/m.dart");
+      expect(out.symbols.some((s) => s.qualifiedName === "Real" && s.kind === "class")).toBe(true);
+      expect(out.symbols.some((s) => s.qualifiedName === "Real.work" && s.kind === "method")).toBe(true);
+      // The unsupported declaration produces no symbol named Meters
+      expect(out.symbols.some((s) => s.name === "Meters")).toBe(false);
+    });
+
     it("detects main() so Dart apps get a conventional entry point", () => {
       const src = `
 void main() {

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -188,6 +188,48 @@ describe("indexer utilities", () => {
       }
     });
 
+    it("uses AST-aware chunking for Dart files (class and signature/body boundaries)", () => {
+      // Two large Dart classes plus a top-level function, exceeding CHUNK_SIZE
+      // lines. Dart splits a top-level function into sibling signature and
+      // body nodes; if the two were not merged into one region, the function
+      // body would be severed from its signature.
+      const method = (name: string) => {
+        const body = Array.from({ length: 12 }, (_, j) => `    final v${j} = ${j};`).join("\n");
+        return `  void ${name}() {\n${body}\n  }`;
+      };
+      // Six 14-line methods per class (~86 lines each): two classes exceed the
+      // 150-line merge cap, so the chunker must flush them as separate chunks
+      // instead of grouping them (small adjacent declarations merge by design).
+      const classOf = (name: string) =>
+        `class ${name} {\n${Array.from({ length: 6 }, (_, i) => method(`m${i}`)).join("\n")}\n}`;
+      const topFn = `Future<int> compute() async {\n${Array.from({ length: 12 }, (_, j) => `  final t${j} = ${j};`).join("\n")}\n  return 1;\n}`;
+      const content = `import 'package:foo/bar.dart';\n\n${classOf("Alpha")}\n\n${classOf("Beta")}\n\n${topFn}\n`;
+
+      const chunks = chunkFileContent("/test/app.dart", "app.dart", content);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(chunk.language).toBe("dart");
+      }
+      // AST-aware (not line-based): each class lives in a single chunk whose
+      // content begins at the declaration. Beta spans lines ~90-175, so a
+      // fixed 100-line window would split it mid-body.
+      const lines = content.split("\n");
+      const alphaLine = lines.findIndex((l) => l.startsWith("class Alpha")) + 1;
+      expect(chunks.some((c) => c.startLine === alphaLine)).toBe(true);
+      const betaLine = lines.findIndex((l) => l.startsWith("class Beta")) + 1;
+      const betaClassLines = classOf("Beta").split("\n").length;
+      const betaChunk = chunks.find((c) => c.startLine <= betaLine && c.endLine >= betaLine);
+      expect(betaChunk).toBeDefined();
+      expect(betaChunk?.content.trim().startsWith("class Beta")).toBe(true);
+      expect(betaChunk?.endLine).toBeGreaterThanOrEqual(betaLine + betaClassLines - 1);
+      // The top-level function's signature and body stay in the same chunk.
+      const computeLine = lines.findIndex((l) => l.startsWith("Future<int> compute")) + 1;
+      const computeChunk = chunks.find((c) => c.startLine <= computeLine && c.endLine >= computeLine);
+      expect(computeChunk).toBeDefined();
+      expect(computeChunk?.content).toContain("return 1;");
+    });
+
     it("sets correct language for Python files", () => {
       const content = "def hello():\n    print('hello')";
       const chunks = chunkFileContent("/test/app.py", "app.py", content);


### PR DESCRIPTION
## Summary

Dart moves from the regex symbol fallback to full tree-sitter support. The regex fallback matches `function NAME` / `def NAME` style declarations and cannot see Dart's type-first signatures (`void foo()`, `Future<int> baz() async`), so until now classes, mixins, methods, and call sites were invisible to the symbol graph: `codebase_symbol` and `codebase_flow` returned empty for Dart, `codebase_impact` had no source nodes, `main()` was never detected as an entry point, and files were chunked by line count instead of declaration boundaries. This PR fixes all five gaps reported in the issue in one pass.

## Changes

- **Grammar**: register `@ast-grep/lang-dart@0.0.7` in `ensureDynamicLanguages` (same family and version as the Lua grammar shipped in #67). The existing per-grammar `libraryPath` pre-validation isolates platforms without a prebuilt binary, which degrade to today's regex behavior instead of breaking.
- **Symbols** (`extractFromDart` in graph-symbols.ts): classes, mixins (as `trait`), enums, extensions, typedefs (as `interface`), type-first top-level functions, getters and setters, and constructors in all three forms (plain, named, factory) as `constructor` with dotted qualified names. Two Dart grammar quirks are handled explicitly: a function is a `function_signature` followed by a SIBLING `function_body`, so scope ranges are stitched from each pair (otherwise calls inside bodies would attribute to `<module>`); and plain constructors live inside a generic `declaration` wrapper.
- **Calls**: Dart has no `call_expression` node kind. Every invocation wraps an `argument_part`, so calls are recovered from those: bare calls (`helper(5)`), method calls (`f.bar(2)`), constructor invocations (`Foo(1)`, no `new` in modern Dart), prefixed calls (`mat.runApp()`), and cascades (`f..bar(3)..load()` via `cascade_selector`). Each call is attributed to its enclosing function scope.
- **AST chunking**: `dart` added to `TOP_LEVEL_KINDS`. Both `function_signature` and `function_body` are listed so the existing overlap-merge in `findAstBoundaries` fuses each sibling pair into one region; class/mixin/enum/extension nodes already span their bodies.
- **Entry points**: `dart: main` added to `ENTRY_POINT_NAMES`; detection is name-based per language, so Dart `main()` now surfaces through the existing well-known-name heuristic with no new path logic.
- **README**: Dart moved to Full Support in the language matrix, with a note that import/export/part edges remain regex-extracted (unchanged, they already worked and the issue asked to leave them as-is).

Out of scope, per the issue's own framing: the Flutter-specific layer (Widget awareness, pubspec-based resolution) and plain field symbols (not callable, no call-graph value).

The node kinds and ranges used by the extractor were derived empirically from the actual `@ast-grep/lang-dart` tree output, not assumed.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement

## Testing

- [x] Unit tests pass (`npm run test:unit`): 846/846
- [ ] Integration tests pass (`npm run test:integration`) — if applicable
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] New tests added for new/changed functionality

New tests encode the behavior that matters, not just coverage: the symbol test asserts the exact declarations the regex fallback could never match (constructors in all three forms, getter/setter pairs, mixin as trait, type-first signatures); a dedicated test proves a top-level function's scope reaches its sibling body's closing brace (the failure mode being calls attributing to `<module>`); the call test covers method calls, cascades, constructor invocations, and prefixed calls; the chunking test proves an entire large class lands in one chunk where a fixed 100-line window would split it mid-body, and that a signature/body pair is never severed; the entry-point test asserts Dart `main()` fires the well-known-name heuristic on a non-orphan file. The old "handles Dart via regex fallback" test is removed and the fallback block retitled, since Dart no longer routes there.

Backward compatibility: no migration needed. Existing indexed Dart chunks are untouched until a file changes (hash-skip), changed files have old chunks deleted before re-insert, cached symbol graphs keep working and pick up AST symbols on their next rebuild, and platforms without a Dart prebuild keep exactly the current regex behavior.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate
- [x] I have updated documentation (README.md / DEVELOPER.md) if needed
- [x] I have addressed all [CodeRabbit](https://coderabbit.ai) review comments (or marked as resolved with explanation)
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

## Related issues

Fixes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dart now has full AST-based support for symbol extraction, call-site attribution, and entry-point detection.

* **Documentation**
  * Language support matrix updated to show Dart as fully supported and clarify analysis behavior.

* **Tests**
  * Added unit tests validating Dart entry-point detection, symbol extraction, and AST-aware chunking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->