### PR TITLE
fix: resolve Go imports for nested go.mod in monorepos (#82)

### DIFF
--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -703,11 +703,13 @@ export async function buildCodeGraph(
   const hasCs = files.some((f) => path.extname(f).toLowerCase() === ".cs");
   const csNamespaceMap = hasCs ? buildCsNamespaceMap(fileSet, resolvedPath) : undefined;
 
-  // Build Go module-resolution info from go.mod (issue #45). Without this,
-  // every Go import resolved to null and Go projects produced an empty
-  // file graph. The info is null when go.mod is missing or unparseable;
-  // the resolver treats null as "no Go resolution available" and behaves
-  // exactly as it did before this PR for those cases.
+  // Build Go module-resolution info from every go.mod in the tree
+  // (issue #45 for root-level go.mod; issue #82 for nested modules in
+  // monorepos). Without this, every Go import resolved to null and Go
+  // projects produced an empty file graph. The result is an empty array
+  // when no go.mod is found; the resolver treats an empty/undefined
+  // result as "no Go resolution available" and behaves exactly as it did
+  // before this feature for those cases.
   const hasGo = files.some((f) => f.endsWith(".go"));
   const goModuleInfo = hasGo ? buildGoModuleInfo(fileSet, resolvedPath) : undefined;
 

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -375,7 +375,16 @@ export function resolveImport(
 
       let chosen: GoModuleInfo | null = null;
       for (const mod of modules) {
-        if (!moduleSpecifier.startsWith(mod.modulePath)) continue;
+        // Match only structurally: the import equals the module path
+        // (its root package) or is a subpackage of it (path follows the
+        // module path with a "/"). A bare textual prefix is not enough —
+        // e.g. with modules `github.com/x` and `github.com/x/y`, the import
+        // `github.com/x/yother` must resolve via the shorter module, not be
+        // misrouted to `github.com/x/y` and then rejected.
+        const isStructuralPrefix =
+          moduleSpecifier === mod.modulePath ||
+          moduleSpecifier.startsWith(`${mod.modulePath}/`);
+        if (!isStructuralPrefix) continue;
         if (!chosen || mod.modulePath.length > chosen.modulePath.length) {
           chosen = mod;
         }

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -120,38 +120,51 @@ export function buildCsNamespaceMap(
 }
 
 /**
- * Information needed to resolve Go imports to local files.
+ * Information needed to resolve Go imports to local files for one module.
  *
- * Built once per graph build by parsing the project's `go.mod` and walking
- * the file set. `modulePath` is the value of the `module` directive in
- * `go.mod` (e.g. `github.com/user/repo`); imports starting with this
- * prefix are local to the project. `packageMap` maps a Go package's
- * directory (relative to the project root, with "." for the root package)
- * to the lex-smallest non-test `.go` file in that directory, used as a
- * representative target for file-level edges in the graph.
+ * Built once per graph build by parsing each `go.mod` in the project tree
+ * and walking the file set. `modulePath` is the value of the `module`
+ * directive in `go.mod` (e.g. `github.com/user/repo`); imports starting
+ * with this prefix are local to the module. `moduleDir` is the project-
+ * relative directory that contains `go.mod` ("." when it sits at the
+ * indexed root). `packageMap` maps a Go package's directory *relative to
+ * the module directory* (with "." for the module's root package) to the
+ * lex-smallest non-test `.go` file in that directory (project-relative),
+ * used as a representative target for file-level edges in the graph.
  *
- * Returns null when `go.mod` is missing or malformed (no parseable
- * `module` directive). Callers must treat null as "no Go resolution
- * available" and return null for all Go imports.
+ * Returns an empty array when no `go.mod` is found or none parse. Callers
+ * must treat an empty result as "no Go resolution available" and return
+ * null for all Go imports.
  */
 export interface GoModuleInfo {
   modulePath: string;
+  moduleDir: string;
   packageMap: Map<string, string>;
 }
 
 /**
  * Build Go module-resolution info for a project.
  *
- * Reads `<projectPath>/go.mod` once, parses the module path with a regex,
- * and constructs a directory-to-representative-file map across all `.go`
- * files in the file set. `_test.go` files are excluded — Go does not
- * allow them to be imported from non-test code in other packages. Files
- * are sorted lexicographically before the map is built so the
- * representative chosen for each multi-file package is deterministic
- * across machines and runs.
+ * Discovers every `go.mod` that owns indexed Go files by scanning the
+ * file set for `<dir>/go.mod` entries (so a monorepo with nested modules
+ * is supported, not just a single root-level `go.mod`). For each, it
+ * parses the module path with a regex and constructs a directory-to-
+ * representative-file map across the `.go` files that live under that
+ * module's directory. `_test.go` files are excluded — Go does not allow
+ * them to be imported from non-test code in other packages. Files are
+ * sorted lexicographically before the map is built so the representative
+ * chosen for each multi-file package is deterministic across machines and
+ * runs.
  *
- * Cost: one `readFileSync` plus an O(n) walk over `.go` files at
- * graph-build time. Lookups during resolution are O(1).
+ * The `packageMap` keys are *module-relative* (the path of the package
+ * directory with the module directory stripped), because a Go import
+ * strips the module path down to a module-relative directory. Resolution
+ * re-prefixes the key with `moduleDir` before the file lookup, so a
+ * nested module (e.g. `backend/go.mod`) resolves correctly even though
+ * its files live below the indexed root.
+ *
+ * Cost: one `readFileSync` per module plus an O(n) walk over `.go` files
+ * at graph-build time. Lookups during resolution are O(1).
  *
  * Limitations (deferred to follow-up issues if reported):
  *   - Parenthesized `module ( ... )` form (rare; not used by any
@@ -163,38 +176,88 @@ export interface GoModuleInfo {
 export function buildGoModuleInfo(
   fileSet: Set<string>,
   projectPath: string,
-): GoModuleInfo | null {
-  let goModSource: string;
-  try {
-    goModSource = readFileSync(path.join(projectPath, "go.mod"), "utf-8");
-  } catch {
-    return null;
-  }
-
-  // Match `module <path>` at the start of a line, allowing leading
-  // horizontal whitespace and capturing the path token greedily up to
-  // the next whitespace. Module paths are non-whitespace tokens (e.g.
-  // `github.com/user/repo`, `go.uber.org/zap`).
-  const match = goModSource.match(/^[ \t]*module[ \t]+(\S+)/m);
-  if (!match) return null;
-  const modulePath = match[1];
-
-  const goFiles = [...fileSet]
-    .filter((f) => f.endsWith(".go") && !f.endsWith("_test.go"))
+): GoModuleInfo[] {
+  // Collect every candidate go.mod from the file set. go.mod lives at a
+  // directory boundary, so a file set entry ending in "go.mod" (with an
+  // optional parent dir) is exactly one module root.
+  const goModEntries = [...fileSet]
+    .filter((f) => f === "go.mod" || f.endsWith("/go.mod"))
     .sort();
 
-  const packageMap = new Map<string, string>();
-  for (const f of goFiles) {
-    // Go import paths always use forward slashes. fileSet entries are
-    // also forward-slash-normalized (see toForwardSlash in constants.ts),
-    // so the key and value are both in the same form.
-    const dir = path.dirname(f).replace(/\\/g, "/"); // "." for files at the project root
-    if (!packageMap.has(dir)) {
-      packageMap.set(dir, f);
+  // Parse each go.mod into { moduleDir, modulePath }. moduleDir is the
+  // project-relative directory containing go.mod ("." when at the root).
+  interface RawModule {
+    moduleDir: string;
+    modulePath: string;
+  }
+  const rawModules: RawModule[] = [];
+  for (const goModEntry of goModEntries) {
+    const moduleDir = path.dirname(goModEntry).replace(/\\/g, "/"); // "." for root-level go.mod
+    let goModSource: string;
+    try {
+      goModSource = readFileSync(path.join(projectPath, goModEntry), "utf-8");
+    } catch {
+      continue;
     }
+
+    // Match `module <path>` at the start of a line, allowing leading
+    // horizontal whitespace and capturing the path token greedily up to
+    // the next whitespace. Module paths are non-whitespace tokens (e.g.
+    // `github.com/user/repo`, `go.uber.org/zap`).
+    const match = goModSource.match(/^[ \t]*module[ \t]+(\S+)/m);
+    if (!match) continue;
+    rawModules.push({ moduleDir, modulePath: match[1] });
   }
 
-  return { modulePath, packageMap };
+  // A Go file belongs to the *deepest* module whose directory is a prefix
+  // of it. This keeps nested modules from being attributed to a parent
+  // module (e.g. `backend/svc/bar.go` is owned by `backend/`, never by a
+  // root-level module), while root-level files with no nested go.mod above
+  // them fall through to the root module when one exists.
+  const owningModule = (file: string): RawModule | null => {
+    let best: RawModule | null = null;
+    for (const mod of rawModules) {
+    const owned =
+      mod.moduleDir === "."
+        ? true // the root module is a prefix of every path, so it owns
+               // everything not claimed by a deeper (nested) module
+        : file === mod.moduleDir || file.startsWith(`${mod.moduleDir}/`);
+      if (!owned) continue;
+      if (!best || mod.moduleDir.length > best.moduleDir.length) best = mod;
+    }
+    return best;
+  };
+
+  const modules: GoModuleInfo[] = [];
+  for (const mod of rawModules) {
+    const goFiles = [...fileSet]
+      .filter((f) => f.endsWith(".go") && !f.endsWith("_test.go"))
+      // Only this module's own files (deepest-owner check).
+      .filter((f) => owningModule(f) === mod)
+      .sort();
+
+    const packageMap = new Map<string, string>();
+    for (const f of goFiles) {
+      // Strip the module directory prefix to get the module-relative
+      // package directory. Go import paths always use forward slashes and
+      // fileSet entries are forward-slash-normalized (see toForwardSlash
+      // in constants.ts), so keys stay consistent.
+      const absDir = path.dirname(f).replace(/\\/g, "/");
+      const dir =
+        mod.moduleDir === "."
+          ? absDir
+          : absDir.startsWith(`${mod.moduleDir}/`)
+            ? absDir.slice(mod.moduleDir.length + 1)
+            : "."; // file sitting directly in the module directory
+      if (!packageMap.has(dir)) {
+        packageMap.set(dir, f);
+      }
+    }
+
+    modules.push({ modulePath: mod.modulePath, moduleDir: mod.moduleDir, packageMap });
+  }
+
+  return modules;
 }
 
 /**
@@ -210,8 +273,8 @@ export function resolveImport(
   aliases?: PathAliases,
   jvmSuffixMap?: Map<string, string>,
   csNamespaceMap?: Map<string, string[]>,
-  goModuleInfo?: GoModuleInfo | null,
-): string | null {
+    goModuleInfo?: GoModuleInfo | GoModuleInfo[] | null,
+  ): string | null {
   // Skip obvious external/stdlib modules. Go is excluded from this
   // pre-check because its external classifier in `isExternalModule`
   // treats any `golang.org/...` import as external, which would block
@@ -293,30 +356,53 @@ export function resolveImport(
 
     case "go": {
       // Local Go imports are rooted at the module path declared in go.mod
-      // (built by buildGoModuleInfo at graph-build time). When the import
-      // starts with that prefix, strip it to get the package's directory
-      // relative to the project root, then look up the representative
-      // file for that directory. Anything else (stdlib like "fmt",
-      // third-party packages like "github.com/x/y", or sibling-module
-      // paths that share a prefix textually but not structurally)
-      // resolves to null.
-      if (!goModuleInfo) return null;
-      if (!moduleSpecifier.startsWith(goModuleInfo.modulePath)) return null;
-      const rest = moduleSpecifier.slice(goModuleInfo.modulePath.length);
-      // rest === "" → the root package (the directory containing go.mod).
-      // rest starts with "/" → a subpackage; strip the leading slash.
-      // Anything else (e.g. an import that happens to share the prefix
-      // but isn't actually a subpackage, like
+      // (built by buildGoModuleInfo at graph-build time). A project may
+      // contain several modules (e.g. a monorepo with nested go.mod
+      // files), so pick the module whose declared path is the longest
+      // prefix of the import, then strip that prefix to get the package's
+      // directory relative to the module. Anything else (stdlib like
+      // "fmt", third-party packages like "github.com/x/y", or
+      // sibling-module paths that share a prefix textually but not
+      // structurally) resolves to null.
+      // Normalise to an array: a single GoModuleInfo (legacy/test form)
+      // or the array built for the whole project both work.
+      const modules = Array.isArray(goModuleInfo)
+        ? goModuleInfo
+        : goModuleInfo
+          ? [goModuleInfo]
+          : [];
+      if (modules.length === 0) return null;
+
+      let chosen: GoModuleInfo | null = null;
+      for (const mod of modules) {
+        if (!moduleSpecifier.startsWith(mod.modulePath)) continue;
+        if (!chosen || mod.modulePath.length > chosen.modulePath.length) {
+          chosen = mod;
+        }
+      }
+      if (!chosen) return null;
+
+      const rest = moduleSpecifier.slice(chosen.modulePath.length);
+      // rest === "" → the module's root package (the dir containing
+      // go.mod). rest starts with "/" → a subpackage; strip the leading
+      // slash. Anything else (e.g. an import that happens to share the
+      // prefix but isn't actually a subpackage, like
       // `github.com/user/repo-other`) is external.
-      let dir: string;
+      let moduleRelDir: string;
       if (rest === "") {
-        dir = ".";
+        moduleRelDir = ".";
       } else if (rest.startsWith("/")) {
-        dir = rest.slice(1);
+        moduleRelDir = rest.slice(1);
       } else {
         return null;
       }
-      return goModuleInfo.packageMap.get(dir) ?? null;
+
+      const file = chosen.packageMap.get(moduleRelDir);
+      if (!file) return null;
+      // `file` is already project-relative (it is the fileSet entry this
+      // module was built from), so no further translation is needed even
+      // for a nested module.
+      return file;
     }
 
     case "java":

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -1230,6 +1230,34 @@ describe("graph-resolution", () => {
       expect(result).toBe("backend/sub/x.go");
     });
 
+    it("does not misroute a root-module subpackage that textually prefixes a nested module", () => {
+      // Modules `github.com/x` (root) and `github.com/x/y` (nested). The
+      // import `github.com/x/yother` is a subpackage `yother` of the root
+      // module, NOT part of `github.com/x/y`. Structural (not bare textual)
+      // prefix matching must route it to the root module.
+      project = createTempProject({
+        "go.mod": "module github.com/x\n\ngo 1.22\n",
+        "yother/z.go": "",
+        "x/y/go.mod": "module github.com/x/y\n\ngo 1.22\n",
+        "x/y/main.go": "",
+      });
+      const goModules = buildGoModuleInfo(project.fileSet, project.root);
+      expect(goModules.length).toBe(2);
+
+      const result = resolveImport(
+        "github.com/x/yother",
+        path.join(project.root, "x/y/main.go"),
+        project.root,
+        project.fileSet,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+      expect(result).toBe("yother/z.go");
+    });
+
     it("returns null for Go imports when no go.mod exists anywhere", () => {
       project = createTempProject({
         "backend/main.go": "",

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -799,7 +799,7 @@ describe("graph-resolution", () => {
         "internal/helper.go": "",
         "internal/util.go": "",
       });
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
       expect(goInfo).not.toBeNull();
 
       const result = resolveImport(
@@ -826,7 +826,7 @@ describe("graph-resolution", () => {
         "doc.go": "",
         "internal/helper.go": "",
       });
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       const result = resolveImport(
         "example.com/myapp",
@@ -848,7 +848,7 @@ describe("graph-resolution", () => {
         "go.mod": "module example.com/myapp\n\ngo 1.21\n",
         "main.go": "",
       });
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       const result = resolveImport(
         "github.com/spf13/cobra",
@@ -865,25 +865,25 @@ describe("graph-resolution", () => {
       expect(result).toBeNull();
     });
 
-    it("returns null when go.mod is missing", () => {
+    it("returns an empty array when go.mod is missing", () => {
       project = createTempProject({
         "main.go": "",
       });
       const goInfo = buildGoModuleInfo(project.fileSet, project.root);
 
-      // No go.mod → buildGoModuleInfo returns null → resolver returns null
+      // No go.mod → buildGoModuleInfo returns [] → resolver returns null
       // for any Go import.
-      expect(goInfo).toBeNull();
+      expect(goInfo).toEqual([]);
     });
 
-    it("returns null when go.mod has no module directive", () => {
+    it("returns an empty array when go.mod has no module directive", () => {
       project = createTempProject({
         "go.mod": "go 1.21\n",
         "main.go": "",
       });
       const goInfo = buildGoModuleInfo(project.fileSet, project.root);
 
-      expect(goInfo).toBeNull();
+      expect(goInfo).toEqual([]);
     });
 
     it("excludes _test.go files from representative selection", () => {
@@ -896,7 +896,7 @@ describe("graph-resolution", () => {
         "service/foo_test.go": "",
         "main.go": "",
       });
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       const result = resolveImport(
         "example.com/myapp/service",
@@ -921,7 +921,7 @@ describe("graph-resolution", () => {
         "pkg/middle.go": "",
         "main.go": "",
       });
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       const result = resolveImport(
         "example.com/myapp/pkg",
@@ -949,7 +949,7 @@ describe("graph-resolution", () => {
         "main.go": "",
         "internal/foo.go": "",
       });
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       const result = resolveImport(
         "golang.org/x/custom/internal",
@@ -975,7 +975,7 @@ describe("graph-resolution", () => {
         "pkg/foo.go": "",
         "main.go": "",
       });
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       const result = resolveImport(
         "example.com/myapp-other/pkg",
@@ -1002,7 +1002,7 @@ describe("graph-resolution", () => {
         "internal/util.go": "",
       });
 
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       expect(goInfo).not.toBeNull();
       expect(goInfo?.modulePath).toBe("example.com/myapp");
@@ -1018,22 +1018,22 @@ describe("graph-resolution", () => {
         "main.go": "",
       });
 
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       expect(goInfo?.modulePath).toBe("github.com/user/repo");
     });
 
-    it("returns null when go.mod is missing", () => {
+    it("returns an empty array when go.mod is missing", () => {
       project = createTempProject({
         "main.go": "",
       });
 
       const goInfo = buildGoModuleInfo(project.fileSet, project.root);
 
-      expect(goInfo).toBeNull();
+      expect(goInfo).toEqual([]);
     });
 
-    it("returns null when go.mod has no module directive", () => {
+    it("returns an empty array when go.mod has no module directive", () => {
       project = createTempProject({
         "go.mod": "// no module line\ngo 1.21\n",
         "main.go": "",
@@ -1041,7 +1041,7 @@ describe("graph-resolution", () => {
 
       const goInfo = buildGoModuleInfo(project.fileSet, project.root);
 
-      expect(goInfo).toBeNull();
+      expect(goInfo).toEqual([]);
     });
 
     it("excludes _test.go files from the package map representatives", () => {
@@ -1051,7 +1051,7 @@ describe("graph-resolution", () => {
         "service/foo.go": "",
       });
 
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       expect(goInfo?.packageMap.get("service")).toBe("service/foo.go");
     });
@@ -1063,7 +1063,7 @@ describe("graph-resolution", () => {
         "main.go": "",
       });
 
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       // Map has "." (for main.go) but no "internal" entry, because the
       // only file there is a test file.
@@ -1083,7 +1083,7 @@ describe("graph-resolution", () => {
         "pkg/subpkg/file.go": "",
       });
 
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       expect(goInfo?.packageMap.has("pkg/subpkg")).toBe(true);
       expect(goInfo?.packageMap.get("pkg/subpkg")).toBe("pkg/subpkg/file.go");
@@ -1095,7 +1095,7 @@ describe("graph-resolution", () => {
         "pkg/subpkg/file.go": "",
         "main.go": "",
       });
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       const result = resolveImport(
         "example.com/myapp/pkg/subpkg",
@@ -1110,6 +1110,146 @@ describe("graph-resolution", () => {
       );
 
       expect(result).toBe("pkg/subpkg/file.go");
+    });
+  });
+
+  // ── Nested go.mod (monorepo, issue #82) ───────────────────────────────
+  describe("Go resolution with nested go.mod (monorepo, #82)", () => {
+    it("discovers a nested go.mod and resolves imports against it", () => {
+      // go.mod lives in `backend/`, not at the indexed root. Imports are
+      // rooted at the module path and must be offset by the module's own
+      // subdirectory before the file lookup.
+      project = createTempProject({
+        "backend/go.mod": "module github.com/example/myapp-backend\n\ngo 1.22\n",
+        "backend/cmd/server/main.go": "",
+        "backend/internal/middleware/auth.go": "",
+        "backend/internal/service/user.go": "",
+        "frontend/src/app.ts": "",
+      });
+      const goModules = buildGoModuleInfo(project.fileSet, project.root);
+      expect(goModules.length).toBe(1);
+      expect(goModules[0].moduleDir).toBe("backend");
+      expect(goModules[0].modulePath).toBe("github.com/example/myapp-backend");
+
+      const result = resolveImport(
+        "github.com/example/myapp-backend/internal/middleware",
+        path.join(project.root, "backend/cmd/server/main.go"),
+        project.root,
+        project.fileSet,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+
+      // The representative file is resolved back to a project-relative path
+      // (module dir + module-relative file), not a module-relative one.
+      expect(result).toBe("backend/internal/middleware/auth.go");
+    });
+
+    it("resolves the module's own root package when go.mod is nested", () => {
+      project = createTempProject({
+        "backend/go.mod": "module github.com/example/myapp-backend\n\ngo 1.22\n",
+        "backend/main.go": "",
+        "backend/internal/helper.go": "",
+      });
+      const goModules = buildGoModuleInfo(project.fileSet, project.root);
+
+      const result = resolveImport(
+        "github.com/example/myapp-backend",
+        path.join(project.root, "backend/internal/helper.go"),
+        project.root,
+        project.fileSet,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+
+      expect(result).toBe("backend/main.go");
+    });
+
+    it("does not attribute a nested module's files to the root or other modules", () => {
+      // Two modules: one at the root, one nested under `backend/`. Files
+      // under `backend/` must resolve only via the nested module's path,
+      // and never collide with the root module's package map.
+      project = createTempProject({
+        "go.mod": "module github.com/example/root\n\ngo 1.22\n",
+        "rootpkg/foo.go": "",
+        "backend/go.mod": "module github.com/example/backend\n\ngo 1.22\n",
+        "backend/svc/bar.go": "",
+      });
+      const goModules = buildGoModuleInfo(project.fileSet, project.root);
+      expect(goModules.length).toBe(2);
+
+      const backend = goModules.find((m) => m.moduleDir === "backend");
+      expect(backend).toBeDefined();
+      expect(backend?.packageMap.has("svc")).toBe(true);
+      expect(backend?.packageMap.get("svc")).toBe("backend/svc/bar.go");
+      // The root module must not have picked up the nested file.
+      const root = goModules.find((m) => m.moduleDir === ".");
+      expect(root).toBeDefined();
+      expect(root?.packageMap.has("backend/svc")).toBe(false);
+
+      const result = resolveImport(
+        "github.com/example/backend/svc",
+        path.join(project.root, "backend/svc/bar.go"),
+        project.root,
+        project.fileSet,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+      expect(result).toBe("backend/svc/bar.go");
+    });
+
+    it("resolves the longest module-path prefix when modules share a prefix", () => {
+      // `github.com/example/app` (nested) vs `github.com/example/app-extra`
+      // style collisions are avoided by picking the longest matching path.
+      project = createTempProject({
+        "backend/go.mod": "module github.com/example/app\n\ngo 1.22\n",
+        "backend/sub/x.go": "",
+      });
+      const goModules = buildGoModuleInfo(project.fileSet, project.root);
+
+      const result = resolveImport(
+        "github.com/example/app/sub",
+        path.join(project.root, "backend/sub/x.go"),
+        project.root,
+        project.fileSet,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+      expect(result).toBe("backend/sub/x.go");
+    });
+
+    it("returns null for Go imports when no go.mod exists anywhere", () => {
+      project = createTempProject({
+        "backend/main.go": "",
+        "frontend/src/app.ts": "",
+      });
+      const goModules = buildGoModuleInfo(project.fileSet, project.root);
+      expect(goModules).toEqual([]);
+
+      const result = resolveImport(
+        "github.com/example/anything/internal",
+        path.join(project.root, "backend/main.go"),
+        project.root,
+        project.fileSet,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+      expect(result).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #82 — Go dependency graph and impact analysis return 0 edges when `go.mod` is nested below the indexed root (monorepo layout).

The Go module resolver previously read `go.mod` only from the project root. This PR generalizes it to discover **every** `go.mod` in the indexed tree and attribute each `.go` file to its **deepest** owning module, then resolves imports against the matched module's path with a module-directory offset (the detail the maintainer flagged in the issue).

## How it works

- `buildGoModuleInfo` now scans the file set for all `go.mod` entries (root-level or nested), parses each into `{ modulePath, moduleDir, packageMap }`.
- Each `.go` file is owned by the deepest module whose directory is a prefix, so nested modules don't leak into a parent (root module still owns top-level files).
- `packageMap` keys are module-relative; the resolver re-prefixes by `moduleDir` before the file lookup.
- `resolveImport`'s Go branch matches the **longest** module-path prefix and returns the project-relative file.

## Backward compatibility

A single root-level `go.mod` (issue #45) resolves exactly as before — all 18 existing Go tests still pass, no changes to the symbol/impact path (it auto-recovers once file edges exist). `go.work`, `vendor/`, and `replace` remain out of scope per the issue discussion.

## Verification

- `npm run lint` clean, `npx tsc --noEmit` clean
- `npm run test:unit` — full suite 1118/1118 pass
- Added 5 regression tests for nested-monorepo layouts (single nested module, nested root package, multi-module non-collision, longest-prefix match, and no-go.mod fallback)

## CLA

By submitting this pull request, I agree to the [Contributor License Agreement (CLA)](https://github.com/giancarloerra/SocratiCode/blob/main/CLA.md).

🤖 Generated with [opencode](https://github.com/anomalyco/opencode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Go support for multi-module and nested-module repositories.
  * Go import resolution now targets the most specific matching module when module paths overlap.
  * Package attribution is refined so Go files map to the nearest owning module.
* **Bug Fixes**
  * Unresolvable Go imports remain correctly marked as unresolved when module information is missing.
* **Tests**
  * Expanded Go resolution coverage, including nested `go.mod` scenarios and overlapping module paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->