### PR TITLE
fix(graph): resolve Go imports when go.mod is nested in a monorepo (#82)

### DIFF
--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -703,11 +703,14 @@ export async function buildCodeGraph(
   const hasCs = files.some((f) => path.extname(f).toLowerCase() === ".cs");
   const csNamespaceMap = hasCs ? buildCsNamespaceMap(fileSet, resolvedPath) : undefined;
 
-  // Build Go module-resolution info from go.mod (issue #45). Without this,
-  // every Go import resolved to null and Go projects produced an empty
-  // file graph. The info is null when go.mod is missing or unparseable;
-  // the resolver treats null as "no Go resolution available" and behaves
-  // exactly as it did before this PR for those cases.
+  // Build Go module-resolution info from every go.mod in the tree (issue
+  // #45 for a root-level go.mod; issue #82 for nested modules in a
+  // monorepo). Without this, every Go import resolved to null and Go
+  // projects produced an empty file graph. buildGoModuleInfo discovers
+  // go.mod itself (independently of the graphable file set) and returns
+  // one entry per module, or an empty array when none parse; the resolver
+  // treats an empty/undefined result as "no Go resolution available" and
+  // behaves exactly as it did before this feature for those cases.
   const hasGo = files.some((f) => f.endsWith(".go"));
   const goModuleInfo = hasGo ? buildGoModuleInfo(fileSet, resolvedPath) : undefined;
 

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
-import { type Dirent, readdirSync, readFileSync } from "node:fs";
+import { type Dirent, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { toForwardSlash } from "../constants.js";
 import type { PathAliases } from "./graph-aliases.js";
@@ -300,8 +300,22 @@ function findGoModFiles(projectPath: string): string[] {
       if (shouldIgnore(ig, entry.isDirectory() ? `${relPath}/` : relPath)) continue;
       if (entry.isDirectory()) {
         walk(path.join(dir, entry.name));
-      } else if (entry.isFile() && entry.name === "go.mod") {
-        results.push(relPath);
+      } else if (entry.name === "go.mod") {
+        // readdirSync Dirents do not follow symlinks: a symlinked go.mod
+        // reports isFile()===false, so without this it would be neither
+        // recorded nor followed and a root-level symlinked go.mod would
+        // regress (the old single readFileSync followed the link). statSync
+        // resolves the link so a symlinked go.mod is discovered like a real
+        // one; broken links and non-file targets are skipped.
+        let isFile = entry.isFile();
+        if (!isFile && entry.isSymbolicLink()) {
+          try {
+            isFile = statSync(path.join(dir, entry.name)).isFile();
+          } catch {
+            continue;
+          }
+        }
+        if (isFile) results.push(relPath);
       }
     }
   };

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
-import { readFileSync } from "node:fs";
+import { type Dirent, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { toForwardSlash } from "../constants.js";
 import type { PathAliases } from "./graph-aliases.js";
+import { createIgnoreFilter, shouldIgnore } from "./ignore.js";
 
 // ── Module resolution ────────────────────────────────────────────────────
 
@@ -120,38 +121,67 @@ export function buildCsNamespaceMap(
 }
 
 /**
- * Information needed to resolve Go imports to local files.
+ * Information needed to resolve Go imports to local files for ONE module.
  *
- * Built once per graph build by parsing the project's `go.mod` and walking
- * the file set. `modulePath` is the value of the `module` directive in
- * `go.mod` (e.g. `github.com/user/repo`); imports starting with this
- * prefix are local to the project. `packageMap` maps a Go package's
- * directory (relative to the project root, with "." for the root package)
- * to the lex-smallest non-test `.go` file in that directory, used as a
- * representative target for file-level edges in the graph.
+ * A project may contain several Go modules (a monorepo with nested
+ * `go.mod` files), so {@link buildGoModuleInfo} returns one of these per
+ * `go.mod` it discovers. `modulePath` is the value of the `module`
+ * directive in `go.mod` (e.g. `github.com/user/repo`); imports starting
+ * with this prefix are local to that module. `moduleDir` is the
+ * project-relative directory that contains `go.mod` ("." when it sits at
+ * the indexed root). `packageMap` maps a Go package's directory *relative
+ * to the module directory* (with "." for the module's own root package)
+ * to the lex-smallest non-test `.go` file in that directory (stored
+ * project-relative), used as a representative target for file-level edges.
  *
- * Returns null when `go.mod` is missing or malformed (no parseable
- * `module` directive). Callers must treat null as "no Go resolution
- * available" and return null for all Go imports.
+ * {@link buildGoModuleInfo} returns an empty array when no `go.mod` is
+ * found or none parse. Callers must treat an empty result as "no Go
+ * resolution available" and return null for all Go imports.
  */
 export interface GoModuleInfo {
   modulePath: string;
+  moduleDir: string;
   packageMap: Map<string, string>;
 }
 
 /**
- * Build Go module-resolution info for a project.
+ * Build Go module-resolution info for a project, one entry per `go.mod`.
  *
- * Reads `<projectPath>/go.mod` once, parses the module path with a regex,
- * and constructs a directory-to-representative-file map across all `.go`
- * files in the file set. `_test.go` files are excluded — Go does not
- * allow them to be imported from non-test code in other packages. Files
- * are sorted lexicographically before the map is built so the
- * representative chosen for each multi-file package is deterministic
- * across machines and runs.
+ * Discovers EVERY `go.mod` under the project root (so a monorepo with
+ * nested modules is supported, not just a single root-level `go.mod`),
+ * parses each module path with a regex, and constructs a per-module
+ * directory-to-representative-file map across the `.go` files owned by
+ * that module. `_test.go` files are excluded — Go does not allow them to
+ * be imported from non-test code in other packages. Files are sorted
+ * lexicographically before each map is built so the representative
+ * chosen for a multi-file package is deterministic across machines/runs.
  *
- * Cost: one `readFileSync` plus an O(n) walk over `.go` files at
- * graph-build time. Lookups during resolution are O(1).
+ * `go.mod` is discovered by walking the tree independently of `fileSet`:
+ * `go.mod` has no AST grammar and is not an extra extension, so it is
+ * NEVER admitted by `getGraphableFiles` and therefore never present in
+ * `fileSet`. An earlier attempt scanned `fileSet` for `go.mod` entries,
+ * which matched nothing in a real build and silently broke Go resolution
+ * for every project (issue #82, including the root-level #45 case). The
+ * walk reuses the same ignore filter `getGraphableFiles` uses, so a
+ * `go.mod` inside `node_modules/`, `.git/`, or a gitignored path is
+ * skipped.
+ *
+ * Each `.go` file is attributed to its DEEPEST owning module (the module
+ * whose `moduleDir` is the longest directory prefix of the file). The
+ * tie-break is directory DEPTH, not string length: the root module
+ * (`"."`, depth 0) must never win over a single-segment nested module
+ * whose directory name happens to be short (e.g. `z`, which is string
+ * length 1 just like `"."`).
+ *
+ * `packageMap` keys are MODULE-relative (the package directory with the
+ * module directory stripped), because a Go import strips the module path
+ * down to a module-relative directory. The map VALUES stay
+ * project-relative (they are the `fileSet` entries), so resolution needs
+ * no further translation even for a nested module.
+ *
+ * Cost: one tree walk (ignore-filtered) + one `readFileSync` per module
+ * plus an O(n) walk over `.go` files at graph-build time. Lookups during
+ * resolution are O(1).
  *
  * Limitations (deferred to follow-up issues if reported):
  *   - Parenthesized `module ( ... )` form (rare; not used by any
@@ -163,38 +193,120 @@ export interface GoModuleInfo {
 export function buildGoModuleInfo(
   fileSet: Set<string>,
   projectPath: string,
-): GoModuleInfo | null {
-  let goModSource: string;
-  try {
-    goModSource = readFileSync(path.join(projectPath, "go.mod"), "utf-8");
-  } catch {
-    return null;
+): GoModuleInfo[] {
+  const goModPaths = findGoModFiles(projectPath);
+  if (goModPaths.length === 0) return [];
+
+  interface RawModule {
+    moduleDir: string; // project-relative, forward-slash; "." at the root
+    modulePath: string; // declared `module` path
+    depth: number; // directory depth, for deepest-owner attribution
   }
+  const rawModules: RawModule[] = [];
+  for (const goModRel of goModPaths) {
+    let goModSource: string;
+    try {
+      goModSource = readFileSync(path.join(projectPath, goModRel), "utf-8");
+    } catch {
+      continue;
+    }
 
-  // Match `module <path>` at the start of a line, allowing leading
-  // horizontal whitespace and capturing the path token greedily up to
-  // the next whitespace. Module paths are non-whitespace tokens (e.g.
-  // `github.com/user/repo`, `go.uber.org/zap`).
-  const match = goModSource.match(/^[ \t]*module[ \t]+(\S+)/m);
-  if (!match) return null;
-  const modulePath = match[1];
+    // Match `module <path>` at the start of a line, allowing leading
+    // horizontal whitespace and capturing the path token greedily up to
+    // the next whitespace. Module paths are non-whitespace tokens (e.g.
+    // `github.com/user/repo`, `go.uber.org/zap`).
+    const match = goModSource.match(/^[ \t]*module[ \t]+(\S+)/m);
+    if (!match) continue;
+    const moduleDir = path.dirname(goModRel).replace(/\\/g, "/"); // "." for a root-level go.mod
+    const depth = moduleDir === "." ? 0 : moduleDir.split("/").length;
+    rawModules.push({ moduleDir, modulePath: match[1], depth });
+  }
+  if (rawModules.length === 0) return [];
 
+  // Precompute each .go file's owning module once. A file is owned by the
+  // DEEPEST module whose directory is a prefix of the file's directory
+  // (depth, not string length — see the function docstring).
   const goFiles = [...fileSet]
     .filter((f) => f.endsWith(".go") && !f.endsWith("_test.go"))
     .sort();
-
-  const packageMap = new Map<string, string>();
+  const ownerByFile = new Map<string, RawModule | null>();
   for (const f of goFiles) {
-    // Go import paths always use forward slashes. fileSet entries are
-    // also forward-slash-normalized (see toForwardSlash in constants.ts),
-    // so the key and value are both in the same form.
-    const dir = path.dirname(f).replace(/\\/g, "/"); // "." for files at the project root
-    if (!packageMap.has(dir)) {
-      packageMap.set(dir, f);
+    const fileDir = path.dirname(f).replace(/\\/g, "/");
+    let best: RawModule | null = null;
+    for (const mod of rawModules) {
+      // The root module (".") is a prefix of every path; a nested module
+      // owns a file only when the file's directory is itself or below it.
+      const owned =
+        mod.moduleDir === "." ||
+        fileDir === mod.moduleDir ||
+        fileDir.startsWith(`${mod.moduleDir}/`);
+      if (!owned) continue;
+      if (best === null || mod.depth > best.depth) best = mod;
     }
+    ownerByFile.set(f, best);
   }
 
-  return { modulePath, packageMap };
+  const modules: GoModuleInfo[] = [];
+  for (const mod of rawModules) {
+    const packageMap = new Map<string, string>();
+    for (const f of goFiles) {
+      if (ownerByFile.get(f) !== mod) continue;
+      const absDir = path.dirname(f).replace(/\\/g, "/");
+      // Strip the module directory to get the MODULE-relative package
+      // directory (the form a Go import resolves to). Go import paths
+      // always use forward slashes and fileSet entries are forward-slash-
+      // normalized (see toForwardSlash in constants.ts).
+      const dir =
+        mod.moduleDir === "."
+          ? absDir
+          : absDir === mod.moduleDir
+            ? "."
+            : absDir.slice(mod.moduleDir.length + 1); // absDir starts with `${mod.moduleDir}/`
+      if (!packageMap.has(dir)) {
+        packageMap.set(dir, f); // value stays project-relative (a fileSet entry)
+      }
+    }
+    modules.push({ modulePath: mod.modulePath, moduleDir: mod.moduleDir, packageMap });
+  }
+  return modules;
+}
+
+/**
+ * Discover every `go.mod` under `projectPath`, project-relative and
+ * forward-slash-normalized.
+ *
+ * `go.mod` is not a graphable file (no AST grammar, not an extra
+ * extension), so it is never in the set returned by `getGraphableFiles`.
+ * This walk is therefore independent of that set and is how
+ * {@link buildGoModuleInfo} finds modules without relying on `go.mod`
+ * being graphable (issue #82). The same ignore filter
+ * (`createIgnoreFilter` / `shouldIgnore`) `getGraphableFiles` uses is
+ * applied, with the same trailing-slash convention for directories, so a
+ * `go.mod` under `node_modules/`, `.git/`, or a gitignored path is
+ * skipped — exactly matching what the graphable walk would do.
+ */
+function findGoModFiles(projectPath: string): string[] {
+  const ig = createIgnoreFilter(projectPath);
+  const results: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const relPath = toForwardSlash(path.relative(projectPath, path.join(dir, entry.name)));
+      if (shouldIgnore(ig, entry.isDirectory() ? `${relPath}/` : relPath)) continue;
+      if (entry.isDirectory()) {
+        walk(path.join(dir, entry.name));
+      } else if (entry.isFile() && entry.name === "go.mod") {
+        results.push(relPath);
+      }
+    }
+  };
+  walk(projectPath);
+  return results.sort();
 }
 
 /**
@@ -210,7 +322,7 @@ export function resolveImport(
   aliases?: PathAliases,
   jvmSuffixMap?: Map<string, string>,
   csNamespaceMap?: Map<string, string[]>,
-  goModuleInfo?: GoModuleInfo | null,
+  goModuleInfo?: GoModuleInfo[] | null,
 ): string | null {
   // Skip obvious external/stdlib modules. Go is excluded from this
   // pre-check because its external classifier in `isExternalModule`
@@ -292,31 +404,52 @@ export function resolveImport(
     }
 
     case "go": {
-      // Local Go imports are rooted at the module path declared in go.mod
-      // (built by buildGoModuleInfo at graph-build time). When the import
-      // starts with that prefix, strip it to get the package's directory
-      // relative to the project root, then look up the representative
-      // file for that directory. Anything else (stdlib like "fmt",
-      // third-party packages like "github.com/x/y", or sibling-module
-      // paths that share a prefix textually but not structurally)
+      // Local Go imports are rooted at the module path declared in each
+      // go.mod (built by buildGoModuleInfo at graph-build time). A project
+      // may contain several modules (a monorepo with nested go.mod files),
+      // so pick the module whose declared path is the longest STRUCTURAL
+      // prefix of the import, then strip that prefix to get the package's
+      // directory relative to the module and look up its representative
+      // file. Anything else (stdlib like "fmt", third-party packages like
+      // "github.com/x/y", or a path that only shares a textual prefix)
       // resolves to null.
-      if (!goModuleInfo) return null;
-      if (!moduleSpecifier.startsWith(goModuleInfo.modulePath)) return null;
-      const rest = moduleSpecifier.slice(goModuleInfo.modulePath.length);
-      // rest === "" → the root package (the directory containing go.mod).
+      const modules = goModuleInfo ?? [];
+      if (modules.length === 0) return null;
+
+      let chosen: GoModuleInfo | null = null;
+      for (const mod of modules) {
+        // Structural prefix only: the import equals the module path (its
+        // root package) or is a direct subpackage (module path + "/").
+        // A bare textual prefix is NOT a match — e.g. with modules
+        // github.com/x and github.com/x/y, the import github.com/x/yother
+        // must resolve via github.com/x, not be misrouted to github.com/x/y
+        // and then rejected as a missing package.
+        const isMatch =
+          moduleSpecifier === mod.modulePath ||
+          moduleSpecifier.startsWith(`${mod.modulePath}/`);
+        if (!isMatch) continue;
+        if (chosen === null || mod.modulePath.length > chosen.modulePath.length) {
+          chosen = mod;
+        }
+      }
+      if (!chosen) return null;
+
+      const rest = moduleSpecifier.slice(chosen.modulePath.length);
+      // rest === "" → the module's root package (the dir containing go.mod).
       // rest starts with "/" → a subpackage; strip the leading slash.
-      // Anything else (e.g. an import that happens to share the prefix
-      // but isn't actually a subpackage, like
-      // `github.com/user/repo-other`) is external.
-      let dir: string;
+      // Anything else (an import that shares the prefix but isn't a real
+      // subpackage, e.g. `github.com/user/repo-other`) is external.
+      let moduleRelDir: string;
       if (rest === "") {
-        dir = ".";
+        moduleRelDir = ".";
       } else if (rest.startsWith("/")) {
-        dir = rest.slice(1);
+        moduleRelDir = rest.slice(1);
       } else {
         return null;
       }
-      return goModuleInfo.packageMap.get(dir) ?? null;
+      // packageMap values are already project-relative fileSet entries,
+      // so no further translation is needed — even for a nested module.
+      return chosen.packageMap.get(moduleRelDir) ?? null;
     }
 
     case "java":

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -269,4 +269,80 @@ describe("buildCodeGraph — Go module resolution (issues #45 & #82)", () => {
       ),
     ).toBe(true);
   });
+
+  it("discovers a symlinked go.mod (no symlink regression vs the old single read)", async () => {
+    // readdirSync Dirents don't follow symlinks: a symlinked go.mod reports
+    // isFile()===false. The old root-level readFileSync DID follow it, so the
+    // new tree walk must too — otherwise a root-level symlinked go.mod
+    // regresses to 0 edges (PR #84 review).
+    const target = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-go-symlink-src-"));
+    roots.push(target);
+    const realGoMod = path.join(target, "go.mod.real");
+    fs.writeFileSync(realGoMod, "module github.com/example/symlinked\n\ngo 1.22\n");
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-go-e2e-"));
+    roots.push(dir);
+    // go.mod is a symlink to a file OUTSIDE the indexed tree.
+    fs.symlinkSync(realGoMod, path.join(dir, "go.mod"));
+    fs.writeFileSync(
+      path.join(dir, "main.go"),
+      [
+        "package main",
+        "",
+        'import "github.com/example/symlinked/internal/middleware"',
+        "",
+        'func main() { _ = middleware.Authorize("admin") }',
+      ].join("\n"),
+    );
+    fs.mkdirSync(path.join(dir, "internal", "middleware"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "internal", "middleware", "auth.go"),
+      [
+        "package middleware",
+        "",
+        'func Authorize(role string) bool { return role == "admin" }',
+      ].join("\n"),
+    );
+
+    const graph = await buildCodeGraph(dir);
+    expect(
+      graph.edges.some(
+        (e) => e.source === "main.go" && e.target === "internal/middleware/auth.go",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores a stray go.mod under a default-ignored dir (build/) so it can't shadow the real module", async () => {
+    // findGoModFiles reuses createIgnoreFilter; `build/` is in the default
+    // skip list (and hard-skipped in findNestedGitignores). If discovery ever
+    // bypassed the filter, the stray build/go.mod — declaring the SAME module
+    // path as the root and alphabetically first — would win module selection
+    // in resolveImport with an empty package map and silently drop every edge:
+    // the same silent-zero-edge class #82 fixes. This case fails the moment
+    // shouldIgnore is stubbed to a no-op.
+    const graph = await buildGraph({
+      "go.mod": "module github.com/example/myapp\n\ngo 1.22\n",
+      "main.go": [
+        "package main",
+        "",
+        'import "github.com/example/myapp/internal/middleware"',
+        "",
+        'func main() { _ = middleware.Authorize("admin") }',
+      ].join("\n"),
+      "internal/middleware/auth.go": [
+        "package middleware",
+        "",
+        'func Authorize(role string) bool { return role == "admin" }',
+      ].join("\n"),
+      // Stray module under an ignored dir: same module path as the root, so it
+      // would shadow the root module if discovery ever picked it up.
+      "build/go.mod": "module github.com/example/myapp\n\ngo 1.22\n",
+    });
+
+    expect(
+      graph.edges.some(
+        (e) => e.source === "main.go" && e.target === "internal/middleware/auth.go",
+      ),
+    ).toBe(true);
+  });
 });

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -118,3 +118,155 @@ describe("getGraphableFiles / buildCodeGraph — extensionless", () => {
     expect((symbols ?? []).map((s) => s.name)).toEqual(expect.arrayContaining(["configure", "build"]));
   });
 });
+
+// ── Go module resolution through the real pipeline (#45 root + #82 nested) ─
+// These drive the actual getGraphableFiles → buildCodeGraph path, where
+// go.mod is NOT part of the graphable file set (it has no AST grammar).
+// The first #82 attempt scanned the file set for go.mod and so produced 0
+// edges for EVERY Go project — root or nested — while its hand-built unit
+// tests stayed green. These end-to-end checks fail under that approach.
+function writeLayout(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-go-e2e-"));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return dir;
+}
+
+describe("buildCodeGraph — Go module resolution (issues #45 & #82)", () => {
+  const roots: string[] = [];
+
+  afterAll(() => {
+    for (const r of roots) {
+      try { fs.rmSync(r, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  // Confirms getGraphableFiles admits the .go files (it does) and that
+  // buildCodeGraph then builds Go edges — independent of any unit test's
+  // hand-built file set.
+  async function buildGraph(layout: Record<string, string>): Promise<ReturnType<typeof buildCodeGraph>> {
+    const dir = writeLayout(layout);
+    roots.push(dir);
+    return buildCodeGraph(dir);
+  }
+
+  it("produces Go edges when go.mod is at the indexed root (#45 still works)", async () => {
+    const graph = await buildGraph({
+      "go.mod": "module github.com/example/myapp\n\ngo 1.22\n",
+      "main.go": [
+        "package main",
+        "",
+        "import \"github.com/example/myapp/internal/middleware\"",
+        "",
+        "func main() {",
+        "\tif middleware.Authorize(\"admin\") {}",
+        "}",
+      ].join("\n"),
+      "internal/middleware/auth.go": [
+        "package middleware",
+        "",
+        "func Authorize(role string) bool { return role == \"admin\" }",
+      ].join("\n"),
+    });
+
+    // The root-level module path resolves the import to a real file and an
+    // edge is created. This is the #45 behavior that must not regress.
+    expect(graph.edges.length).toBeGreaterThan(0);
+    expect(
+      graph.edges.some(
+        (e) => e.source === "main.go" && e.target === "internal/middleware/auth.go",
+      ),
+    ).toBe(true);
+  });
+
+  it("produces Go edges when go.mod is nested below the indexed root (#82)", async () => {
+    // The exact monorepo shape from the issue: go.mod lives in `backend/`,
+    // one level below the path passed to buildCodeGraph.
+    const graph = await buildGraph({
+      "docker-compose.yml": "services: {}\n",
+      "frontend/src/app.ts": "export const x = 1;\n",
+      "backend/go.mod": "module github.com/example/myapp-backend\n\ngo 1.22\n",
+      "backend/internal/middleware/auth.go": [
+        "package middleware",
+        "",
+        "func Authorize(role string) bool { return role == \"admin\" }",
+      ].join("\n"),
+      "backend/internal/service/user.go": [
+        "package service",
+        "",
+        "import \"github.com/example/myapp-backend/internal/middleware\"",
+        "",
+        "func CanDeleteUser(role string) bool {",
+        "\treturn middleware.Authorize(role)",
+        "}",
+      ].join("\n"),
+      "backend/cmd/server/main.go": [
+        "package main",
+        "",
+        "import (",
+        "\t\"github.com/example/myapp-backend/internal/middleware\"",
+        "\t\"github.com/example/myapp-backend/internal/service\"",
+        ")",
+        "",
+        "func main() {",
+        "\tif middleware.Authorize(\"admin\") {",
+        "\t\t_ = service.CanDeleteUser(\"admin\")",
+        "\t}",
+        "}",
+      ].join("\n"),
+    });
+
+    // Non-Go files are unaffected and still produce edges.
+    expect(graph.edges.some((e) => e.source === "frontend/src/app.ts")).toBe(false);
+
+    // The nested module is discovered from disk (go.mod is not graphable)
+    // and both cross-package imports resolve to real edges.
+    expect(graph.edges.length).toBeGreaterThan(0);
+    expect(
+      graph.edges.some(
+        (e) =>
+          e.source === "backend/cmd/server/main.go" &&
+          e.target === "backend/internal/middleware/auth.go",
+      ),
+    ).toBe(true);
+    expect(
+      graph.edges.some(
+        (e) =>
+          e.source === "backend/internal/service/user.go" &&
+          e.target === "backend/internal/middleware/auth.go",
+      ),
+    ).toBe(true);
+  });
+
+  it("resolves a nested module under a single-character dir `z/` (depth tie-break)", async () => {
+    // Root module `github.com/example/root` + nested `github.com/example/z`
+    // under `z/`. A string-length tie-break (`.` and `z` are both length 1)
+    // can mis-attribute `z/` files to the root; directory depth must not.
+    const graph = await buildGraph({
+      "go.mod": "module github.com/example/root\n\ngo 1.22\n",
+      "main.go": "package main\n\nfunc main() {}\n",
+      "z/go.mod": "module github.com/example/z\n\ngo 1.22\n",
+      "z/svc/bar.go": "package svc\n\nfunc Bar() {}\n",
+      "z/caller/main.go": [
+        "package main",
+        "",
+        "import \"github.com/example/z/svc\"",
+        "",
+        "func main() { _ = svc.Bar() }",
+      ].join("\n"),
+    });
+
+    // The `z/` module owns its files (depth 1 > root depth 0), so the
+    // import `github.com/example/z/svc` resolves to z/svc/bar.go and an edge
+    // is created. Under the buggy string-length tie-break this would either
+    // fail to resolve or attribute the edge to the root module.
+    expect(
+      graph.edges.some(
+        (e) => e.source === "z/caller/main.go" && e.target === "z/svc/bar.go",
+      ),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -800,7 +800,7 @@ describe("graph-resolution", () => {
         "internal/util.go": "",
       });
       const goInfo = buildGoModuleInfo(project.fileSet, project.root);
-      expect(goInfo).not.toBeNull();
+      expect(goInfo).toHaveLength(1);
 
       const result = resolveImport(
         "example.com/myapp/internal",
@@ -871,9 +871,9 @@ describe("graph-resolution", () => {
       });
       const goInfo = buildGoModuleInfo(project.fileSet, project.root);
 
-      // No go.mod → buildGoModuleInfo returns null → resolver returns null
-      // for any Go import.
-      expect(goInfo).toBeNull();
+      // No go.mod on disk → buildGoModuleInfo returns [] → resolver
+      // returns null for any Go import.
+      expect(goInfo).toEqual([]);
     });
 
     it("returns null when go.mod has no module directive", () => {
@@ -883,7 +883,8 @@ describe("graph-resolution", () => {
       });
       const goInfo = buildGoModuleInfo(project.fileSet, project.root);
 
-      expect(goInfo).toBeNull();
+      // go.mod parses but has no module directive → skipped → [].
+      expect(goInfo).toEqual([]);
     });
 
     it("excludes _test.go files from representative selection", () => {
@@ -1002,9 +1003,9 @@ describe("graph-resolution", () => {
         "internal/util.go": "",
       });
 
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
-      expect(goInfo).not.toBeNull();
+      expect(goInfo).toBeDefined();
       expect(goInfo?.modulePath).toBe("example.com/myapp");
       // Root package
       expect(goInfo?.packageMap.get(".")).toBe("main.go");
@@ -1018,22 +1019,22 @@ describe("graph-resolution", () => {
         "main.go": "",
       });
 
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       expect(goInfo?.modulePath).toBe("github.com/user/repo");
     });
 
-    it("returns null when go.mod is missing", () => {
+    it("returns an empty array when go.mod is missing", () => {
       project = createTempProject({
         "main.go": "",
       });
 
       const goInfo = buildGoModuleInfo(project.fileSet, project.root);
 
-      expect(goInfo).toBeNull();
+      expect(goInfo).toEqual([]);
     });
 
-    it("returns null when go.mod has no module directive", () => {
+    it("returns an empty array when go.mod has no module directive", () => {
       project = createTempProject({
         "go.mod": "// no module line\ngo 1.21\n",
         "main.go": "",
@@ -1041,7 +1042,7 @@ describe("graph-resolution", () => {
 
       const goInfo = buildGoModuleInfo(project.fileSet, project.root);
 
-      expect(goInfo).toBeNull();
+      expect(goInfo).toEqual([]);
     });
 
     it("excludes _test.go files from the package map representatives", () => {
@@ -1051,7 +1052,7 @@ describe("graph-resolution", () => {
         "service/foo.go": "",
       });
 
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       expect(goInfo?.packageMap.get("service")).toBe("service/foo.go");
     });
@@ -1063,7 +1064,7 @@ describe("graph-resolution", () => {
         "main.go": "",
       });
 
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       // Map has "." (for main.go) but no "internal" entry, because the
       // only file there is a test file.
@@ -1083,7 +1084,7 @@ describe("graph-resolution", () => {
         "pkg/subpkg/file.go": "",
       });
 
-      const goInfo = buildGoModuleInfo(project.fileSet, project.root);
+      const goInfo = buildGoModuleInfo(project.fileSet, project.root)[0];
 
       expect(goInfo?.packageMap.has("pkg/subpkg")).toBe(true);
       expect(goInfo?.packageMap.get("pkg/subpkg")).toBe("pkg/subpkg/file.go");
@@ -1110,6 +1111,228 @@ describe("graph-resolution", () => {
       );
 
       expect(result).toBe("pkg/subpkg/file.go");
+    });
+  });
+
+  // ── Nested go.mod (monorepo, issue #82) ───────────────────────────────
+  // These cover the case the original #45 fix did not handle: go.mod sits
+  // in a subdirectory of the indexed root. buildGoModuleInfo must discover
+  // it by walking the tree (go.mod is never in the graphable file set) and
+  // offset the package-directory lookup by the module's own subdirectory.
+  describe("Go resolution with nested go.mod (monorepo, #82)", () => {
+    it("discovers a nested go.mod and resolves imports against it", () => {
+      // go.mod lives in `backend/`, not at the indexed root. Imports are
+      // rooted at the module path and must be offset by the module's own
+      // subdirectory before the file lookup.
+      project = createTempProject({
+        "backend/go.mod": "module github.com/example/myapp-backend\n\ngo 1.22\n",
+        "backend/cmd/server/main.go": "",
+        "backend/internal/middleware/auth.go": "",
+        "backend/internal/service/user.go": "",
+        "frontend/src/app.ts": "",
+      });
+      const goModules = buildGoModuleInfo(project.fileSet, project.root);
+      expect(goModules).toHaveLength(1);
+      expect(goModules[0].moduleDir).toBe("backend");
+      expect(goModules[0].modulePath).toBe("github.com/example/myapp-backend");
+
+      const result = resolveImport(
+        "github.com/example/myapp-backend/internal/middleware",
+        path.join(project.root, "backend/cmd/server/main.go"),
+        project.root,
+        project.fileSet,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+
+      // Resolved back to a project-relative path (module dir + module-
+      // relative file), not a module-relative one.
+      expect(result).toBe("backend/internal/middleware/auth.go");
+    });
+
+    it("resolves the module's own root package when go.mod is nested", () => {
+      project = createTempProject({
+        "backend/go.mod": "module github.com/example/myapp-backend\n\ngo 1.22\n",
+        "backend/main.go": "",
+        "backend/internal/helper.go": "",
+      });
+      const goModules = buildGoModuleInfo(project.fileSet, project.root);
+
+      const result = resolveImport(
+        "github.com/example/myapp-backend",
+        path.join(project.root, "backend/internal/helper.go"),
+        project.root,
+        project.fileSet,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+
+      expect(result).toBe("backend/main.go");
+    });
+
+    it("attributes a nested module's files to it, not to a root module", () => {
+      // Two modules: one at the root, one nested under `backend/`. Files
+      // under `backend/` must resolve only via the nested module's path
+      // and never collide with the root module's package map.
+      project = createTempProject({
+        "go.mod": "module github.com/example/root\n\ngo 1.22\n",
+        "rootpkg/foo.go": "",
+        "backend/go.mod": "module github.com/example/backend\n\ngo 1.22\n",
+        "backend/svc/bar.go": "",
+      });
+      const goModules = buildGoModuleInfo(project.fileSet, project.root);
+      expect(goModules).toHaveLength(2);
+
+      const backend = goModules.find((m) => m.moduleDir === "backend");
+      expect(backend).toBeDefined();
+      // packageMap keys are MODULE-relative (the module dir is stripped).
+      expect(backend?.packageMap.get("svc")).toBe("backend/svc/bar.go");
+      // The root module must not have picked up the nested file.
+      const root = goModules.find((m) => m.moduleDir === ".");
+      expect(root).toBeDefined();
+      expect(root?.packageMap.has("backend/svc")).toBe(false);
+
+      const result = resolveImport(
+        "github.com/example/backend/svc",
+        path.join(project.root, "backend/svc/bar.go"),
+        project.root,
+        project.fileSet,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+      expect(result).toBe("backend/svc/bar.go");
+    });
+
+    it("owns a nested module under a single-character dir `z/` (depth tie-break, #82 review)", () => {
+      // The deepest-module tie-break must use directory DEPTH, not string
+      // length: the root module is `"."` (string length 1) and a nested
+      // module under `z/` is `"z"` (also string length 1). A string-length
+      // comparison ties them and the winner becomes order-dependent, so
+      // `z/svc/bar.go` can be mis-attributed to the root module. Directory
+      // depth (`.` = 0, `z` = 1) attributes it correctly to the nested one.
+      project = createTempProject({
+        "go.mod": "module github.com/example/root\n",
+        "main.go": "",
+        "z/go.mod": "module github.com/example/z\n",
+        "z/svc/bar.go": "",
+      });
+      const goModules = buildGoModuleInfo(project.fileSet, project.root);
+      expect(goModules).toHaveLength(2);
+
+      const zMod = goModules.find((m) => m.moduleDir === "z");
+      expect(zMod).toBeDefined();
+      expect(zMod?.packageMap.get("svc")).toBe("z/svc/bar.go");
+      // The root module must not have absorbed the nested file under its
+      // project-relative path.
+      const rootMod = goModules.find((m) => m.moduleDir === ".");
+      expect(rootMod?.packageMap.has("z/svc")).toBe(false);
+
+      const result = resolveImport(
+        "github.com/example/z/svc",
+        path.join(project.root, "z/svc/bar.go"),
+        project.root,
+        project.fileSet,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+      expect(result).toBe("z/svc/bar.go");
+    });
+
+    it("matches the longest module path that is a structural (not textual) prefix", () => {
+      // Modules `github.com/x` (root) and `github.com/x/y` (nested). The
+      // import `github.com/x/yother` shares the textual prefix
+      // `github.com/x/y` but is NOT a subpackage of `github.com/x/y` — it
+      // is the `yother` package of the root module `github.com/x`.
+      // Structural matching (exact or `/`-delimited) routes it correctly;
+      // a bare startsWith would misroute it to `github.com/x/y` and fail.
+      project = createTempProject({
+        "go.mod": "module github.com/x\n\ngo 1.22\n",
+        "yother/z.go": "",
+        "x/y/go.mod": "module github.com/x/y\n\ngo 1.22\n",
+        "x/y/main.go": "",
+      });
+      const goModules = buildGoModuleInfo(project.fileSet, project.root);
+      expect(goModules).toHaveLength(2);
+
+      const result = resolveImport(
+        "github.com/x/yother",
+        path.join(project.root, "x/y/main.go"),
+        project.root,
+        project.fileSet,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+      expect(result).toBe("yother/z.go");
+    });
+
+    it("discovers go.mod from disk even when it is absent from the file set", () => {
+      // The regression that sank the first #82 attempt: buildGoModuleInfo
+      // must NOT rely on go.mod being in the graphable file set, because
+      // getGraphableFiles never admits go.mod (no AST grammar). Drop every
+      // go.mod entry from the file set and confirm modules are still
+      // discovered via the tree walk and imports still resolve.
+      project = createTempProject({
+        "backend/go.mod": "module github.com/example/myapp-backend\n\ngo 1.22\n",
+        "backend/internal/middleware/auth.go": "",
+        "backend/cmd/server/main.go": "",
+      });
+      const fileSetWithoutGoMod = new Set(
+        [...project.fileSet].filter((f) => !f.endsWith("go.mod")),
+      );
+
+      const goModules = buildGoModuleInfo(fileSetWithoutGoMod, project.root);
+      expect(goModules).toHaveLength(1);
+      expect(goModules[0].moduleDir).toBe("backend");
+
+      const result = resolveImport(
+        "github.com/example/myapp-backend/internal/middleware",
+        path.join(project.root, "backend/cmd/server/main.go"),
+        project.root,
+        fileSetWithoutGoMod,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+      expect(result).toBe("backend/internal/middleware/auth.go");
+    });
+
+    it("returns null for Go imports when no go.mod exists anywhere", () => {
+      project = createTempProject({
+        "backend/main.go": "",
+        "frontend/src/app.ts": "",
+      });
+      const goModules = buildGoModuleInfo(project.fileSet, project.root);
+      expect(goModules).toEqual([]);
+
+      const result = resolveImport(
+        "github.com/example/anything/internal",
+        path.join(project.root, "backend/main.go"),
+        project.root,
+        project.fileSet,
+        "go",
+        undefined,
+        undefined,
+        undefined,
+        goModules,
+      );
+      expect(result).toBeNull();
     });
   });
 


### PR DESCRIPTION
 The Go module resolver read go.mod only from the indexed project root, so any Go project whose go.mod sits in a subdirectory (e.g. <root>/backend/) produced an empty file graph and 0 impact edges.

 Discover every go.mod under the root via an independent, ignore-aware tree walk (go.mod is never in the graphable file set), then attribute each .go file to its deepest owning module and resolve imports against the matching module using a structural prefix check. A single root-level go.mod (#45) keeps resolving exactly as before.

 Refs #82

 Summary

 When a Go project's go.mod lives below the indexed root — the common monorepo layout — the module resolver never found it: it read <projectPath>/go.mod from exactly one location, got back null/empty, and resolved every Go import to null. The result was an empty Go file graph: every .go file an orphan with 0 connections, codebase_graph_query returning "No dependency information found", and codebase_impact reporting 0 callers even for plainly-called symbols. Non-Go files were unaffected, proving the graph builder itself was fine — it specifically failed for Go.

 This generalizes the single root-level read (from #45) to discover every owning go.mod in the tree, so both a root-level module and nested/monorepo modules resolve correctly. Because the symbol-level Impact Analysis path consumes these file-import edges, it recovers automatically — no changes were needed there.

 Changes

 - src/services/graph-resolution.ts
     - buildGoModuleInfo now returns GoModuleInfo[] (one entry per discovered module) instead of GoModuleInfo | null.
     - New findGoModFiles() walks the tree to discover every go.mod, independent of the graphable file set (go.mod has no AST grammar and is never admitted by getGraphableFiles — relying on fileSet silently produced 0 edges for every Go project). It reuses the same createIgnoreFilter / shouldIgnore conventions as getGraphableFiles, with the trailing-slash-for-dirs rule, so go.mod under node_modules/, .git/, or gitignored paths is skipped.
     - Each .go file is attributed to its deepest owning module (by directory depth, not string length — so the root module . never beats a short-named nested module like z).
     - resolveImport's go case picks the matching module by structural prefix (import equals the module path, or is module-path/...), preventing overlapping paths from misrouting — e.g. github.com/x/yother is not swallowed by module github.com/x/y.
     - packageMap keys are now module-relative (a Go import strips the module path down to a module-relative dir); values stay project-relative so no further translation is needed for nested modules.
 - src/services/code-graph.ts — Updated the call site and surrounding comments to reflect the array return type.
 - tests/unit/graph-resolution.test.ts — Added coverage for nested modules, deepest-owner attribution, structural-vs-textual prefix matching, and module-relative package lookup.
 - tests/unit/graph-discovery.test.ts — Added an e2e test that exercises the real file-discovery → graph-build pipeline (where go.mod is absent from the file set) for both root-level and nested layouts, asserting Go edges are produced.

 Type of change

 - [x] Bug fix (non-breaking change that fixes an issue)
 - [ ] New feature (non-breaking change that adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update
 - [ ] Refactoring (no functional changes)
 - [ ] Test coverage improvement

 Testing

 - [x] Unit tests pass (npm run test:unit)
 - [x] Integration tests pass (npm run test:integration) — if applicable
 - [x] TypeScript compiles cleanly (npx tsc --noEmit)
 - [x] New tests added for new/changed functionality

 Added unit tests for: nested-module discovery, deepest-owner attribution (including the root-vs-nested tie-break), structural prefix matching (github.com/x/y vs github.com/x/yother), and module-relative package resolution. Added an e2e test that runs the real pipeline with go.mod absent from the graphable file set for both root-level and monorepo layouts.

 Checklist

 - [x] My code follows the existing code style and conventions
 - [x] I have added/updated JSDoc comments where appropriate
 - [x] I have updated documentation (README.md / DEVELOPER.md) if needed
 - [ ] I have addressed all CodeRabbit review comments (or marked as resolved with explanation)
 - [x] I have read the Contributing Guide
 - [x] I agree to the Contributor License Agreement

 Related issues

 Fixes #82
 Relates to #45 (root-level go.mod support — this PR generalizes that single-read approach and preserves its behaviour)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Go import resolution to support multi-module repositories, including nested `go.mod` discovery and correct module-root vs subpackage mapping.
* **Bug Fixes**
  * Corrected module ownership and import matching using deterministic, depth-based selection and structural (segment) prefix matching.
  * Fixed edge cases for symlinked `go.mod` files and ensured ignored directories (e.g., build folders) can’t override real modules.
* **Tests**
  * Added/updated regression and unit tests covering nested modules, tie-breaking behavior, missing/invalid `go.mod`, and end-to-end graph resolution.
* **Documentation**
  * Refreshed inline documentation for Go module-resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->