### PR TITLE
fix(engines): drop the <26 upper bound so Node 26 hits the guard, not a silent downgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "vitest": "^4.0.18"
   },
   "engines": {
-    "node": ">=18.0.0 <26.0.0"
+    "node": ">=18.0.0"
   },
   "overrides": {
     "vitest": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,18 +3,26 @@
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 
 // Pre-flight: refuse to start on Node versions known to break @qdrant/js-client-rest.
-// The qdrant client pins undici ^6 and constructs an undici.Agent it passes to Node's
-// built-in fetch() as a dispatcher. Node 26+ ships a stricter undici whose dispatcher
-// hook validation rejects the v6 Agent's contract — surfaces as
-// `UND_ERR_INVALID_ARG: invalid onError method` on the first qdrant request.
-// (The imports below are evaluated before this check at runtime per ESM semantics,
-// but qdrant-js's module-init is side-effect-light — only an actual request triggers
-// the undici path — so exiting here is enough to spare users the opaque error later.)
-// Tracked upstream: https://github.com/qdrant/qdrant-js/issues/134
-// Upstream PRs under discussion: qdrant/qdrant-js#123 (undici major upgrade) and
-// qdrant/qdrant-js#128 (inject fetch into REST transport). If either lands — or any
-// other fix supersedes them — raise the upper bound in package.json's `engines.node`
-// and remove this check.
+// The qdrant client bundles its own undici ^6 and constructs an undici.Agent it passes to
+// Node's built-in fetch() as init.dispatcher. On Node 26+ the built-in fetch is undici 8,
+// whose request handler renamed the legacy `onError` hook to `onResponseError`. qdrant's
+// bundled undici 6 Agent still validates that handler for a function `onError`, does not
+// find one, and throws `UND_ERR_INVALID_ARG: invalid onError method` on the first qdrant
+// call. (It is qdrant's old undici rejecting Node 26's new handler, not Node rejecting the
+// v6 Agent.)
+//
+// This runtime guard is deliberately the ONLY gate. Do NOT add an upper bound to
+// `engines.node` in package.json. An upper bound is actively harmful here: a bare
+// `npx socraticode` install resolves a version range, and npm engine-filters that range,
+// so a `<26.0.0` bound makes Node 26 silently resolve to the newest version *below* the
+// bound (which predates this guard) and boot into the broken client instead of refusing.
+// With no upper bound, Node 26 installs the guarded version and hits this loud exit.
+//
+// (Imports below are evaluated before this check per ESM semantics, but qdrant-js's
+// module-init is side-effect-light: only an actual request triggers the undici path, so
+// exiting here is enough to spare users the opaque error later.)
+// Tracked upstream: https://github.com/qdrant/qdrant-js/issues/134 (PRs #123, #128).
+// Remove or relax this check when qdrant-js supports the undici bundled in Node 26+.
 const nodeMajor = Number.parseInt(process.versions.node.split(".")[0], 10);
 if (Number.isFinite(nodeMajor) && nodeMajor >= 26) {
   // fs.writeSync(2, …) is the canonical Node idiom for "print fatal error then die":


### PR DESCRIPTION
## The problem

A user pilot on macOS (Homebrew default Node **26**) found SocratiCode indexes nothing and eventually errors with `fetch failed / UND_ERR_INVALID_ARG: invalid onError method`. Root cause is a two-part trap, both verified on a real Node 26.5.0 runtime:

1. **Delivery.** The plugin (and every README/extension example) launches the server with a **bare** `npx -y socraticode`. A bare package name is a version **range** (`*`), not the `latest` tag, and npm **engine-filters a range**. The `engines.node: >=18.0.0 <26.0.0` cap (added in c23120e to "protect" Node 26 users) therefore excludes every guard-bearing version (v1.8.11–v1.9.0) on Node 26, and npm silently resolves to **v1.8.10** — the last version that predates *both* the cap and the runtime guard.
   - Verified with npm's own resolver against the live registry: `pickManifest("*", node=26.5.0)` → **1.8.10**; `pickManifest("latest", node=26.5.0)` → 1.9.0. And on real Node 26.5.0, `npm install socraticode --dry-run` → "add socraticode **1.8.10**".
2. **Runtime.** v1.8.10 boots (no guard), passes the plain-`fetch` `/healthz` probe (the undici bug is dispatcher-specific), then dies on the first qdrant **client** call. `codebase_index` is fire-and-forget, so it returns an optimistic "indexing started" ack and stores nothing; the failure surfaces only on the next `codebase_status`/`codebase_search` as a raw undici error that reads like an env/npx-cache quirk.

So the cap meant to protect Node 26 users is exactly what hides the loud "use Node 22" guard from them and serves the guardless build instead.

## The fix (Tier 1: make the failure honest)

- **Remove the `<26.0.0` upper bound** (`engines.node` back to `>=18.0.0`). With no upper bound, a bare install resolves to the **guarded** version on Node 26. Verified against the live packument with a simulated post-fix release: `*` at node 26.5.0 → the guarded version → the runtime guard fires `exit(1)` with "Use Node 22.x" instead of silently downgrading.
- **Keep the runtime guard as the sole gate**, and **correct its comment**: the causality was inverted. It is qdrant's *own bundled undici 6* Agent rejecting the handler that **Node 26's undici 8** builds (`onError` renamed to `onResponseError`), not Node rejecting the v6 Agent. The comment now also warns future maintainers never to re-add an engines upper bound (it is the misrouting mechanism).

This does **not** make Node 26 work (upstream qdrant-js #134 / #123 / #128 are still open); it converts silent data loss into a loud, actionable refusal for every consumer of the bare name.

### Why not pin the manifests to `@latest`
Removing the cap fixes bare-name resolution systemically, for all ~15 `npx -y socraticode` references (README, extension, gemini config, both mcp.json). Pinning only the two manifests would be redundant once this ships and would leave the docs inconsistent, and `@latest` forces a per-launch registry check on every user. So the one-line engines change is the smaller, complete fix.

## Type of change

- [x] Bug fix (non-breaking; converts a silent failure into a loud, correct refusal)

## Testing

- [x] `npx tsc --noEmit` clean, `npm run lint` (biome) clean, `npm run build` succeeds (guard still compiled into `dist/index.js`)
- [x] Unit tests: 939/939 pass
- [x] CodeRabbit local review: no findings
- [x] Resolver proof (npm-pick-manifest vs live packument): pre-fix `*`@node26 → 1.8.10; post-fix `*`@node26 → guarded version
- [x] Node 26 behavior confirmed by two independent agents on a SHA-verified node-v26.5.0: bare → 1.8.10 (silent), `@latest` → 1.9.0 (guard fires)

Refs #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated the supported Node.js version range to include Node.js 26 and newer versions.

* **Documentation**
  * Clarified Node.js runtime compatibility behavior and startup safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->