### PR TITLE
fix(graph): label extensionless files by detected language in graph stats and visualization

### DIFF
--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -778,6 +778,10 @@ export async function buildCodeGraph(
     }
     const node = nodesMap.get(relPath);
     if (!node) continue;
+    // Record the (post-detection) language so display/stats sites don't have to
+    // re-derive it from the path — which silently mislabels extensionless files
+    // as plaintext.
+    node.language = language;
 
     // Extract imports using ast-grep
     const importInfos = extractImports(source, lang, ext);

--- a/src/services/graph-analysis.ts
+++ b/src/services/graph-analysis.ts
@@ -2,7 +2,17 @@
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 import path from "node:path";
 import { getLanguageFromExtension, toForwardSlash } from "../constants.js";
-import type { CodeGraph } from "../types.js";
+import type { CodeGraph, CodeGraphNode } from "../types.js";
+
+/**
+ * Resolve a graph node's language for display/stats. Prefers the language stored
+ * on the node at build time (correct for extensionless files, whose path carries
+ * no extension); falls back to deriving it from the path extension for nodes with
+ * no stored language (older persisted graphs and import-target-only leaf nodes).
+ */
+export function nodeLanguage(node: Pick<CodeGraphNode, "language" | "relativePath">): string {
+  return node.language ?? getLanguageFromExtension(path.extname(node.relativePath).toLowerCase());
+}
 
 /**
  * Get dependencies for a specific file.
@@ -101,8 +111,7 @@ export function getGraphStats(graph: CodeGraph): {
   // Language breakdown
   const languageBreakdown: Record<string, number> = {};
   for (const node of graph.nodes) {
-    const ext = path.extname(node.relativePath).toLowerCase();
-    const lang = getLanguageFromExtension(ext);
+    const lang = nodeLanguage(node);
     languageBreakdown[lang] = (languageBreakdown[lang] || 0) + 1;
   }
 
@@ -181,8 +190,7 @@ export function generateMermaidDiagram(graph: CodeGraph): string {
   // Style nodes by language
   const langNodes = new Map<string, string[]>();
   for (const node of graph.nodes) {
-    const ext = path.extname(node.relativePath).toLowerCase();
-    const lang = getLanguageFromExtension(ext);
+    const lang = nodeLanguage(node);
     if (!langNodes.has(lang)) langNodes.set(lang, []);
     const nid = nodeIds.get(node.relativePath);
     if (nid) langNodes.get(lang)?.push(nid);

--- a/src/services/graph-visualize-html.ts
+++ b/src/services/graph-visualize-html.ts
@@ -29,9 +29,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { getLanguageFromExtension } from "../constants.js";
 import type { CodeGraph } from "../types.js";
-import { findCircularDependencies } from "./graph-analysis.js";
+import { findCircularDependencies, nodeLanguage } from "./graph-analysis.js";
 import { logger } from "./logger.js";
 import { loadFilePayload, loadSymbolGraphMeta } from "./symbol-graph-store.js";
 
@@ -213,7 +212,7 @@ function buildFileVizData(graph: CodeGraph): { files: VizFile[]; fileEdges: VizF
   const files: VizFile[] = graph.nodes.map((n) => ({
     id: n.relativePath,
     label: path.basename(n.relativePath),
-    language: getLanguageFromExtension(path.extname(n.relativePath).toLowerCase()),
+    language: nodeLanguage(n),
     deps: n.dependencies.length,
     dependents: n.dependents.length,
     symbolCount: 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,13 @@ export interface FileChunk {
 export interface CodeGraphNode {
   filePath: string;
   relativePath: string;
+  /**
+   * Language label for display/stats, set at graph-build time. For extensionless
+   * files this carries the content-detected language, which the path alone cannot
+   * yield. Absent on nodes from older persisted graphs and on import-target-only
+   * leaf nodes; consumers fall back to path-based derivation via nodeLanguage().
+   */
+  language?: string;
   imports: string[];
   exports: string[];
   dependencies: string[];

--- a/tests/unit/code-graph-node-language.test.ts
+++ b/tests/unit/code-graph-node-language.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  buildCodeGraph,
+  ensureDynamicLanguages,
+  invalidateGraphCache,
+} from "../../src/services/code-graph.js";
+import { addFileToFixture, createFixtureProject, type FixtureProject } from "../helpers/fixtures.js";
+
+describe("buildCodeGraph node language", () => {
+  let fixture: FixtureProject;
+
+  beforeAll(() => {
+    vi.stubEnv("INDEX_EXTENSIONLESS", "1"); // deterministic: content detection on
+    ensureDynamicLanguages();
+    fixture = createFixtureProject("node-language");
+    addFileToFixture(fixture.root, "scripts/deploy", "#!/bin/bash\necho deploying\n");
+  });
+
+  afterAll(() => {
+    invalidateGraphCache(fixture.root);
+    fixture.cleanup();
+    vi.unstubAllEnvs();
+  });
+
+  it("stores the detected language on a grammar-bearing extensionless node", async () => {
+    const graph = await buildCodeGraph(fixture.root);
+    const deploy = graph.nodes.find((n) => n.relativePath === "scripts/deploy");
+    expect(deploy).toBeDefined();
+    expect(deploy?.language).toBe("shell");
+  });
+
+  it("stores the language on ordinary extensioned nodes too", async () => {
+    const graph = await buildCodeGraph(fixture.root);
+    const index = graph.nodes.find((n) => n.relativePath === "src/index.ts");
+    expect(index?.language).toBe("typescript");
+  });
+});

--- a/tests/unit/graph-language-display.test.ts
+++ b/tests/unit/graph-language-display.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import { describe, expect, it } from "vitest";
+import { generateMermaidDiagram, getGraphStats } from "../../src/services/graph-analysis.js";
+import type { CodeGraph, CodeGraphNode } from "../../src/types.js";
+
+function node(relativePath: string, language?: string): CodeGraphNode {
+  return {
+    filePath: `/proj/${relativePath}`,
+    relativePath,
+    imports: [],
+    exports: [],
+    dependencies: [],
+    dependents: [],
+    ...(language ? { language } : {}),
+  };
+}
+
+describe("getGraphStats language breakdown", () => {
+  it("counts a stored language for an extensionless node instead of plaintext", () => {
+    const graph: CodeGraph = { nodes: [node("scripts/deploy", "shell")], edges: [] };
+    const stats = getGraphStats(graph);
+    expect(stats.languageBreakdown.shell).toBe(1);
+    expect(stats.languageBreakdown.plaintext).toBeUndefined();
+  });
+
+  it("falls back to plaintext for an extensionless node with no stored language", () => {
+    const graph: CodeGraph = { nodes: [node("scripts/legacy")], edges: [] };
+    const stats = getGraphStats(graph);
+    expect(stats.languageBreakdown.plaintext).toBe(1);
+  });
+
+  it("still derives extensioned files from their path", () => {
+    const graph: CodeGraph = { nodes: [node("src/app.ts")], edges: [] };
+    const stats = getGraphStats(graph);
+    expect(stats.languageBreakdown.typescript).toBe(1);
+  });
+});
+
+describe("generateMermaidDiagram language colouring", () => {
+  it("colours an extensionless node by its stored language", () => {
+    const graph: CodeGraph = { nodes: [node("scripts/deploy", "shell")], edges: [] };
+    const mermaid = generateMermaidDiagram(graph);
+    expect(mermaid).toContain("fill:#4EAA25"); // the shell colour
+  });
+
+  it("uses the default colour for an extensionless node with no stored language", () => {
+    const graph: CodeGraph = { nodes: [node("scripts/legacy")], edges: [] };
+    const mermaid = generateMermaidDiagram(graph);
+    expect(mermaid).toContain("fill:#607D8B"); // default grey for the plaintext fallback
+  });
+});

--- a/tests/unit/graph-node-language.test.ts
+++ b/tests/unit/graph-node-language.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import { describe, expect, it } from "vitest";
+import { nodeLanguage } from "../../src/services/graph-analysis.js";
+
+describe("nodeLanguage", () => {
+  it("prefers the language stored on the node", () => {
+    expect(nodeLanguage({ language: "shell", relativePath: "scripts/deploy" })).toBe("shell");
+  });
+
+  it("falls back to the path extension when no language is stored (extensioned)", () => {
+    expect(nodeLanguage({ relativePath: "src/app.ts" })).toBe("typescript");
+  });
+
+  it("falls back to plaintext for an extensionless node with no stored language", () => {
+    expect(nodeLanguage({ relativePath: "scripts/legacy" })).toBe("plaintext");
+  });
+});

--- a/tests/unit/graph-visualize-html.test.ts
+++ b/tests/unit/graph-visualize-html.test.ts
@@ -135,4 +135,39 @@ describe("graph-visualize-html", () => {
     });
     expect(html).toContain('"cyclic":true');
   });
+
+  it("labels an extensionless node with its stored language in the embedded data", async () => {
+    const graph: CodeGraph = {
+      nodes: [{
+        filePath: "/proj/scripts/deploy", relativePath: "scripts/deploy", language: "shell",
+        imports: [], exports: [], dependencies: [], dependents: [],
+      }],
+      edges: [],
+    };
+    const { html } = await buildInteractiveGraphHtml({
+      projectPath: "/proj", projectName: "x", projectId: "p1", graph,
+    });
+    const match = html.match(/<script id="socraticode-data"[^>]*>([\s\S]*?)<\/script>/);
+    expect(match).toBeTruthy();
+    const data = JSON.parse(match?.[1] ?? "{}") as { files: Array<{ id: string; language: string }> };
+    const file = data.files.find((f) => f.id === "scripts/deploy");
+    expect(file?.language).toBe("shell");
+  });
+
+  it("falls back to path-derived language in the embedded data when a node has no stored language", async () => {
+    const graph: CodeGraph = {
+      nodes: [
+        { filePath: "/proj/a.ts", relativePath: "a.ts", imports: [], exports: [], dependencies: [], dependents: [] },
+        { filePath: "/proj/scripts/legacy", relativePath: "scripts/legacy", imports: [], exports: [], dependencies: [], dependents: [] },
+      ],
+      edges: [],
+    };
+    const { html } = await buildInteractiveGraphHtml({
+      projectPath: "/proj", projectName: "x", projectId: "p1", graph,
+    });
+    const match = html.match(/<script id="socraticode-data"[^>]*>([\s\S]*?)<\/script>/);
+    const data = JSON.parse(match?.[1] ?? "{}") as { files: Array<{ id: string; language: string }> };
+    expect(data.files.find((f) => f.id === "a.ts")?.language).toBe("typescript");
+    expect(data.files.find((f) => f.id === "scripts/legacy")?.language).toBe("plaintext");
+  });
 });


### PR DESCRIPTION
## What & why

Grammar-bearing extensionless files (e.g. `#!/bin/bash` scripts, no-shebang Python) are indexed and labelled with the correct language in search and the symbol graph, but three **display-only** sites re-derive the language from the file *path* with no content in hand. Since `path.extname("")` is `""`, `getLanguageFromExtension("")` returns `"plaintext"` — so a detected shell script shows as `shell` in `codebase_search` yet `plaintext` in the graph stats and visualisation:

- `getGraphStats().languageBreakdown` — surfaced by `codebase_graph_stats`
- `generateMermaidDiagram` node colour-coding — `codebase_graph_visualize`
- `buildFileVizData` node language — `codebase_graph_visualize mode="interactive"`

This is the cosmetic follow-up called out as a non-goal in the extensionless-file indexing work (#81, released in 1.9.0).

## Change

- Add an optional `language?: string` to `CodeGraphNode`.
- Populate it once in `buildCodeGraph`, at the grammar-bearing node-creation site, from the already-computed **post-detection** language — no extra I/O.
- Add a `nodeLanguage(node)` helper that prefers `node.language` and falls back to path-based derivation for nodes without it (older persisted graphs and import-target-only leaf nodes). The three display sites now go through it, which also removes the path→language derivation that was previously copy-pasted across all three.

Rejected alternative: head-reading file content at render time — adds async I/O and file re-reads to synchronous display/stat paths.

## Backward compatibility

`language` is optional and additive. Graphs persist as whole-graph JSON (`saveGraphData`/`loadGraphData`), so the field round-trips with **no persistence change**, and graphs saved before this change deserialise with `language` absent → fallback → identical to current behaviour. Extensioned files are unaffected (their stored language equals the path-derived fallback under a stable extension map). The corrected label surfaces for extensionless nodes after a graph rebuild.

## Scope

Display/stats only. Search, `codebase_symbol` / `codebase_impact` / `codebase_flow`, graph edges, symbols, chunking, and embeddings are already correct and untouched.

## Tests

Unit tests, no Docker required:

- `nodeLanguage` — stored-language and both fallback branches.
- `buildCodeGraph` stamps `shell` on a real `#!/bin/bash` fixture (real content detection, no mocks).
- Stats breakdown, mermaid colour, and interactive-viz language — each for both the stored-language and fallback cases.

Full unit suite green (`npm run test:unit`), `npm run lint` (biome) and `npm run build` (tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved language detection for extensionless files, preventing incorrect `plaintext` labels when a language can be identified.
  - Updated language statistics, Mermaid diagrams, and interactive graph displays to use detected languages consistently.
  - Added safe fallback behavior for files without stored or path-derived language information.

- **Tests**
  - Added coverage for language detection, statistics, diagram coloring, and interactive graph metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->