### PR TITLE
fix(graph): count skipped files and label extensionless nodes

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -456,12 +456,20 @@ When `codebase_graph_build` is called:
 1. BACKGROUND EXECUTION (fire-and-forget)
    ├── Tool returns immediately with "build started" message
    ├── Actual build runs asynchronously on the event loop
-   ├── Progress tracked via GraphBuildProgress { filesTotal, filesProcessed, phase }
+   ├── Progress tracked via GraphBuildProgress { filesTotal, filesProcessed, filesSkipped, phase }
    └── Client polls codebase_graph_status for progress %
 
 2. FILE DISCOVERY (phase: "scanning files")
    ├── Get graphable files from project (same ignore filters as indexing)
-   └── Include files with AST-grep grammar + files with extra extensions
+   ├── Include files with AST-grep grammar + files with extra extensions
+   ├── Extensionless files: admitted only when content detection on the first
+   │   8 KB yields a grammar-bearing extension; that extension is returned
+   │   alongside the path so the parse step need not head-read them again
+   └── Sort the file list lexicographically — Node documents no readdir ordering,
+       and a depth-first walk additionally interleaves a directory's contents with
+       the sibling entries that sort after it (a/x.ts before a.ts), while
+       processing order drives node insertion order and the JVM suffix map's
+       duplicate-class tie-break
 
 3. PARSE IMPORTS (phase: "analyzing imports", per file, via ast-grep)
    ├── Determine AST-grep language from file extension
@@ -486,6 +494,21 @@ When `codebase_graph_build` is called:
    │   └── CSS/SCSS/SASS/LESS: @import/@import url()/@require regex extraction
    ├── Tag CSS imports with isCssImport flag (for correct resolution extensions)
    ├── Update progress: filesProcessed++
+   ├── Extensionless files are re-detected on the bytes about to be parsed and
+   │   parsed under the grammar those bytes call for, so content that changed
+   │   since discovery is followed rather than dropped
+   ├── Skipped files count toward filesProcessed too and increment filesSkipped,
+   │   with the reason logged at debug and a per-reason breakdown in the
+   │   "Code graph built" log: oversized (> MAX_GRAPH_FILE_BYTES), vanished
+   │   (ENOENT between discovery and read), read-failed (any other fault, e.g.
+   │   EACCES/EIO/EMFILE), content-changed (extensionless only: re-detection on
+   │   the parsed bytes no longer yields a grammar-bearing language, so there is
+   │   no grammar to parse it with). A skipped file builds no node of its own and
+   │   contributes no outgoing edges; if another file imports it, the importer's
+   │   placeholder node still represents it — labelled by the discovery-detected
+   │   language when the target was extensionless, and left unlabelled otherwise
+   │   so nodeLanguage() derives it from the path, since detectedExts holds no
+   │   entry for an extensioned file.
    └── Return ImportInfo[] with module specifiers
 
 4. RESOLVE IMPORTS
@@ -1164,8 +1187,8 @@ Parameters:
   projectPath?: string  — Absolute path (defaults to cwd)
 
 Returns:
-  If build in progress: Status BUILDING with phase, progress %, elapsed time
-  If ready: Status READY with node/edge count, last built time, cache status, last build duration
+  If build in progress: Status BUILDING with phase, progress % (and a skipped count when non-zero), elapsed time
+  If ready: Status READY with node/edge count, last built time, cache status, last build duration, and files skipped when non-zero
   If not found: Instructions to build
 ```
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -401,9 +401,10 @@ export function getLanguageFromExtension(
 // ── Extensionless file detection ──────────────────────────────────────────
 
 /**
- * Bytes of file head inspected for extensionless language detection. Shared by
- * the discovery head-read (`readFileHead`) and the chunk-time re-detection so
- * the two paths always look at the same window and agree on the language.
+ * Bytes of file head inspected for extensionless language detection. Read by the
+ * two functions that bound a detection window — `readFileHead` on disk and
+ * `detectExtensionFromSource` in memory — so every site that decides an
+ * extensionless file's language scores the same bytes and cannot disagree about it.
  */
 export const DETECT_HEAD_BYTES = 8192;
 

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -11,7 +11,7 @@ import type {
   CodeGraph, CodeGraphEdge, CodeGraphNode,
   SymbolEdge, SymbolGraphFilePayload, SymbolGraphMeta, SymbolNode, SymbolRef,
 } from "../types.js";
-import { resolveExtensionlessExtension } from "./extensionless.js";
+import { detectExtensionFromSource, resolveExtensionlessExtension } from "./extensionless.js";
 import { loadPathAliases } from "./graph-aliases.js";
 import { extractImports } from "./graph-imports.js";
 import { buildCsNamespaceMap, buildGoModuleInfo, buildJvmSuffixMap, resolveImport } from "./graph-resolution.js";
@@ -593,16 +593,30 @@ export function getAstGrepLang(
 // ── Graph building ───────────────────────────────────────────────────────
 
 /**
- * Get all source files in a project for graph analysis.
- * Includes files with known AST grammars and any extra extensions.
+ * Get all source files in a project for graph analysis, with the detected
+ * extension of every extensionless file admitted by content detection.
+ *
+ * Includes files with known AST grammars and any extra extensions. Extensionless
+ * files are head-read here to decide admission, and the extension that decision
+ * used is returned in `detectedExts` so the build pass can reuse it instead of
+ * reading the head again.
+ *
+ * `files` is sorted lexicographically. Node documents no readdir ordering, and a
+ * depth-first walk additionally interleaves a directory's contents with the
+ * sibling entries that sort after it — `a/x.ts` is yielded before `a.ts`.
+ * Processing order determines node insertion order, and `buildJvmSuffixMap`'s
+ * first-match-wins tie-break for duplicate class paths reads the set in that
+ * order directly (`buildCsNamespaceMap` and `buildGoModuleInfo` sort their own
+ * filtered views instead). Normalize here rather than leaving it to the traversal.
  */
 export async function getGraphableFiles(
   projectPath: string,
   extraExts?: Set<string>,
-): Promise<string[]> {
+): Promise<{ files: string[]; detectedExts: Map<string, string> }> {
   const ig = createIgnoreFilter(projectPath);
   const extras = extraExts ?? EXTRA_EXTENSIONS;
   const files: string[] = [];
+  const detectedExts = new Map<string, string>();
   // Match getIndexableFiles' dotfile policy (glob dot:false by default) so the
   // graph and the index admit the same extensionless *dotfiles* — otherwise a
   // dot-named file like .bashrc/.profile would be graphed but never indexed
@@ -641,6 +655,7 @@ export async function getGraphableFiles(
           const detected = await resolveExtensionlessExtension(fullPath);
           if (detected && getAstGrepLang(detected) !== null) {
             files.push(relPath);
+            detectedExts.set(relPath, detected);
           }
         }
       }
@@ -648,7 +663,8 @@ export async function getGraphableFiles(
   }
 
   await walk(projectPath);
-  return files;
+  files.sort();
+  return { files, detectedExts };
 }
 
 /**
@@ -671,7 +687,7 @@ export async function buildCodeGraph(
 
   const resolvedPath = path.resolve(projectPath);
   const aliases = await loadPathAliases(resolvedPath);
-  const files = await getGraphableFiles(resolvedPath, extraExtensions);
+  const { files, detectedExts } = await getGraphableFiles(resolvedPath, extraExtensions);
   const fileSet = new Set(files);
 
   if (progress) {
@@ -717,18 +733,17 @@ export async function buildCodeGraph(
   for (const relPath of files) {
     let ext = path.extname(relPath).toLowerCase();
     let lang = getAstGrepLang(ext);
+    const wasExtensionless = ext === "";
 
-    // Extensionless entries were admitted by getGraphableFiles only when
-    // detection yields a grammar-bearing extension, but it admits by path and
-    // does not carry the detected extension forward — so re-detect here to
-    // recover ext/lang.
-    if (!lang && ext === "") {
-      const detected = await resolveExtensionlessExtension(path.join(resolvedPath, relPath));
+    // Extensionless entries carry the extension discovery detected when it
+    // head-read them to decide admission; reuse it so the file clears the
+    // grammar-less-leaf gate below without a second head-read — without it an
+    // extensionless file would become a leaf node instead of being parsed. What it
+    // is actually parsed as comes from the re-detection on the read bytes further
+    // down, which supersedes this one.
+    if (!lang && wasExtensionless) {
+      const detected = detectedExts.get(relPath);
       const detectedLang = detected ? getAstGrepLang(detected) : null;
-      // getGraphableFiles admits an extensionless entry only when detection
-      // yields a grammar-bearing extension. If the content changed since
-      // discovery (TOCTOU) so it no longer does — null, or a grammar-less
-      // `.txt` — skip it rather than adding a spurious grammar-less leaf node.
       if (!detected || !detectedLang) continue;
       ext = detected;
       lang = detectedLang;
@@ -753,7 +768,6 @@ export async function buildCodeGraph(
       continue;
     }
 
-    const language = getLanguageFromExtension(ext);
     const absolutePath = path.join(resolvedPath, relPath);
 
     let source: string;
@@ -764,6 +778,23 @@ export async function buildCodeGraph(
     } catch {
       continue;
     }
+
+    // Detection ran on a head-read during discovery, so content may have changed
+    // before this read. Re-detect on the bytes about to be parsed and parse under
+    // the grammar those bytes call for: the fresh answer describes what is in
+    // hand, so it supersedes discovery's rather than being compared to it. Only
+    // content that no longer detects as a grammar-bearing language has nothing to
+    // parse with, and that is the skip — labelling it from the stale detection
+    // would write junk imports and symbols into the graph.
+    if (wasExtensionless) {
+      const redetected = detectExtensionFromSource(source);
+      const redetectedLang = redetected ? getAstGrepLang(redetected) : null;
+      if (!redetected || !redetectedLang) continue;
+      ext = redetected;
+      lang = redetectedLang;
+    }
+
+    const language = getLanguageFromExtension(ext);
 
     // Create node for this file
     if (!nodesMap.has(relPath)) {
@@ -810,6 +841,10 @@ export async function buildCodeGraph(
 
         // Ensure target node exists
         if (!nodesMap.has(resolved)) {
+          // A target may be skipped when its own turn comes and so never build
+          // its own node; carry the discovery-detected language here, since the
+          // path alone would report an extensionless script as plaintext.
+          const targetExt = detectedExts.get(resolved);
           nodesMap.set(resolved, {
             filePath: path.join(resolvedPath, resolved),
             relativePath: resolved,
@@ -817,6 +852,7 @@ export async function buildCodeGraph(
             exports: [],
             dependencies: [],
             dependents: [],
+            language: targetExt ? getLanguageFromExtension(targetExt) : undefined,
           });
         }
         nodesMap.get(resolved)?.dependents.push(relPath);

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -46,11 +46,24 @@ const esmRequire = createRequire(import.meta.url);
 
 // ── Graph build progress tracking ────────────────────────────────────────
 
+/**
+ * Why a file the graph walk discovered did not get a node of its own — an
+ * importer may still create a placeholder for it. Module-local:
+ * the counts leave this file as a total plus a per-reason breakdown in the build
+ * log, not as a type consumers branch on.
+ */
+type SkipReason = "oversized" | "vanished" | "read-failed" | "content-changed";
+
 /** Progress details for an in-flight graph build operation */
 export interface GraphBuildProgress {
   startedAt: number;       // Date.now()
   filesTotal: number;
   filesProcessed: number;
+  /**
+   * Files counted in `filesProcessed` that got no node of their own; an importer
+   * may still have created a placeholder for them. Absent until the first skip.
+   */
+  filesSkipped?: number;
   phase: string;           // "scanning files" | "analyzing imports" | "persisting"
   error?: string;
 }
@@ -60,6 +73,11 @@ export interface GraphBuildCompleted {
   completedAt: number;     // Date.now()
   durationMs: number;
   filesProcessed: number;
+  /**
+   * Files that got no node of their own during this build; an importer may still
+   * have created a placeholder for them. Absent when none were skipped.
+   */
+  filesSkipped?: number;
   nodesCreated: number;
   edgesCreated: number;
   error?: string;
@@ -225,6 +243,7 @@ async function doRebuildGraph(
       completedAt: Date.now(),
       durationMs: Date.now() - progress.startedAt,
       filesProcessed: progress.filesProcessed,
+      filesSkipped: progress.filesSkipped,
       nodesCreated: graph.nodes.length,
       edgesCreated: graph.edges.length,
     });
@@ -237,6 +256,7 @@ async function doRebuildGraph(
       completedAt: Date.now(),
       durationMs: Date.now() - progress.startedAt,
       filesProcessed: progress.filesProcessed,
+      filesSkipped: progress.filesSkipped,
       nodesCreated: 0,
       edgesCreated: 0,
       error: message,
@@ -628,7 +648,20 @@ export async function getGraphableFiles(
     let entries: import("node:fs").Dirent[];
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
-    } catch {
+    } catch (err) {
+      // Every file under an unreadable directory leaves the walk here, before it
+      // has a path of its own to report, so none of them reach the build loop's
+      // skip accounting — this log is their only trace. ENOENT stays quiet for a
+      // directory removed mid-walk, which has nothing left to graph, but not for
+      // the project root: there it means the whole project is missing, and the
+      // build would otherwise report a clean empty graph.
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== "ENOENT" || dir === projectPath) {
+        logger.debug("Could not read directory in graph discovery (subtree omitted)", {
+          dir: toForwardSlash(path.relative(projectPath, dir)) || ".",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
       return;
     }
 
@@ -702,6 +735,20 @@ export async function buildCodeGraph(
   const symbolsByFile = new Map<string, SymbolNode[]>();
   const outgoingCallsByFile = new Map<string, SymbolEdge[]>();
 
+  // Per-reason counts, holding only the reasons that actually fired — the build log
+  // emits `skipReasons` straight from this map, so it never carries a zero.
+  const skipsByReason = new Map<SkipReason, number>();
+  let filesSkipped = 0;
+  const recordSkip = (file: string, reason: SkipReason, detail?: Record<string, unknown>): void => {
+    logger.debug("Skipping file in graph build", { file, reason, ...detail });
+    skipsByReason.set(reason, (skipsByReason.get(reason) ?? 0) + 1);
+    filesSkipped++;
+    if (progress) {
+      progress.filesProcessed++;
+      progress.filesSkipped = filesSkipped;
+    }
+  };
+
   // Build a suffix lookup map for JVM multi-module projects (Java/Kotlin/Scala).
   // This resolves FQNs like com.example.Foo when the class lives under a nested
   // src/main/java/ tree (e.g. module-a/sub/src/main/java/com/example/Foo.java).
@@ -738,9 +785,11 @@ export async function buildCodeGraph(
     // Extensionless entries carry the extension discovery detected when it
     // head-read them to decide admission; reuse it so the file clears the
     // grammar-less-leaf gate below without a second head-read — without it an
-    // extensionless file would become a leaf node instead of being parsed. What it
-    // is actually parsed as comes from the re-detection on the read bytes further
-    // down, which supersedes this one.
+    // extensionless file would become a leaf node instead of being parsed or
+    // counted. What it is actually parsed as comes from the re-detection on the
+    // read bytes further down, which supersedes this one. Discovery admits an
+    // extensionless path only together with a grammar-bearing detection, so the
+    // guard below narrows types rather than handling a case that can occur.
     if (!lang && wasExtensionless) {
       const detected = detectedExts.get(relPath);
       const detectedLang = detected ? getAstGrepLang(detected) : null;
@@ -773,9 +822,18 @@ export async function buildCodeGraph(
     let source: string;
     try {
       const stat = await fs.stat(absolutePath);
-      if (stat.size > MAX_GRAPH_FILE_BYTES) continue; // Skip large files
+      if (stat.size > MAX_GRAPH_FILE_BYTES) {
+        recordSkip(relPath, "oversized", { size: stat.size, limit: MAX_GRAPH_FILE_BYTES });
+        continue;
+      }
       source = await fs.readFile(absolutePath, "utf-8");
-    } catch {
+    } catch (err) {
+      // ENOENT means the file vanished between discovery and this read; anything
+      // else is a real fault worth the error text. Both drop the file, so both
+      // count — unlike a discovery-time detection miss, which keeps the file out
+      // of `files` entirely, leaving nothing here to count.
+      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") recordSkip(relPath, "vanished");
+      else recordSkip(relPath, "read-failed", { error: err instanceof Error ? err.message : String(err) });
       continue;
     }
 
@@ -789,26 +847,30 @@ export async function buildCodeGraph(
     if (wasExtensionless) {
       const redetected = detectExtensionFromSource(source);
       const redetectedLang = redetected ? getAstGrepLang(redetected) : null;
-      if (!redetected || !redetectedLang) continue;
+      if (!redetected || !redetectedLang) {
+        recordSkip(relPath, "content-changed", { atDiscovery: ext, redetected });
+        continue;
+      }
       ext = redetected;
       lang = redetectedLang;
     }
 
     const language = getLanguageFromExtension(ext);
 
-    // Create node for this file
-    if (!nodesMap.has(relPath)) {
-      nodesMap.set(relPath, {
+    // get() may return a placeholder an earlier importer created, whose
+    // dependents are already populated — keep it rather than replacing it.
+    let node = nodesMap.get(relPath);
+    if (!node) {
+      node = {
         filePath: absolutePath,
         relativePath: relPath,
         imports: [],
         exports: [],
         dependencies: [],
         dependents: [],
-      });
+      };
+      nodesMap.set(relPath, node);
     }
-    const node = nodesMap.get(relPath);
-    if (!node) continue;
     // Record the (post-detection) language so display/stats sites don't have to
     // re-derive it from the path — which silently mislabels extensionless files
     // as plaintext.
@@ -868,7 +930,12 @@ export async function buildCodeGraph(
     if (progress) progress.filesProcessed++;
   }
 
-  logger.info("Code graph built", { nodes: nodesMap.size, edges: edges.length });
+  logger.info("Code graph built", {
+    nodes: nodesMap.size,
+    edges: edges.length,
+    filesSkipped,
+    ...(skipsByReason.size > 0 ? { skipReasons: Object.fromEntries(skipsByReason) } : {}),
+  });
 
   return {
     nodes: Array.from(nodesMap.values()),

--- a/src/services/extensionless.ts
+++ b/src/services/extensionless.ts
@@ -47,6 +47,40 @@ export async function readFileHead(absolutePath: string, maxBytes = DETECT_HEAD_
 }
 
 /**
+ * Detect the canonical extension of source text already held in memory, scoring
+ * the same window {@link readFileHead} reads from disk: the first
+ * {@link DETECT_HEAD_BYTES} **bytes** of UTF-8, not characters.
+ *
+ * The byte window is load-bearing, not incidental. `detectExtensionlessExtension`
+ * counts pattern hits, so a larger window can change its answer; a character
+ * slice of a file with multibyte text near the top would cover more content than
+ * the disk head and could disagree about identical bytes. Re-encoding keeps the
+ * two answers comparable — including at the boundary, where each decodes a
+ * character split by the cut to U+FFFD.
+ *
+ * Content that was lossily decoded — invalid UTF-8 replaced by U+FFFD — re-encodes
+ * to at least as many bytes as it came from, three per U+FFFD, so it scores a
+ * window no longer than the raw file's. A decoded string cannot recover the bytes
+ * it came from, so the in-memory and on-disk sides cannot be made to score the
+ * same span of such a file; the disk-side resolver routes through this helper so
+ * both settle on the narrower window instead of disagreeing. The window is
+ * therefore about {@link DETECT_HEAD_BYTES} / 3 characters for wholly lossy
+ * content, and a latin-1 file whose only code markers sit past that point reads as
+ * "not code" wherever this window is scored.
+ *
+ * The leading character slice only bounds the allocation, keeping a whole-file
+ * encode off this path: the first N characters always encode to at least N
+ * bytes, so slicing to N characters cannot drop anything inside the N-byte
+ * window.
+ */
+export function detectExtensionFromSource(source: string): string | null {
+  const head = Buffer.from(source.slice(0, DETECT_HEAD_BYTES), "utf-8")
+    .subarray(0, DETECT_HEAD_BYTES)
+    .toString("utf-8");
+  return detectExtensionlessExtension(head);
+}
+
+/**
  * Like {@link resolveExtensionlessExtension} but **throws** on a read/stat
  * failure instead of collapsing it to `null`, so a caller that must not conflate
  * "unreadable" with "not code" can tell them apart — e.g. the incremental
@@ -68,7 +102,7 @@ export async function resolveExtensionlessExtensionStrict(absolutePath: string):
   // files (the watcher's isIndexableFile guards the same way).
   const stats = await fsp.lstat(absolutePath);
   if (!stats.isFile()) return null;
-  return detectExtensionlessExtension(await readFileHead(absolutePath));
+  return detectExtensionFromSource(await readFileHead(absolutePath));
 }
 
 /**

--- a/src/services/graph-analysis.ts
+++ b/src/services/graph-analysis.ts
@@ -8,7 +8,8 @@ import type { CodeGraph, CodeGraphNode } from "../types.js";
  * Resolve a graph node's language for display/stats. Prefers the language stored
  * on the node at build time (correct for extensionless files, whose path carries
  * no extension); falls back to deriving it from the path extension for nodes with
- * no stored language (older persisted graphs and import-target-only leaf nodes).
+ * no stored language (older persisted graphs, grammar-less extra-extension nodes,
+ * and import-target-only nodes that discovery never content-detected).
  */
 export function nodeLanguage(node: Pick<CodeGraphNode, "language" | "relativePath">): string {
   return node.language ?? getLanguageFromExtension(path.extname(node.relativePath).toLowerCase());

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -21,6 +21,12 @@ import { createIgnoreFilter, shouldIgnore } from "./ignore.js";
  * found via the standard prefix-based scan (e.g. src/main/java/…).
  *
  * Call this once per graph build and pass the result to resolveImport.
+ *
+ * When two modules provide the same class path, the first one iterated wins, so
+ * `fileSet`'s order decides between them — pass a lexicographically ordered set
+ * (as `buildCodeGraph` does) for a stable pick. Either file resolves the import;
+ * ordering only settles which, so an unordered caller gets a valid map with an
+ * arbitrary winner.
  */
 export function buildJvmSuffixMap(fileSet: Set<string>): Map<string, string> {
   const map = new Map<string, string>();
@@ -93,8 +99,8 @@ export function buildCsNamespaceMap(
   const namespaceRegex =
     /^\s*namespace\s+([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s*(?=[;{])/gm;
 
-  // `fileSet` reflects fs.readdir() traversal order, which POSIX does not
-  // guarantee. Sort .cs paths lexically so candidate lists are stable.
+  // Sort .cs paths lexically so `candidates[0]` is deterministic without relying
+  // on how the caller ordered `fileSet` — this map owns its own ordering.
   const csFiles = [...fileSet]
     .filter((f) => path.extname(f).toLowerCase() === ".cs")
     .sort();

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -10,8 +10,6 @@ import { collectionName, projectIdFromPath } from "../config.js";
 import {
   CHUNK_OVERLAP,
   CHUNK_SIZE,
-  DETECT_HEAD_BYTES,
-  detectExtensionlessExtension,
   EXTENSION_LANGUAGE_MAP,
   EXTRA_EXTENSIONS,
   getLanguageFromExtension,
@@ -26,7 +24,7 @@ import type { FileChunk } from "../types.js";
 import { ensureDynamicLanguages, getAstGrepLang, rebuildGraph, removeGraph } from "./code-graph.js";
 import { ensureArtifactsIndexed, loadConfig, removeAllArtifacts } from "./context-artifacts.js";
 import { generateEmbeddings, prepareDocumentText } from "./embeddings.js";
-import { resolveExtensionlessExtension } from "./extensionless.js";
+import { detectExtensionFromSource, resolveExtensionlessExtension } from "./extensionless.js";
 import { createIgnoreFilter, shouldIgnore } from "./ignore.js";
 import { acquireProjectLock, releaseProjectLock } from "./lock.js";
 import { logger } from "./logger.js";
@@ -442,14 +440,10 @@ export function chunkFileContent(
   // stay consistent. The on-disk path is never rewritten — only the
   // language/grammar selection changes.
   if (ext === "" && indexExtensionlessEnabled() && !SPECIAL_FILES.has(path.basename(filePath))) {
-    // Detect on the same byte window as discovery's readFileHead. `content` is
-    // a decoded string, so slice counts UTF-16 units, not bytes; take the first
-    // DETECT_HEAD_BYTES chars (which encode to >= that many bytes) and truncate
-    // to DETECT_HEAD_BYTES bytes so both paths inspect an identical head.
-    const head = Buffer.from(content.slice(0, DETECT_HEAD_BYTES), "utf-8")
-      .subarray(0, DETECT_HEAD_BYTES)
-      .toString("utf-8");
-    const detected = detectExtensionlessExtension(head);
+    // Scores the same byte window as discovery's readFileHead, via the one
+    // helper that owns that rule, so chunking and discovery cannot disagree
+    // about the same bytes.
+    const detected = detectExtensionFromSource(content);
     // If the content changed since discovery admitted this file (TOCTOU) and it
     // no longer detects as code, produce no chunks rather than indexing it as
     // plaintext — keeping chunking consistent with getIndexableFiles' contract.

--- a/src/services/symbol-graph-incremental.ts
+++ b/src/services/symbol-graph-incremental.ts
@@ -195,7 +195,18 @@ export async function updateChangedFilesSymbolGraph(
     let source: string;
     try {
       source = await fs.readFile(path.join(projectPath, relPath), "utf-8");
-    } catch {
+    } catch (err) {
+      // ENOENT (deleted between change-detection and read) is an expected skip —
+      // a real delete is reconciled via removedRelPaths. Any other fault
+      // (EACCES/EIO) means we are keeping a now-stale payload for a changed file
+      // we could not read; surface it at debug rather than swallowing it, and
+      // skip without purging so a transient blip cannot drop valid symbols.
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        logger.debug("Could not read changed file; keeping prior symbols (skipping)", {
+          relPath,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
       continue;
     }
     const language = getLanguageFromExtension(ext) ?? "plaintext";

--- a/src/services/watcher.ts
+++ b/src/services/watcher.ts
@@ -6,14 +6,13 @@ import type { AsyncSubscription, Event } from "@parcel/watcher";
 import watcher from "@parcel/watcher";
 import { collectionName, projectIdFromPath } from "../config.js";
 import {
-  detectExtensionlessExtension,
   EXTENSION_LANGUAGE_MAP,
   indexExtensionlessEnabled,
   SPECIAL_FILES,
   SUPPORTED_EXTENSIONS,
 } from "../constants.js";
 import { invalidateGraphCache } from "./code-graph.js";
-import { readFileHead } from "./extensionless.js";
+import { detectExtensionFromSource, readFileHead } from "./extensionless.js";
 import { createIgnoreFilter, shouldIgnore } from "./ignore.js";
 import { FILE_SCAN_BATCH, isIndexingInProgress, updateProjectIndex } from "./indexer.js";
 import { acquireProjectLock, isProjectLocked, releaseProjectLock } from "./lock.js";
@@ -82,7 +81,7 @@ export async function isIndexableFile(filePath: string): Promise<boolean> {
   // updateProjectIndex (any other change / nightly / manual codebase_update) —
   // a bounded, self-healing gap.
   try {
-    return detectExtensionlessExtension(await readFileHead(filePath)) !== null;
+    return detectExtensionFromSource(await readFileHead(filePath)) !== null;
   } catch (err) {
     if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
       logger.debug("Extensionless watch check could not read file (scheduling update)", {

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -43,8 +43,9 @@ export async function handleGraphTool(
           const pct = progress.filesTotal > 0
             ? ` (${Math.round((progress.filesProcessed / progress.filesTotal) * 100)}%)`
             : "";
+          const skippedNote = progress.filesSkipped ? ` — ${progress.filesSkipped} skipped` : "";
           lines.push(`Phase: ${progress.phase}`);
-          lines.push(`Progress: ${progress.filesProcessed}/${progress.filesTotal} files${pct}`);
+          lines.push(`Progress: ${progress.filesProcessed}/${progress.filesTotal} files${pct}${skippedNote}`);
           lines.push(`Elapsed: ${elapsed}s`);
         }
         lines.push("", "Call codebase_graph_status to check progress.");
@@ -59,6 +60,7 @@ export async function handleGraphTool(
             projectPath: resolved,
             nodes: graph.nodes.length,
             edges: graph.edges.length,
+            filesSkipped: getLastGraphBuildCompleted(resolved)?.filesSkipped ?? 0,
           });
         })
         .catch((err) => {
@@ -272,7 +274,7 @@ export async function handleGraphTool(
           "",
           `Status: BUILDING`,
           `Phase: ${progress.phase}`,
-          `Progress: ${progress.filesProcessed}/${progress.filesTotal} files (${pct}%)`,
+          `Progress: ${progress.filesProcessed}/${progress.filesTotal} files (${pct}%)${progress.filesSkipped ? ` — ${progress.filesSkipped} skipped` : ""}`,
           `Elapsed: ${elapsed}s`,
           ...renderGrammarBlock(),
           "",
@@ -309,6 +311,9 @@ export async function handleGraphTool(
 
       if (lastBuild) {
         lines.push(`Last build duration: ${(lastBuild.durationMs / 1000).toFixed(1)}s`);
+        if (lastBuild.filesSkipped) {
+          lines.push(`Files skipped: ${lastBuild.filesSkipped}`);
+        }
       }
 
       if (graphInfo.symbol) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,8 +17,10 @@ export interface CodeGraphNode {
   /**
    * Language label for display/stats, set at graph-build time. For extensionless
    * files this carries the content-detected language, which the path alone cannot
-   * yield. Absent on nodes from older persisted graphs and on import-target-only
-   * leaf nodes; consumers fall back to path-based derivation via nodeLanguage().
+   * yield. Absent on nodes from older persisted graphs, on grammar-less
+   * extra-extension nodes, and on import-target-only nodes that discovery never
+   * content-detected; consumers fall back to path-based derivation via
+   * nodeLanguage().
    */
   language?: string;
   imports: string[];

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -13,6 +13,7 @@ import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { GraphBuildProgress } from "../../src/services/code-graph.js";
 
 // ── Docker availability ──────────────────────────────────────────────────
 
@@ -399,3 +400,37 @@ export function removeFixtureFile(projectRoot: string, relativePath: string): vo
  */
 export const canTestPermissionDenied =
   process.platform !== "win32" && process.getuid?.() !== 0;
+
+let _oversizedTs: string | undefined;
+let _oversizedPy: string | undefined;
+
+/**
+ * Padding that puts a file over MAX_GRAPH_FILE_BYTES (1_000_000, compared with a
+ * strict `>`), so the graph build skips it at the size guard.
+ *
+ * The byte counts are literal rather than derived from the limit: deriving them
+ * would scale these fixtures with any future increase, and the tests that rely on
+ * the skip assert `filesSkipped`, so a raised limit fails loudly instead of
+ * silently no longer exercising the skip.
+ *
+ * Built on first call and memoised, so the test files that never ask for a
+ * megabyte of padding do not allocate one just by importing this module.
+ */
+export const oversizedTs = (): string => (_oversizedTs ??= "// pad\n".repeat(150_000)); // 1_050_000 bytes
+
+/**
+ * As {@link oversizedTs}, but content-detected as Python so it can stand in for an
+ * extensionless script. The padding is NUL-free on purpose: written to an
+ * extensionless path, discovery head-reads it and rejects anything that looks
+ * binary, so the file would never be admitted.
+ */
+export const oversizedPy = (): string =>
+  (_oversizedPy ??= `def configure(conf):\n    return 1\n${"# pad\n".repeat(170_000)}`); // 1_020_034 bytes
+
+/** A GraphBuildProgress seeded the way `doRebuildGraph` seeds it. */
+export const freshProgress = (): GraphBuildProgress => ({
+  startedAt: Date.now(),
+  filesTotal: 0,
+  filesProcessed: 0,
+  phase: "scanning files",
+});

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -389,3 +389,13 @@ export function removeFixtureFile(projectRoot: string, relativePath: string): vo
     fs.unlinkSync(fullPath);
   }
 }
+
+// ── Graph-build fixtures ─────────────────────────────────────────────────
+
+/**
+ * Whether this environment can observe a permission-denied read. Root bypasses
+ * mode bits, and Windows does not enforce them the same way, so tests that chmod
+ * a file or directory to 000 have nothing to assert on either.
+ */
+export const canTestPermissionDenied =
+  process.platform !== "win32" && process.getuid?.() !== 0;

--- a/tests/integration/symbol-graph-incremental.test.ts
+++ b/tests/integration/symbol-graph-incremental.test.ts
@@ -2,18 +2,20 @@
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 import fs from "node:fs";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { projectIdFromPath } from "../../src/config.js";
 import {
   invalidateGraphCache,
   rebuildGraph,
 } from "../../src/services/code-graph.js";
+import { logger } from "../../src/services/logger.js";
 import { updateChangedFilesSymbolGraph } from "../../src/services/symbol-graph-incremental.js";
 import {
   loadFilePayload,
   loadSymbolGraphMeta,
 } from "../../src/services/symbol-graph-store.js";
 import {
+  canTestPermissionDenied,
   createFixtureProject,
   type FixtureProject,
   isDockerAvailable,
@@ -318,7 +320,7 @@ describe.skipIf(!dockerAvailable)(
       }
     });
 
-    it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+    it.skipIf(!canTestPermissionDenied)(
       "keeps a changed extensionless file's payload when its head-read fails transiently",
       async () => {
         const rel = "ro/probe";
@@ -352,6 +354,51 @@ describe.skipIf(!dockerAvailable)(
           }
           try {
             fs.rmSync(path.join(fixture.root, "ro"), { recursive: true, force: true });
+          } catch {
+            /* ignore */
+          }
+        }
+      },
+    );
+
+    it.skipIf(!canTestPermissionDenied)(
+      "logs a transient read failure for a changed extensioned file and keeps its payload",
+      async () => {
+        const rel = "ro2/probe.py";
+        const abs = path.join(fixture.root, rel);
+        fs.mkdirSync(path.dirname(abs), { recursive: true });
+        fs.writeFileSync(abs, "def a():\n    return b()\n\ndef b():\n    return 1\n", "utf-8");
+        const debugSpy = vi.spyOn(logger, "debug");
+        try {
+          await rebuildGraph(fixture.root);
+          const before = await loadFilePayload(projectId, rel);
+          expect((before?.symbols ?? []).map((s) => s.name)).toContain("a");
+
+          fs.chmodSync(abs, 0o000);
+          const graph = await rebuildGraph(fixture.root, { skipSymbolGraph: true });
+          const result = await updateChangedFilesSymbolGraph(projectId, fixture.root, graph, [rel], []);
+          expect(result.filesRemoved).toBe(0);
+
+          // The payload survives — that is what the continue exists to protect.
+          const after = await loadFilePayload(projectId, rel);
+          expect((after?.symbols ?? []).map((s) => s.name)).toContain("a");
+
+          // The fault is reported, not swallowed. Matched in full because the
+          // extensionless catch above ends in the same "keeping prior symbols
+          // (skipping)" fragment, so a substring match would not tell the two apart.
+          expect(debugSpy).toHaveBeenCalledWith(
+            "Could not read changed file; keeping prior symbols (skipping)",
+            expect.objectContaining({ relPath: rel }),
+          );
+        } finally {
+          debugSpy.mockRestore();
+          try {
+            fs.chmodSync(abs, 0o644);
+          } catch {
+            /* ignore */
+          }
+          try {
+            fs.rmSync(path.join(fixture.root, "ro2"), { recursive: true, force: true });
           } catch {
             /* ignore */
           }

--- a/tests/unit/code-graph-node-language.test.ts
+++ b/tests/unit/code-graph-node-language.test.ts
@@ -16,6 +16,19 @@ describe("buildCodeGraph node language", () => {
     ensureDynamicLanguages();
     fixture = createFixtureProject("node-language");
     addFileToFixture(fixture.root, "scripts/deploy", "#!/bin/bash\necho deploying\n");
+
+    // An oversized (>1 MB) extensionless Python script that another module
+    // imports. It is admitted by discovery (which reads only the 8 KB head),
+    // then skipped at the size guard — so its only node is the placeholder its
+    // importer creates, which must still carry the detected language.
+    // Two pairs cover both processing orders under the sorted walk:
+    // aaa_import.py runs before zzz_target (importer first), and aaa_target
+    // runs before zzz_import.py (target first).
+    const oversizedScript = `def configure(conf):\n    return 1\n${"# pad\n".repeat(170_000)}`;
+    addFileToFixture(fixture.root, "aaa_import.py", "import zzz_target\n");
+    addFileToFixture(fixture.root, "zzz_target", oversizedScript);
+    addFileToFixture(fixture.root, "aaa_target", oversizedScript);
+    addFileToFixture(fixture.root, "zzz_import.py", "import aaa_target\n");
   });
 
   afterAll(() => {
@@ -35,5 +48,19 @@ describe("buildCodeGraph node language", () => {
     const graph = await buildCodeGraph(fixture.root);
     const index = graph.nodes.find((n) => n.relativePath === "src/index.ts");
     expect(index?.language).toBe("typescript");
+  });
+
+  it("labels an oversized extensionless import target by detected language (importer first)", async () => {
+    const graph = await buildCodeGraph(fixture.root);
+    const target = graph.nodes.find((n) => n.relativePath === "zzz_target");
+    expect(target).toBeDefined();
+    expect(target?.language).toBe("python");
+  });
+
+  it("labels an oversized extensionless import target by detected language (target first)", async () => {
+    const graph = await buildCodeGraph(fixture.root);
+    const target = graph.nodes.find((n) => n.relativePath === "aaa_target");
+    expect(target).toBeDefined();
+    expect(target?.language).toBe("python");
   });
 });

--- a/tests/unit/code-graph-node-language.test.ts
+++ b/tests/unit/code-graph-node-language.test.ts
@@ -6,7 +6,13 @@ import {
   ensureDynamicLanguages,
   invalidateGraphCache,
 } from "../../src/services/code-graph.js";
-import { addFileToFixture, createFixtureProject, type FixtureProject } from "../helpers/fixtures.js";
+import {
+  addFileToFixture,
+  createFixtureProject,
+  type FixtureProject,
+  freshProgress,
+  oversizedPy,
+} from "../helpers/fixtures.js";
 
 describe("buildCodeGraph node language", () => {
   let fixture: FixtureProject;
@@ -24,10 +30,9 @@ describe("buildCodeGraph node language", () => {
     // Two pairs cover both processing orders under the sorted walk:
     // aaa_import.py runs before zzz_target (importer first), and aaa_target
     // runs before zzz_import.py (target first).
-    const oversizedScript = `def configure(conf):\n    return 1\n${"# pad\n".repeat(170_000)}`;
     addFileToFixture(fixture.root, "aaa_import.py", "import zzz_target\n");
-    addFileToFixture(fixture.root, "zzz_target", oversizedScript);
-    addFileToFixture(fixture.root, "aaa_target", oversizedScript);
+    addFileToFixture(fixture.root, "zzz_target", oversizedPy());
+    addFileToFixture(fixture.root, "aaa_target", oversizedPy());
     addFileToFixture(fixture.root, "zzz_import.py", "import aaa_target\n");
   });
 
@@ -51,16 +56,23 @@ describe("buildCodeGraph node language", () => {
   });
 
   it("labels an oversized extensionless import target by detected language (importer first)", async () => {
-    const graph = await buildCodeGraph(fixture.root);
+    const progress = freshProgress();
+    const graph = await buildCodeGraph(fixture.root, undefined, progress);
     const target = graph.nodes.find((n) => n.relativePath === "zzz_target");
     expect(target).toBeDefined();
     expect(target?.language).toBe("python");
+    // Both padded fixtures must actually exceed MAX_GRAPH_FILE_BYTES, or this and
+    // the test below stop exercising the placeholder branch: a processed file gets
+    // its own node and is labelled python by a different code path.
+    expect(progress.filesSkipped).toBe(2);
   });
 
   it("labels an oversized extensionless import target by detected language (target first)", async () => {
-    const graph = await buildCodeGraph(fixture.root);
+    const progress = freshProgress();
+    const graph = await buildCodeGraph(fixture.root, undefined, progress);
     const target = graph.nodes.find((n) => n.relativePath === "aaa_target");
     expect(target).toBeDefined();
     expect(target?.language).toBe("python");
+    expect(progress.filesSkipped).toBe(2);
   });
 });

--- a/tests/unit/code-graph-progress.test.ts
+++ b/tests/unit/code-graph-progress.test.ts
@@ -13,8 +13,11 @@ import {
   isGraphBuildInProgress,
 } from "../../src/services/code-graph.js";
 import {
+  addFileToFixture,
   createFixtureProject,
   type FixtureProject,
+  freshProgress,
+  oversizedTs,
 } from "../helpers/fixtures.js";
 
 // ── Progress tracking API (pure in-memory, no Docker needed) ─────────────
@@ -51,12 +54,7 @@ describe("graph build progress tracking", () => {
 
   describe("buildCodeGraph with progress tracking", () => {
     it("updates progress.filesTotal after scanning", async () => {
-      const progress: GraphBuildProgress = {
-        startedAt: Date.now(),
-        filesTotal: 0,
-        filesProcessed: 0,
-        phase: "scanning files",
-      };
+      const progress = freshProgress();
 
       const graph = await buildCodeGraph(fixture.root, undefined, progress);
 
@@ -71,12 +69,7 @@ describe("graph build progress tracking", () => {
     });
 
     it("tracks filesProcessed incrementally during build", async () => {
-      const progress: GraphBuildProgress = {
-        startedAt: Date.now(),
-        filesTotal: 0,
-        filesProcessed: 0,
-        phase: "scanning files",
-      };
+      const progress = freshProgress();
 
       await buildCodeGraph(fixture.root, undefined, progress);
 
@@ -90,6 +83,25 @@ describe("graph build progress tracking", () => {
       const graph = await buildCodeGraph(fixture.root);
       expect(graph.nodes.length).toBeGreaterThan(0);
       expect(graph.edges.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it("keeps filesProcessed equal to filesTotal when a file is skipped", async () => {
+      // A skipped file still counts toward filesProcessed, so a finished build
+      // reports every file discovery admitted. Its own fixture on purpose —
+      // an oversized file in this file's shared fixture would add a permanent
+      // skip to every sibling test's filesTotal and filesSkipped.
+      const skipFixture = createFixtureProject("graph-progress-skip");
+      addFileToFixture(skipFixture.root, "src/oversized.ts", oversizedTs());
+      try {
+        const progress = freshProgress();
+
+        await buildCodeGraph(skipFixture.root, undefined, progress);
+
+        expect(progress.filesProcessed).toBe(progress.filesTotal);
+        expect(progress.filesSkipped).toBe(1);
+      } finally {
+        skipFixture.cleanup();
+      }
     });
   });
 

--- a/tests/unit/code-graph-skips.test.ts
+++ b/tests/unit/code-graph-skips.test.ts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { MAX_GRAPH_FILE_BYTES } from "../../src/constants.js";
+import { buildCodeGraph, ensureDynamicLanguages } from "../../src/services/code-graph.js";
+import { logger } from "../../src/services/logger.js";
+import {
+  addFileToFixture,
+  canTestPermissionDenied,
+  createFixtureProject,
+  type FixtureProject,
+  freshProgress,
+  oversizedPy,
+  oversizedTs,
+} from "../helpers/fixtures.js";
+
+describe("graph build skip accounting", () => {
+  beforeAll(() => {
+    ensureDynamicLanguages();
+  });
+
+  describe("oversized file with no importer", () => {
+    let fixture: FixtureProject;
+    beforeAll(() => {
+      fixture = createFixtureProject("skips-oversized");
+      addFileToFixture(fixture.root, "src/huge.ts", oversizedTs());
+    });
+    afterAll(() => fixture.cleanup());
+
+    it("drops it from the graph but counts it as processed and skipped", async () => {
+      const progress = freshProgress();
+      const graph = await buildCodeGraph(fixture.root, undefined, progress);
+
+      expect(graph.nodes.find((n) => n.relativePath === "src/huge.ts")).toBeUndefined();
+      expect(progress.filesProcessed).toBe(progress.filesTotal);
+      expect(progress.filesSkipped).toBe(1);
+    });
+
+    it("logs the reason and the size that tripped the limit", async () => {
+      // The reason and its detail payload reach no tool output — this log is their
+      // only observable, so assert it or the classification is untested.
+      const debug = vi.spyOn(logger, "debug");
+      try {
+        await buildCodeGraph(fixture.root, undefined, freshProgress());
+        expect(debug).toHaveBeenCalledWith(
+          "Skipping file in graph build",
+          expect.objectContaining({
+            file: "src/huge.ts",
+            reason: "oversized",
+            size: oversizedTs().length,
+            limit: MAX_GRAPH_FILE_BYTES,
+          }),
+        );
+      } finally {
+        debug.mockRestore();
+      }
+    });
+  });
+
+  describe("oversized extensionless import target", () => {
+    let fixture: FixtureProject;
+    beforeAll(() => {
+      vi.stubEnv("INDEX_EXTENSIONLESS", "1");
+      fixture = createFixtureProject("skips-extensionless");
+      addFileToFixture(fixture.root, "run.py", "import deploy\n");
+      addFileToFixture(fixture.root, "deploy", oversizedPy());
+    });
+    afterAll(() => {
+      fixture.cleanup();
+      vi.unstubAllEnvs(); // else INDEX_EXTENSIONLESS leaks into the describes below
+    });
+
+    it("counts the skip and still labels the placeholder by detected language", async () => {
+      const progress = freshProgress();
+      const graph = await buildCodeGraph(fixture.root, undefined, progress);
+
+      expect(progress.filesSkipped).toBe(1);
+      const target = graph.nodes.find((n) => n.relativePath === "deploy");
+      expect(target?.language).toBe("python");
+    });
+  });
+
+  describe("extensionless file whose tail reads as another language", () => {
+    let fixture: FixtureProject;
+    beforeAll(() => {
+      vi.stubEnv("INDEX_EXTENSIONLESS", "1");
+      fixture = createFixtureProject("skips-window");
+      // Python inside the first DETECT_HEAD_BYTES, shell markers past them.
+      // Discovery scores the head; the build re-detects on the bytes it read. Both
+      // score the same window, so they agree and the file is kept — dropping the
+      // window on either side would make them disagree about unchanged content.
+      addFileToFixture(
+        fixture.root,
+        "wide_script",
+        `def configure(conf):\n    return 1\n${"# pad\n".repeat(1500)}${
+          "if [ -d /tmp ]; then\n  export PATH=/bin\nfi\n".repeat(20)
+        }`,
+      );
+    });
+    afterAll(() => {
+      fixture.cleanup();
+      vi.unstubAllEnvs();
+    });
+
+    it("keeps it under the language its head detects, and counts no skip", async () => {
+      const progress = freshProgress();
+      const graph = await buildCodeGraph(fixture.root, undefined, progress);
+
+      const node = graph.nodes.find((n) => n.relativePath === "wide_script");
+      expect(node?.language).toBe("python");
+      expect(progress.filesSkipped).toBeUndefined();
+    });
+  });
+
+  describe("unreadable file", () => {
+    let fixture: FixtureProject;
+    let abs: string;
+    beforeAll(() => {
+      fixture = createFixtureProject("skips-eacces");
+      // Must be extension-bearing: discovery head-reads extensionless files, so a
+      // mode-000 extensionless file is rejected there and never reaches the read
+      // guard this test is pinning.
+      addFileToFixture(fixture.root, "src/secret.ts", "export const a = 1;\n");
+      abs = path.join(fixture.root, "src/secret.ts");
+    });
+    afterAll(() => fixture.cleanup());
+
+    it.skipIf(!canTestPermissionDenied)(
+      "counts an EACCES read failure as processed and skipped",
+      async () => {
+        fs.chmodSync(abs, 0o000);
+        try {
+          const progress = freshProgress();
+          const graph = await buildCodeGraph(fixture.root, undefined, progress);
+
+          expect(graph.nodes.find((n) => n.relativePath === "src/secret.ts")).toBeUndefined();
+          expect(progress.filesProcessed).toBe(progress.filesTotal);
+          expect(progress.filesSkipped).toBe(1);
+        } finally {
+          fs.chmodSync(abs, 0o644);
+        }
+      },
+    );
+
+    it.skipIf(!canTestPermissionDenied)(
+      "classifies it read-failed rather than vanished, with the error text",
+      async () => {
+        // Only the log distinguishes a real fault from ENOENT — both count as one
+        // skip — so inverting that check is invisible without this assertion.
+        const debug = vi.spyOn(logger, "debug");
+        fs.chmodSync(abs, 0o000);
+        try {
+          await buildCodeGraph(fixture.root, undefined, freshProgress());
+          expect(debug).toHaveBeenCalledWith(
+            "Skipping file in graph build",
+            expect.objectContaining({
+              file: "src/secret.ts",
+              reason: "read-failed",
+              error: expect.stringContaining("EACCES"),
+            }),
+          );
+        } finally {
+          fs.chmodSync(abs, 0o644);
+          debug.mockRestore();
+        }
+      },
+    );
+  });
+
+  describe("clean project", () => {
+    let fixture: FixtureProject;
+    beforeAll(() => {
+      fixture = createFixtureProject("skips-clean");
+    });
+    afterAll(() => fixture.cleanup());
+
+    it("leaves filesSkipped undefined when nothing was skipped", async () => {
+      const progress = freshProgress();
+      await buildCodeGraph(fixture.root, undefined, progress);
+
+      expect(progress.filesProcessed).toBe(progress.filesTotal);
+      expect(progress.filesSkipped).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/extensionless.test.ts
+++ b/tests/unit/extensionless.test.ts
@@ -6,11 +6,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DETECT_HEAD_BYTES, detectExtensionlessExtension } from "../../src/constants.js";
 import {
+  detectExtensionFromSource,
   readFileHead,
   resolveExtensionlessExtension,
   resolveExtensionlessExtensionStrict,
 } from "../../src/services/extensionless.js";
+import { canTestPermissionDenied } from "../helpers/fixtures.js";
 
 describe("extensionless I/O helpers", () => {
   let root: string;
@@ -139,7 +142,7 @@ describe("extensionless I/O helpers", () => {
       const p = write("probe", "#!/bin/bash\nexit 0\n");
       expect(await resolveExtensionlessExtensionStrict(p)).toBe(".sh");
     });
-    it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+    it.skipIf(!canTestPermissionDenied)(
       "throws on a head-read failure (EACCES), distinct from a stat failure",
       async () => {
         // The stat-failure path is covered above (missing file → lstat throws).
@@ -157,5 +160,72 @@ describe("extensionless I/O helpers", () => {
         }
       },
     );
+  });
+
+  describe("detectExtensionFromSource", () => {
+    it("detects a shebang script", () => {
+      expect(detectExtensionFromSource("#!/bin/bash\nexit 0\n")).toBe(".sh");
+    });
+    it("detects Python by content sniff", () => {
+      expect(detectExtensionFromSource("def configure(conf):\n    return 1\n")).toBe(".py");
+    });
+    it("returns null for prose", () => {
+      expect(detectExtensionFromSource("All rights reserved.\n")).toBeNull();
+    });
+    it("returns null for content containing a NUL byte", () => {
+      expect(detectExtensionFromSource(`abc${String.fromCharCode(0)}def`)).toBeNull();
+    });
+    it("scores an 8192-BYTE head, not an 8192-character one", async () => {
+      // "é" is 1 character but 2 UTF-8 bytes. 5000 of them is 10000 bytes — past
+      // the 8192-byte head — while being only ~5003 characters, so a character
+      // slice would reach the shell markers below and score them.
+      const padding = `# ${"é".repeat(5000)}\n`;
+      const source = `${padding}if [ -d /tmp ]; then\n  export PATH=/bin\nfi\n`;
+
+      // Byte window: the head is all padding, so nothing is detected.
+      expect(detectExtensionFromSource(source)).toBeNull();
+
+      // Sanity check that the markers WOULD score if they were in the window —
+      // otherwise this test would pass for the wrong reason.
+      expect(detectExtensionFromSource("if [ -d /tmp ]; then\n  export PATH=/bin\nfi\n")).toBe(".sh");
+
+      // And in-memory detection agrees with the on-disk reader on the same bytes.
+      const p = write("wide", source);
+      expect(await resolveExtensionlessExtensionStrict(p)).toBeNull();
+    });
+    it("narrows the window for lossily-decoded content, on disk as well as in memory", async () => {
+      // Latin-1 bytes are invalid UTF-8, so each decodes to U+FFFD and re-encodes
+      // to three bytes: a head of them fills the byte window in a third of the
+      // characters, leaving the shell markers after the padding outside it — even
+      // though the whole file fits inside the raw head the disk reader takes.
+      const padBytes = Math.ceil(DETECT_HEAD_BYTES / 3) + 100;
+      const markers = "\nif [ -d /tmp ]; then\n  export PATH=/bin\nfi\n";
+      const latin1 = Buffer.concat([
+        Buffer.from("# "),
+        Buffer.alloc(padBytes, 0xe9),
+        Buffer.from(markers),
+      ]);
+      expect(latin1.length).toBeLessThan(DETECT_HEAD_BYTES);
+      const p = write("latin1", latin1);
+
+      // Scoring the raw decoded head reaches the markers, so the two windows
+      // genuinely diverge here and the assertions below are not a dead fixture.
+      expect(detectExtensionlessExtension(await readFileHead(p))).toBe(".sh");
+
+      // The helper's window stops short of them, and the disk-side resolver routes
+      // through the helper, so both sides answer "not code" rather than disagreeing.
+      expect(detectExtensionFromSource(await readFileHead(p))).toBeNull();
+      expect(await resolveExtensionlessExtensionStrict(p)).toBeNull();
+      expect(detectExtensionFromSource(fs.readFileSync(p, "utf-8"))).toBeNull();
+
+      // Same length, same markers, valid UTF-8: still detected, so it is the lossy
+      // decode that moves the window and not the padding length.
+      const ascii = Buffer.concat([
+        Buffer.from("# "),
+        Buffer.alloc(padBytes, 0x61),
+        Buffer.from(markers),
+      ]);
+      expect(await resolveExtensionlessExtensionStrict(write("ascii", ascii))).toBe(".sh");
+    });
   });
 });

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -6,6 +6,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { buildCodeGraph, ensureDynamicLanguages, getGraphableFiles } from "../../src/services/code-graph.js";
+import { logger } from "../../src/services/logger.js";
+import { canTestPermissionDenied } from "../helpers/fixtures.js";
 
 // Regression for the whitelist .gitignore discovery fix: a `/*` then `!/src/`
 // pattern ignores everything at the root but re-includes `src/`. The old walk
@@ -168,6 +170,52 @@ describe("getGraphableFiles — depth-first interleaving", () => {
     const { files } = await getGraphableFiles(root);
     expect(files).toEqual(["a.py", "a/x.py"]);
   });
+});
+
+// A directory the walk cannot read takes its whole subtree out of the file list
+// before any of those files has a path to report, so they never reach the build
+// loop's skip accounting. The log is the only trace, which is what this pins.
+describe("getGraphableFiles — unreadable directory", () => {
+  let root: string;
+  let locked: string;
+
+  beforeAll(() => {
+    ensureDynamicLanguages();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-discovery-eacces-"));
+    fs.writeFileSync(path.join(root, "top.py"), "def a():\n    return 1\n");
+    locked = path.join(root, "locked");
+    fs.mkdirSync(locked, { recursive: true });
+    fs.writeFileSync(path.join(locked, "hidden.py"), "def b():\n    return 2\n");
+  });
+
+  afterAll(() => {
+    try {
+      fs.chmodSync(locked, 0o755);
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it.skipIf(!canTestPermissionDenied)(
+    "logs the directory and omits its subtree",
+    async () => {
+      const debug = vi.spyOn(logger, "debug");
+      fs.chmodSync(locked, 0o000);
+      try {
+        const { files } = await getGraphableFiles(root);
+
+        expect(files).toEqual(["top.py"]);
+        expect(debug).toHaveBeenCalledWith(
+          "Could not read directory in graph discovery (subtree omitted)",
+          expect.objectContaining({ dir: "locked", error: expect.stringContaining("EACCES") }),
+        );
+      } finally {
+        fs.chmodSync(locked, 0o755);
+        debug.mockRestore();
+      }
+    },
+  );
 });
 
 // Sorting discovery output also settles buildJvmSuffixMap's tie-break for a class

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -37,7 +37,7 @@ describe("getGraphableFiles — whitelist .gitignore", () => {
   });
 
   it("descends into re-included src/ and discovers its files", async () => {
-    const files = await getGraphableFiles(root);
+    const { files } = await getGraphableFiles(root);
     expect(files).toContain("src/mod.lua");
     // The `/*` pattern still ignores top-level entries that are not re-included.
     expect(files).not.toContain("ignored.lua");
@@ -71,6 +71,9 @@ describe("getGraphableFiles / buildCodeGraph — extensionless", () => {
       path.join(root, ".profile"),
       'set -eu\nif [ -d "$HOME/bin" ]; then\n  export PATH="$HOME/bin"\nfi\n',
     );
+    // Extensioned file: admitted by extension alone, so detection never runs and
+    // it must carry no detectedExts entry.
+    fs.writeFileSync(path.join(root, "mod.py"), "def f():\n    return 1\n");
   });
 
   afterAll(() => {
@@ -82,7 +85,7 @@ describe("getGraphableFiles / buildCodeGraph — extensionless", () => {
   });
 
   it("includes grammar-bearing extensionless files, excludes .txt-detected and non-code", async () => {
-    const files = await getGraphableFiles(root);
+    const { files } = await getGraphableFiles(root);
     expect(files).toContain("wscript");
     expect(files).not.toContain("helper"); // .txt — grammar-less, stays out of graph
     expect(files).not.toContain("NOTICE");
@@ -93,7 +96,7 @@ describe("getGraphableFiles / buildCodeGraph — extensionless", () => {
   it("excludes all extensionless files when INDEX_EXTENSIONLESS=false", async () => {
     vi.stubEnv("INDEX_EXTENSIONLESS", "false");
     try {
-      const files = await getGraphableFiles(root);
+      const { files } = await getGraphableFiles(root);
       expect(files).not.toContain("wscript");
       expect(files).not.toContain("helper");
     } finally {
@@ -104,7 +107,7 @@ describe("getGraphableFiles / buildCodeGraph — extensionless", () => {
   it("includes a detected extensionless dotfile when INCLUDE_DOT_FILES=true", async () => {
     vi.stubEnv("INCLUDE_DOT_FILES", "true");
     try {
-      const files = await getGraphableFiles(root);
+      const { files } = await getGraphableFiles(root);
       expect(files).toContain(".profile"); // shell dotfile now admitted (matches the index)
     } finally {
       vi.unstubAllEnvs();
@@ -116,6 +119,95 @@ describe("getGraphableFiles / buildCodeGraph — extensionless", () => {
     const symbols = graph.symbolsByFile.get("wscript");
     expect(symbols).toBeDefined();
     expect((symbols ?? []).map((s) => s.name)).toEqual(expect.arrayContaining(["configure", "build"]));
+  });
+
+  it("carries the discovery-detected extension for admitted extensionless files", async () => {
+    const { files, detectedExts } = await getGraphableFiles(root);
+    expect(files).toContain("wscript");
+    expect(detectedExts.get("wscript")).toBe(".py");
+    // Extensioned files are admitted by extension, so detection never ran.
+    expect(files).toContain("mod.py");
+    expect(detectedExts.has("mod.py")).toBe(false);
+    // Rejected extensionless files carry no entry either.
+    expect(detectedExts.has("NOTICE")).toBe(false);
+  });
+
+  it("returns files in lexicographic order", async () => {
+    // wscript is written before mod.py above, so this fails on a filesystem that
+    // yields creation order. Where readdir is already sorted it cannot fail —
+    // the interleaving test below is the one that pins the sort on those.
+    const { files } = await getGraphableFiles(root);
+    expect(files).toEqual(["mod.py", "wscript"]);
+  });
+});
+
+// The half of the sort's job that is observable on every filesystem, sorted
+// readdir included: a depth-first walk yields a directory's contents before the
+// sibling entries that sort after it, because "/" (0x2F) sorts after "." (0x2E).
+// So the raw traversal order is not lexicographic even when each readdir is.
+describe("getGraphableFiles — depth-first interleaving", () => {
+  let root: string;
+
+  beforeAll(() => {
+    ensureDynamicLanguages();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-discovery-order-"));
+    fs.mkdirSync(path.join(root, "a"), { recursive: true });
+    fs.writeFileSync(path.join(root, "a", "x.py"), "def x():\n    return 1\n");
+    fs.writeFileSync(path.join(root, "a.py"), "def y():\n    return 2\n");
+  });
+
+  afterAll(() => {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it("puts a.py before a/x.py, the opposite of what the walk yields", async () => {
+    const { files } = await getGraphableFiles(root);
+    expect(files).toEqual(["a.py", "a/x.py"]);
+  });
+});
+
+// Sorting discovery output also settles buildJvmSuffixMap's tie-break for a class
+// path that two modules both provide: it keeps the first path it sees, so the
+// winner is the lexicographically first module rather than whichever the walk
+// reached first. "mod-b/…" sorts before "mod/…" ("-" 0x2D < "/" 0x2F) while the
+// walk descends "mod" first, so the two orders disagree on this fixture.
+describe("buildCodeGraph — duplicate JVM class path tie-break", () => {
+  let root: string;
+
+  beforeAll(() => {
+    ensureDynamicLanguages();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-jvm-tiebreak-"));
+    for (const module of ["mod", "mod-b"]) {
+      const dir = path.join(root, module, "src", "main", "java", "com", "example");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "Foo.java"), "package com.example;\n\npublic class Foo {}\n");
+    }
+    const appDir = path.join(root, "app", "src", "main", "java", "com", "other");
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, "App.java"),
+      "package com.other;\n\nimport com.example.Foo;\n\npublic class App {}\n",
+    );
+  });
+
+  afterAll(() => {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it("resolves a duplicated class to the lexicographically first module", async () => {
+    const graph = await buildCodeGraph(root);
+    const app = graph.nodes.find(
+      (n) => n.relativePath === "app/src/main/java/com/other/App.java",
+    );
+    expect(app?.dependencies).toEqual(["mod-b/src/main/java/com/example/Foo.java"]);
   });
 });
 

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -71,6 +71,7 @@ vi.mock("../../src/services/lock.js", () => ({
   isProjectLocked: (...args: unknown[]) => mockIsProjectLocked(...(args as [string, string])),
 }));
 
+import { DETECT_HEAD_BYTES } from "../../src/constants.js";
 import { shouldIgnore } from "../../src/services/ignore.js";
 import { logger } from "../../src/services/logger.js";
 // Import after mocks
@@ -756,6 +757,24 @@ describe("watcher isIndexableFile — extensionless", () => {
   it("ignores a readable non-code extensionless file", async () => {
     const p = path.join(dir, "LICENSE");
     fs.writeFileSync(p, "MIT License\n\nCopyright (c) 2026\n");
+    expect(await isIndexableFile(p)).toBe(false);
+  });
+
+  it("scores lossily-decoded content on the same window discovery uses", async () => {
+    // Latin-1 bytes each re-encode to three, so markers sitting past
+    // DETECT_HEAD_BYTES / 3 characters are outside the shared window. Scoring the
+    // raw head instead would call this code and schedule an update for a file
+    // discovery will not admit — this check's answer decides whether an edit is
+    // scheduled at all, so it has to agree with discovery.
+    const p = path.join(dir, "deploy-latin1");
+    fs.writeFileSync(
+      p,
+      Buffer.concat([
+        Buffer.from("# "),
+        Buffer.alloc(Math.ceil(DETECT_HEAD_BYTES / 3) + 100, 0xe9),
+        Buffer.from("\nif [ -d /tmp ]; then\n  export PATH=/bin\nfi\n"),
+      ]),
+    );
     expect(await isIndexableFile(p)).toBe(false);
   });
 


### PR DESCRIPTION

## Summary

`buildCodeGraph` dropped files from the graph with no trace. The per-file read guard swallowed every
`fs` error in a bare `catch`, and neither the oversized skip nor that catch incremented
`filesProcessed` — so a build that dropped files reported a percentage that never reached 100, and
nothing anywhere reported that the graph was incomplete.

Fixing that surfaced a second problem in the same loop: extensionless files were head-read a second
time to recover their language, and the label an *import-target* placeholder got depended on whether
the target happened to be processed before its importer. A grammar-bearing extensionless file that
was an import target and also oversized or unreadable showed up as `plaintext` in graph stats and
visualization.

This PR makes every abandoned file counted and logged with a reason, carries content detection from
discovery into the build instead of re-reading, and routes every extensionless-language decision
through one shared byte window, so discovery, chunking, the graph build, the watcher, and the
incremental symbol-graph update cannot disagree about the language of the same file. That is four call
sites of the new helper — one of them the disk-side resolver that discovery and the incremental update
both go through.

## Reviewing this

Five commits, each self-contained and each typechecking on its own, so they read in order:

1. `fix(graph): carry detected language from discovery into graph build`
2. `fix(graph): count and log files skipped during code graph build`
3. `fix(graph): log unreadable files in the incremental symbol-graph update`
4. `docs: document graph-build skip accounting and discovery ordering`
5. `fix(watcher): score the extensionless watch check on the shared byte window`

Commit 1 is the largest and the one worth reading closely — it carries the discovery→build handoff, the
shared detection window, and the sort. Commit 2 is the skip accounting proper. The rest are small.

## Changes

- **Detected language flows from discovery into the build.** `getGraphableFiles` now returns
  `{ files, detectedExts }`; the build loop reuses that detection instead of head-reading again, and
  import-target placeholders take their language from the map at creation time (so the label no
  longer depends on processing order). Discovery output is also sorted — see reviewer notes.
- **One shared detection window.** New `detectExtensionFromSource` scores an 8192-**byte** UTF-8
  window (bytes, not characters, so multibyte content cannot shift the score). The chunker's inline
  copy of that computation and the watcher's raw `readFileHead` call both fold into it. Detection also
  re-runs on the bytes about to be parsed rather than on a separate head-read, closing the window the
  old re-detect left open; what happens when it disagrees with discovery is the next bullet.
- **Skip accounting.** Every path that abandons a file routes through one `recordSkip` helper: logs
  the reason at `debug`, counts the file toward `filesProcessed`, and increments a new optional
  `filesSkipped`. Four reasons: `oversized`, `vanished` (ENOENT between discovery and read),
  `read-failed` (any other fault — EACCES/EIO/EMFILE, logged with the error text), `content-changed`
  (extensionless only: re-detection on the parsed bytes no longer yields a grammar-bearing language,
  so there is nothing to parse it with).
- **Re-detection adopts the fresh answer.** An extensionless file is re-detected on the bytes about to
  be parsed and parsed under the grammar *those* bytes call for, so content that changed since
  discovery is followed rather than dropped — the fresh detection describes what is in hand, so it
  supersedes discovery's rather than being compared against it. This keeps the graph aligned with the
  chunker, which has always adopted the fresh detection and bails only when detection fails.
- **Where the counts surface.** Per-reason breakdown plus total in the existing `"Code graph built"`
  log (which runs at `info`, the default level); total in `codebase_graph_status` while building, in
  its READY block, and in the background-build completion log. The count is omitted entirely when
  nothing was skipped.
- **A directory the walk cannot read is no longer silent.** `getGraphableFiles`' `walk` swallowed
  `readdir` failures in a bare `catch`, so one EACCES/EIO directory removed its entire subtree from the
  file list — a larger blast radius than any per-file reason, and the files leave the walk before they
  have a path of their own, so none of them can reach `recordSkip`. It now logs the directory and the
  error at `debug` (ENOENT stays quiet: a directory removed mid-walk has nothing left to graph).
  Control flow is unchanged — the parent keeps walking, as before.
- **Watcher path.** The `readFile` catch in the incremental symbol-graph update's changed-files loop
  swallowed every error, so a file whose symbols could not be refreshed kept a stale payload with no
  trace — on every change. Control flow is deliberately unchanged; only the ENOENT split was
  missing, mirroring the catch forty lines above it. ENOENT stays quiet because a real delete is
  reconciled through `removedRelPaths`.
- **Docs.** Four `DEVELOPER.md` passages: the `filesSkipped` counter and its four reasons, that
  discovery returns detected extensions and sorts its output, and the skipped count in
  `codebase_graph_status`.
- Also drops an unreachable node-lookup guard in the build loop by holding the node reference instead
  of re-reading it from the map.

### Behaviour a reviewer may notice

- `codebase_graph_status` gains a skipped count (only when non-zero); `GraphBuildProgress` gains an
  optional `filesSkipped`.
- Extensionless import targets that are oversized or unreadable now carry their detected language
  instead of `plaintext`.
- `buildJvmSuffixMap`'s duplicate class-path tie-break moves from traversal order to lexicographic.
- **Extensionless files with invalid UTF-8 in their head are admitted on a narrower window than
  before, at every detection site.** This one is worth a close look, since it is the only place the PR
  narrows behaviour rather than preserving it. A lossily-decoded head re-encodes to three bytes per
  U+FFFD, so the shared window covers roughly `DETECT_HEAD_BYTES / 3` characters of such a file: a
  latin-1 script whose only code markers sit past ~2730 characters detected as code before and does
  not now. Measured on a 3051-byte latin-1 shell script that fits entirely inside the raw 8 KB head —
  `main` answers `.sh`, this branch answers `null`, and an ASCII file of identical length still
  answers `.sh`. The narrowing is not incidental: a decoded string cannot recover the bytes it came
  from, so the in-memory and on-disk sides cannot be made to score the same span of a lossy file, and
  the only way to stop them disagreeing is to put both on the narrower window. Pinned by a test, and
  the reasoning is in `detectExtensionFromSource`'s JSDoc.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test coverage improvement

## Testing

Full suite on Node 22: **53 files / 1160 tests passing**, `npm run lint` clean with zero warnings,
`npm run build` (tsc + asset copy) clean.

- [x] Unit tests pass (`npm run test:unit`)
- [x] Integration tests pass (`npm run test:integration`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] New tests added for new/changed functionality

New coverage: `tests/unit/code-graph-skips.test.ts` (oversized with no importer; oversized
extensionless import target — asserts both the skip count and that the placeholder keeps its detected
language; unreadable file, including that it is classified `read-failed` and not `vanished`; a file
whose head and tail read as different languages is kept under its head's language; clean project
leaves `filesSkipped` undefined), plus additions to `code-graph-progress.test.ts`,
`code-graph-node-language.test.ts`, `extensionless.test.ts`, `graph-discovery.test.ts`,
`watcher.test.ts`, and `tests/integration/symbol-graph-incremental.test.ts`.

`graph-discovery.test.ts` also covers the unreadable directory, asserting both that its subtree is
omitted and that the omission is logged — the log being the only observable, since those files cannot
reach the skip counter.

Each new ordering/window test was checked by mutation, not just by passing: removing `files.sort()`
fails the interleaving and JVM tie-break tests; reverting either detection call site to raw scoring
fails the lossy-decode tests; dropping the window in the graph's re-detection fails the head/tail test;
restoring the bare `catch` fails the unreadable-directory test.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate
- [x] I have updated documentation (README.md / DEVELOPER.md) if needed
- [x] I have addressed all [CodeRabbit](https://coderabbit.ai) review comments (or marked as resolved with explanation)
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

<!-- CodeRabbit runs once this PR is open — leaving unchecked until its comments are addressed. -->

## Reviewer notes

Decisions below were each made deliberately during implementation, and several of them are the kind a
reviewer would otherwise have to reverse-engineer. Pushing back on any of them is welcome — but the
reasoning is here so it does not have to be rediscovered.

**Why discovery sorts.** Not because any filesystem was observed returning hash order — that premise
did not reproduce on APFS, where each `readdir` is already sorted. Two other reasons stand on their
own: Node documents *no* `readdir` ordering at all, and a depth-first walk is not lexicographic even
when every `readdir` is, because it yields a directory's contents before the sibling entries that sort
after it (`/` 0x2F sorts after `.` 0x2E, so `a/x.ts` comes before `a.ts`). That second property is
filesystem-independent, which makes it testable anywhere — so the sort is pinned by a fixture of
`a/x.py` plus `a.py` that fails on APFS with `files.sort()` removed, rather than only by the
reverse-lexicographic-creation test, which cannot fail where `readdir` is pre-sorted (that one is kept
for platforms yielding creation order). `buildGoModuleInfo` and `buildCsNamespaceMap` already sorted
their own views defensively; this hoists the guarantee up to discovery, where processing order drives
node insertion order and `buildJvmSuffixMap`'s duplicate-class tie-break.

**The JVM tie-break is now pinned.** Sorting discovery output means `buildJvmSuffixMap`'s tie-break for
a class path two modules both provide is defined (lexicographic) rather than arbitrary-by-traversal —
pre-existing nondeterminism this PR settles as a side effect. The test runs through `buildCodeGraph`
with modules `mod` and `mod-b`: `mod-` sorts before `mod/` while the walk descends `mod` first, so the
two orders disagree and the assertion fails if either the sort or the tie-break changes.

**`src/services/graph-analysis.ts` and `src/services/indexer.ts` are touched even though neither is
about skip accounting.** Both are consequences of the main change, not drive-by edits:
`graph-analysis.ts` (and the `CodeGraphNode.language` JSDoc in `types.ts`) documents when the stored
language is absent, and that set changed once placeholders started carrying a detected language;
`indexer.ts` loses its inline copy of the head-window computation to the new shared helper — the
whole point of introducing the helper was that the copies could drift.

**Four skip reasons, not five — the `!detected || !detectedLang` guard is type-narrowing only.** An
earlier iteration counted that guard as a fifth reason. Discovery admits an extensionless path *only*
together with a grammar-bearing detection and records it in `detectedExts` in the same step, so the
state cannot occur; the guard exists because TypeScript cannot infer `detected` is defined from
`detectedLang` being non-null. It `continue`s without counting, and its comment says so. Accepted
consequence: if the invariant were ever broken, that path would be an uncounted skip (and would leave
`filesProcessed` short of `filesTotal`) rather than a counted one.

Worth not confusing it with the re-detect guard further down the loop, which is shaped almost
identically but *does* count, as `content-changed`. The difference is reachability: the re-detect guard
tests content the build actually read, which can genuinely have changed since discovery, while this one
tests a state discovery cannot hand it.

**`vanished` has no direct test, and `content-changed` is pinned only in one direction.** `vanished` is
not reachable through the public API and shares its catch with `read-failed`, which is covered
end-to-end including its log payload. For `content-changed`, the direction that is reachable without a
real race — a file whose head and tail read as different languages must *not* be skipped, because both
sides score the same window — has a test; actually firing the reason needs the content to change
between two reads inside one build, so it is exercised through `detectExtensionFromSource`'s own unit
tests rather than through `buildCodeGraph`.

**One adjacent gap left deliberately unfixed: an unreadable *extensionless* file is not counted.** At
discovery, a head-read failure on an extensionless file collapses into `null`, which the call site
cannot distinguish from "readable, but prose" — so the file is never admitted and never counted, while
the byte-identical file *with* a suffix reaches the build's read guard and is counted as `read-failed`.
Whether a permission fault reaches the skip total therefore depends on whether the file has an
extension.

It is not silent, which is why it is not urgent: `resolveExtensionlessExtension` already logs the
non-ENOENT fault at `debug` with the path and the error, at the same level as every other per-file skip
detail. What is missing is only the aggregate count, and adding it means threading a second counter out
of `getGraphableFiles` and deciding how a discovery-phase failure should render in
`codebase_graph_status` — a design question this PR's per-file funnel, which keys on a project-relative
path, deliberately does not answer. Happy to open it as a follow-up.

**Two related fixes were found while doing this and are deliberately held back.** Both are language-
labelling bugs in the same area this PR touches, and both are being kept out of it so this stays one
reviewable change rather than a grab-bag:

1. **`fix/shell-source-resolution`** — shell `source` / `.` directives are extracted as imports but do
   not resolve to a project file, so the file graph loses those edges. A three-line fix in
   `src/services/graph-resolution.ts` plus tests.
2. **`fix/stylus-language-and-indexing`** — `.styl` files are labelled `plaintext` instead of `stylus`
   and are not indexed at all. A `src/constants.ts` change plus tests and doc updates.

Neither depends on this PR and this PR does not depend on either — all three sit independently on the
same base, so they can be reviewed and merged in any order. Two textual overlaps to be aware of, both
mechanical keep-both-sides resolutions for whichever lands second:
`tests/unit/code-graph-node-language.test.ts` (each branch appends fixtures to the same `beforeAll` and
cases to the same `describe`) and, for the Stylus one, `DEVELOPER.md` (this PR rewrites the
skip-accounting and discovery passages; that one edits the extension table and its count).

I can open either as its own PR on request, or fold one in here if you would rather review them
together.

**Knowingly left alone.** These were raised in review and declined as out of scope — each is a
pre-existing shape this PR does not make worse:

- `graph-tools.ts` renders "N skipped" in three places rather than through one formatter, and those
  output strings have no assertions.
- The three `CodeGraphNode` object literals in `buildCodeGraph` are not unified behind a factory; one
  of the three is pre-existing code this PR does not otherwise touch.
- `isIndexableFile` still re-implements `resolveExtensionlessExtensionStrict` inline. Collapsing it is
  a ~29-line rewrite of a function this PR otherwise leaves alone, and it would merge two distinct
  debug messages into one.
- The two catch blocks in `symbol-graph-incremental.ts` carry near-identical rationale comments. The
  mirroring is deliberate — the second catch's whole justification is that it matches the first.

## Related issues

<!-- None linked. Add "Fixes #N" here if this maps to a filed issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and language detection for extensionless files during indexing and graph building.
  * Preserved existing symbol data when temporary file-read failures occur.
  * Added clearer handling for skipped, oversized, unreadable, or vanished files.
  * Stabilized file ordering and dependency resolution results.

* **New Features**
  * Graph build progress and completion status now report skipped file counts and reasons.
  * Placeholder graph nodes retain detected language information when source files are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->