### PR TITLE
fix(graph): pack symbol-graph upserts by bytes and surface persist failures

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -883,7 +883,7 @@ All points use the dummy-vector-`[0]` pattern (Qdrant requires a vector even whe
 
 A single point that cannot fit under `QDRANT_MAX_REQUEST_BYTES` even alone throws `SymbolGraphPointTooLargeError`, naming the file or shard and pointing at `service.max_request_size_mb`, rather than being dropped. Name shards (27 of them, one per leading character) are the one structure that can grow unbounded with repo size; they are size-checked before write for the same reason. Splitting a shard across multiple points would change the on-disk layout and is deliberately not done here.
 
-When symbol-graph persistence fails, `buildCodeGraph` still returns and saves the file-import graph, but records the reason on `GraphBuildCompleted.symbolGraphError` (unwrapped via `describeQdrantError`, which digs the server's real explanation out of `err.data.status.error`). `codebase_graph_status` prints it, so a half-built graph is no longer reported as a clean success while `codebase_impact` silently answers "0 callers".
+When symbol-graph persistence fails, `doRebuildGraph` (the rebuild driver around `buildCodeGraph`, which itself only parses files) still returns and saves the file-import graph, but records the reason on `GraphBuildCompleted.symbolGraphError` (unwrapped via `describeQdrantError`, which digs the server's real explanation out of `err.data.status.error`). `codebase_graph_status` prints it, so a half-built graph is no longer reported as a clean success while `codebase_impact` silently answers "0 callers".
 
 #### Languages with first-class symbol extraction
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -879,6 +879,12 @@ buildCodeGraph (one pass per file)
 
 All points use the dummy-vector-`[0]` pattern (Qdrant requires a vector even when not used for similarity search). Points use UUID-formatted SHA-256 IDs via `uuidFromString`. The `on_disk_payload: true` flag keeps memory usage bounded.
 
+**Upserts are bounded by bytes, not just by point count.** Qdrant rejects any request body over `service.max_request_size_mb` (default 32 MiB) with an HTTP 400 whose client-side message is only `Bad Request`. A per-file payload scales with the source file, so a few large files (a 900 KB Java file yields a ~6 MB point) used to overflow a fixed 50-point batch and fail the whole request — issue #89. `saveFilePayloads` therefore packs each request up to `QDRANT_UPSERT_BUDGET_BYTES` (24 MiB, headroom under the 32 MiB ceiling) *and* the historic 50-point cap, so ordinary repos batch exactly as before while large files simply get more requests. Point ids and payload shapes are unchanged, so this is purely a transport-level change with nothing to migrate.
+
+A single point that cannot fit under `QDRANT_MAX_REQUEST_BYTES` even alone throws `SymbolGraphPointTooLargeError`, naming the file or shard and pointing at `service.max_request_size_mb`, rather than being dropped. Name shards (27 of them, one per leading character) are the one structure that can grow unbounded with repo size; they are size-checked before write for the same reason. Splitting a shard across multiple points would change the on-disk layout and is deliberately not done here.
+
+When symbol-graph persistence fails, `buildCodeGraph` still returns and saves the file-import graph, but records the reason on `GraphBuildCompleted.symbolGraphError` (unwrapped via `describeQdrantError`, which digs the server's real explanation out of `err.data.status.error`). `codebase_graph_status` prints it, so a half-built graph is no longer reported as a clean success while `codebase_impact` silently answers "0 callers".
+
 #### Languages with first-class symbol extraction
 
 TypeScript / JavaScript / TSX, Python, Go, Rust, Java, Kotlin, Scala, C#, C, C++, Ruby, PHP, Swift, Bash. Dart, Lua, Svelte, Vue and unknown languages fall through to a regex fallback that still produces a `<module>` symbol plus best-effort function/class detection.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -107,6 +107,22 @@ export const MAX_FILE_BYTES = Math.round(
 export const MAX_GRAPH_FILE_BYTES = 1_000_000;
 
 /**
+ * Qdrant's default `service.max_request_size_mb` (32 MiB), in bytes. A request
+ * body over this is rejected with HTTP 400 before it reaches the collection, so
+ * it is a hard ceiling on any single upsert, not a tuning knob we control: the
+ * server enforces it and self-hosted deployments may set it lower.
+ */
+export const QDRANT_MAX_REQUEST_BYTES = 33_554_432;
+
+/**
+ * Byte budget we pack a single upsert body up to. Deliberately below
+ * {@link QDRANT_MAX_REQUEST_BYTES} so the JSON envelope around the points
+ * (and any server-side accounting that differs slightly from ours) still fits
+ * under the hard ceiling.
+ */
+export const QDRANT_UPSERT_BUDGET_BYTES = 25_165_824;
+
+/**
  * Maximum average line length (in characters) before a file is treated as
  * minified/bundled and switched to character-based chunking. Minified files
  * have very long lines that would make line-based chunks exceed the embedding

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -251,6 +251,14 @@ async function doRebuildGraph(
           error: symbolGraphError,
         });
       }
+    } else {
+      // This build deliberately did not touch the symbol graph (the incremental
+      // watcher path passes skipSymbolGraph), so it has no standing to declare
+      // the symbol graph healthy. Carry any recorded failure forward, or a
+      // single edited file after a failed persist would overwrite the record
+      // with a clean one and hide a still-broken graph. Only the branch above,
+      // an actual successful persist, clears it.
+      symbolGraphError = lastGraphBuildCompleted.get(resolvedPath)?.symbolGraphError;
     }
 
     lastGraphBuildCompleted.set(resolvedPath, {

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -19,7 +19,7 @@ import { computeUnresolvedPct, resolveCallSites } from "./graph-symbol-resolutio
 import { extractSymbolsAndCalls, rawCallsToUnresolvedEdges } from "./graph-symbols.js";
 import { createIgnoreFilter, shouldIgnore } from "./ignore.js";
 import { logger } from "./logger.js";
-import { deleteGraphData, getGraphMetadata, loadGraphData, saveGraphData } from "./qdrant.js";
+import { deleteGraphData, describeQdrantError, getGraphMetadata, loadGraphData, saveGraphData } from "./qdrant.js";
 import {
   dropSymbolGraphCache,
   SymbolGraphCache,
@@ -81,6 +81,13 @@ export interface GraphBuildCompleted {
   nodesCreated: number;
   edgesCreated: number;
   error?: string;
+  /**
+   * Set when the file-import graph was built and saved but the symbol graph
+   * could not be persisted. That half-failure used to be logged and otherwise
+   * dropped, so the build reported success while `codebase_impact` silently had
+   * nothing to answer with; recording it here is what lets status say so.
+   */
+  symbolGraphError?: string;
 }
 
 /** Track which projects currently have a graph build in flight */
@@ -224,6 +231,7 @@ async function doRebuildGraph(
 
     // Build & persist symbol graph (resolution + sharded persistence) — unless
     // the caller asked to skip it (Phase F watcher path).
+    let symbolGraphError: string | undefined;
     if (!opts.skipSymbolGraph) {
       try {
         progress.phase = "resolving symbols";
@@ -232,9 +240,15 @@ async function doRebuildGraph(
         progress.phase = "persisting symbols";
         await persistSymbolGraph(projectId, resolvedPath, built.symbolsByFile, built.outgoingCallsByFile);
       } catch (err) {
-        logger.warn("Symbol graph build failed (file-import graph saved)", {
+        // Keep returning the file-import graph: it is built and saved, and the
+        // caller asked for it. But record WHY the symbol half is missing, with
+        // the server's own reason (a bare "Bad Request" names nothing), so the
+        // build is no longer reported as an unqualified success while
+        // codebase_impact quietly has no data.
+        symbolGraphError = describeQdrantError(err);
+        logger.error("Symbol graph build failed (file-import graph saved)", {
           projectPath: resolvedPath,
-          error: err instanceof Error ? err.message : String(err),
+          error: symbolGraphError,
         });
       }
     }
@@ -246,6 +260,7 @@ async function doRebuildGraph(
       filesSkipped: progress.filesSkipped,
       nodesCreated: graph.nodes.length,
       edgesCreated: graph.edges.length,
+      symbolGraphError,
     });
 
     return graph;

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -283,6 +283,13 @@ async function doRebuildGraph(
       nodesCreated: 0,
       edgesCreated: 0,
       error: message,
+      // A build that died before (or during) the symbol-graph phase did not fix
+      // it either, so preserve any failure the last build recorded. Reading it
+      // back out of the map is deliberate: this catch is outside the scope of
+      // the try's symbolGraphError, and the get resolves before the set.
+      // Without this a transient outage would wipe the record, and the next
+      // incremental build would carry the blank forward as "healthy".
+      symbolGraphError: lastGraphBuildCompleted.get(resolvedPath)?.symbolGraphError,
     });
     throw err;
   } finally {

--- a/src/services/qdrant.ts
+++ b/src/services/qdrant.ts
@@ -36,6 +36,32 @@ async function withRetry<T>(
 }
 
 /**
+ * Render a Qdrant client error including the reason the server actually gave.
+ *
+ * `@qdrant/js-client-rest` builds an `ApiError` whose `message` is only the HTTP
+ * status text — a 400 reads as the bare, useless "Bad Request" — while the
+ * server's explanation ("JSON payload (N bytes) is larger than allowed …") sits
+ * in `err.data.status.error`. Logging `err.message` alone therefore throws away
+ * the one part a user can act on, so every symbol-graph failure looked
+ * identical. Appends that reason when present, and looks through a `cause`
+ * chain so an error already wrapped by {@link wrapQdrantError} still resolves.
+ */
+export function describeQdrantError(err: unknown): string {
+  const base = err instanceof Error ? err.message : String(err);
+  // Walk the cause chain (bounded — these are never deep) looking for the
+  // client's `data` envelope, which may sit on the error or on its cause.
+  let current: unknown = err;
+  for (let depth = 0; depth < 5 && current; depth++) {
+    const reason = (current as { data?: { status?: { error?: unknown } } })?.data?.status?.error;
+    if (typeof reason === "string" && reason.length > 0) {
+      return base.includes(reason) ? base : `${base}: ${reason}`;
+    }
+    current = (current as { cause?: unknown })?.cause;
+  }
+  return base;
+}
+
+/**
  * Wrap a Qdrant client error with operation context so callers further up the
  * stack (and ultimately the MCP response) get a useful message instead of a
  * bare "Internal Server Error". Preserves the original error via `cause` and

--- a/src/services/symbol-graph-store.ts
+++ b/src/services/symbol-graph-store.ts
@@ -161,6 +161,11 @@ async function upsertWithinBudget(
     const point = points[i];
     const bytes = pointBytes(point);
     if (bytes > QDRANT_MAX_REQUEST_BYTES) {
+      // Deliberately abandon the queued batch rather than flushing it first.
+      // This throw aborts persistSymbolGraph, so the run's metadata is never
+      // written and the symbol graph stays unusable until a later build
+      // rewrites every payload anyway. Flushing here would add points nothing
+      // will read, to a collection already known to be incomplete.
       throw new SymbolGraphPointTooLargeError(describe(i), bytes);
     }
     // Start a new request when this point would push the body over budget, or

--- a/src/services/symbol-graph-store.ts
+++ b/src/services/symbol-graph-store.ts
@@ -20,7 +20,11 @@ import {
   symgraphIndexCollectionName,
   symgraphMetaCollectionName,
 } from "../config.js";
-import { SYMBOL_REVERSE_SHARDS } from "../constants.js";
+import {
+  QDRANT_MAX_REQUEST_BYTES,
+  QDRANT_UPSERT_BUDGET_BYTES,
+  SYMBOL_REVERSE_SHARDS,
+} from "../constants.js";
 import type {
   SymbolGraphFilePayload,
   SymbolGraphMeta,
@@ -78,6 +82,101 @@ function nameShardPointId(projectId: string, shardKey: string): string {
 function revShardPointId(projectId: string, bucketHex: string): string {
   return uuidFromString(`${projectId}::revidx::${bucketHex}`);
 }
+
+// ── Upsert sizing ────────────────────────────────────────────────────────
+
+/** A Qdrant point as this module writes them (dummy `[0]` vector throughout). */
+interface SymgraphPoint {
+  id: string;
+  vector: number[];
+  payload: Record<string, unknown>;
+}
+
+/**
+ * A single point that cannot be written at all because it alone exceeds the
+ * server's request ceiling. Thrown rather than skipped: dropping it would leave
+ * the symbol graph silently missing a file's symbols, which is the failure mode
+ * this whole area exists to avoid. The message names the offending item and the
+ * knob that raises the ceiling.
+ */
+export class SymbolGraphPointTooLargeError extends Error {
+  constructor(
+    readonly what: string,
+    readonly bytes: number,
+    readonly limit: number = QDRANT_MAX_REQUEST_BYTES,
+  ) {
+    super(
+      `${what} serializes to ${bytes} bytes, over Qdrant's ${limit}-byte request limit. ` +
+        "Raise service.max_request_size_mb on the Qdrant server to accept it.",
+    );
+    this.name = "SymbolGraphPointTooLargeError";
+  }
+}
+
+/** Serialized size of a point, matching what the client will send for it. */
+function pointBytes(point: SymgraphPoint): number {
+  return Buffer.byteLength(JSON.stringify(point), "utf-8");
+}
+
+/**
+ * Guard a single-point upsert: a point over the hard ceiling can never be
+ * written, so fail with a message naming it instead of letting Qdrant answer
+ * with a bare "Bad Request" that says nothing about which shard was at fault.
+ */
+function assertPointFits(point: SymgraphPoint, what: string): void {
+  const bytes = pointBytes(point);
+  if (bytes > QDRANT_MAX_REQUEST_BYTES) {
+    throw new SymbolGraphPointTooLargeError(what, bytes);
+  }
+}
+
+/**
+ * Upsert points in requests bounded by BOTH a point count and a byte budget.
+ *
+ * The count cap alone (what this module used to do) is the bug behind #89: a
+ * fixed 50 points per request says nothing about how big those points are, and
+ * large source files produce multi-MB payload points, so a handful of them in
+ * one request pushes the body past Qdrant's 32 MiB ceiling and the whole batch
+ * is rejected with HTTP 400. Packing by bytes keeps every request under the
+ * ceiling regardless of how large individual files are; the count cap is kept
+ * so ordinary repos still batch exactly as before.
+ */
+async function upsertWithinBudget(
+  collName: string,
+  points: SymgraphPoint[],
+  describe: (index: number) => string,
+): Promise<void> {
+  const qdrant = getClient();
+  let batch: SymgraphPoint[] = [];
+  let batchBytes = 0;
+
+  const flush = async (): Promise<void> => {
+    if (batch.length === 0) return;
+    await qdrant.upsert(collName, { points: batch });
+    batch = [];
+    batchBytes = 0;
+  };
+
+  for (let i = 0; i < points.length; i++) {
+    const point = points[i];
+    const bytes = pointBytes(point);
+    if (bytes > QDRANT_MAX_REQUEST_BYTES) {
+      throw new SymbolGraphPointTooLargeError(describe(i), bytes);
+    }
+    // Start a new request when this point would push the body over budget, or
+    // when the count cap is reached. A point larger than the budget but under
+    // the ceiling ends up in a request of its own, which is what we want.
+    if (batch.length > 0 && (batchBytes + bytes > QDRANT_UPSERT_BUDGET_BYTES || batch.length >= UPSERT_MAX_POINTS)) {
+      await flush();
+    }
+    batch.push(point);
+    batchBytes += bytes;
+  }
+  await flush();
+}
+
+/** Point-count cap per upsert. Unchanged from before the byte budget existed. */
+const UPSERT_MAX_POINTS = 50;
 
 // ── Collection lifecycle ─────────────────────────────────────────────────
 
@@ -159,18 +258,21 @@ export async function saveFilePayload(
   const collName = symgraphFileCollectionName(projectId);
   await ensureCollection(collName);
   const qdrant = getClient();
-  await qdrant.upsert(collName, {
-    points: [
-      {
-        id: filePointId(projectId, payload.file),
-        vector: [0],
-        payload: { filePayload: payload },
-      },
-    ],
-  });
+  const point: SymgraphPoint = {
+    id: filePointId(projectId, payload.file),
+    vector: [0],
+    payload: { filePayload: payload },
+  };
+  assertPointFits(point, `symbol payload for ${payload.file}`);
+  await qdrant.upsert(collName, { points: [point] });
 }
 
-/** Bulk upsert per-file payloads. Caller is expected to batch sensibly. */
+/**
+ * Bulk upsert per-file payloads, in requests bounded by size as well as count.
+ *
+ * Point ids and payload shape are unchanged, so this writes exactly the same
+ * data as before; only how it is split across HTTP requests differs.
+ */
 export async function saveFilePayloads(
   projectId: string,
   payloads: SymbolGraphFilePayload[],
@@ -178,19 +280,12 @@ export async function saveFilePayloads(
   if (payloads.length === 0) return;
   const collName = symgraphFileCollectionName(projectId);
   await ensureCollection(collName);
-  const qdrant = getClient();
-  // Chunk to avoid massive single requests
-  const CHUNK = 50;
-  for (let i = 0; i < payloads.length; i += CHUNK) {
-    const slice = payloads.slice(i, i + CHUNK);
-    await qdrant.upsert(collName, {
-      points: slice.map((p) => ({
-        id: filePointId(projectId, p.file),
-        vector: [0],
-        payload: { filePayload: p },
-      })),
-    });
-  }
+  const points: SymgraphPoint[] = payloads.map((p) => ({
+    id: filePointId(projectId, p.file),
+    vector: [0],
+    payload: { filePayload: p },
+  }));
+  await upsertWithinBudget(collName, points, (i) => `symbol payload for ${payloads[i].file}`);
 }
 
 export async function loadFilePayload(
@@ -247,15 +342,17 @@ export async function saveNameShard(
   const collName = symgraphIndexCollectionName(projectId);
   await ensureCollection(collName);
   const qdrant = getClient();
-  await qdrant.upsert(collName, {
-    points: [
-      {
-        id: nameShardPointId(projectId, shardKey),
-        vector: [0],
-        payload: { kind: "name", shard: shardKey, nameToSymbols },
-      },
-    ],
-  });
+  const point: SymgraphPoint = {
+    id: nameShardPointId(projectId, shardKey),
+    vector: [0],
+    payload: { kind: "name", shard: shardKey, nameToSymbols },
+  };
+  // A name shard holds every symbol whose name starts with one character, so on
+  // a large enough repo one shard can outgrow the request ceiling on its own.
+  // Splitting it would change the on-disk layout; naming it in the error keeps
+  // the failure honest and actionable without that.
+  assertPointFits(point, `name index shard '${shardKey}'`);
+  await qdrant.upsert(collName, { points: [point] });
 }
 
 export async function loadNameShard(
@@ -293,15 +390,13 @@ export async function saveReverseShard(
   await ensureCollection(collName);
   const qdrant = getClient();
   const bucketHex = reverseShardHex(bucket);
-  await qdrant.upsert(collName, {
-    points: [
-      {
-        id: revShardPointId(projectId, bucketHex),
-        vector: [0],
-        payload: { kind: "reverse", bucket, reverseEdges },
-      },
-    ],
-  });
+  const point: SymgraphPoint = {
+    id: revShardPointId(projectId, bucketHex),
+    vector: [0],
+    payload: { kind: "reverse", bucket, reverseEdges },
+  };
+  assertPointFits(point, `reverse-call index shard ${bucketHex}`);
+  await qdrant.upsert(collName, { points: [point] });
 }
 
 export async function loadReverseShard(

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -19,7 +19,37 @@ import { logger } from "../services/logger.js";
 import { getSymbolGraphCache } from "../services/symbol-graph-cache.js";
 import { ensureWatcherStarted } from "../services/watcher.js";
 
+/**
+ * Tools that answer purely from the persisted symbol graph. If the last build
+ * could not persist it, they read whatever cache survived, so their answers may
+ * be stale or absent with nothing on screen to say why — the "0 callers, no
+ * explanation" report behind #89. They get the failure prepended.
+ */
+const SYMBOL_GRAPH_TOOLS = new Set([
+  "codebase_impact",
+  "codebase_flow",
+  "codebase_symbol",
+  "codebase_symbols",
+]);
+
 export async function handleGraphTool(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const result = await dispatchGraphTool(name, args);
+  if (!SYMBOL_GRAPH_TOOLS.has(name)) return result;
+  const resolved = path.resolve((args.projectPath as string) || process.cwd());
+  const symbolGraphError = getLastGraphBuildCompleted(resolved)?.symbolGraphError;
+  if (!symbolGraphError) return result;
+  return [
+    `WARNING: the last graph build could not persist the symbol graph: ${symbolGraphError}`,
+    "Results below may be stale or incomplete until a rebuild succeeds.",
+    "",
+    result,
+  ].join("\n");
+}
+
+async function dispatchGraphTool(
   name: string,
   args: Record<string, unknown>,
 ): Promise<string> {

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -314,6 +314,15 @@ export async function handleGraphTool(
         if (lastBuild.filesSkipped) {
           lines.push(`Files skipped: ${lastBuild.filesSkipped}`);
         }
+        if (lastBuild.symbolGraphError) {
+          // The file-import graph above is real; the symbol half is not. Say so
+          // here rather than letting codebase_impact answer "0 callers" as if
+          // that were a finding.
+          lines.push(
+            `Symbol graph FAILED to persist: ${lastBuild.symbolGraphError}`,
+            "  Symbol-level tools (codebase_impact, codebase_flow, codebase_symbol) will be incomplete or empty until a rebuild succeeds.",
+          );
+        }
       }
 
       if (graphInfo.symbol) {

--- a/tests/unit/graph-symbol-error-record.test.ts
+++ b/tests/unit/graph-symbol-error-record.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+//
+// Issue #89: when symbol-graph persistence fails, the build must record WHY
+// instead of reporting an unqualified success (which left codebase_impact
+// answering "0 callers" with no explanation). The subtle half is that the
+// incremental watcher path calls rebuildGraph with skipSymbolGraph, which does
+// not touch the symbol graph at all and therefore must not erase a failure
+// recorded by the last build that did.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Persisting the FILE graph must succeed; only the SYMBOL graph fails.
+vi.mock("../../src/services/qdrant.js", () => ({
+  saveGraphData: vi.fn(async () => undefined),
+  loadGraphData: vi.fn(async () => null),
+  getGraphMetadata: vi.fn(async () => null),
+  deleteGraphData: vi.fn(async () => undefined),
+  describeQdrantError: (err: unknown) => {
+    const base = err instanceof Error ? err.message : String(err);
+    const reason = (err as { data?: { status?: { error?: unknown } } })?.data?.status?.error;
+    return typeof reason === "string" ? `${base}: ${reason}` : base;
+  },
+}));
+
+const symbolPersistFails = { value: true };
+
+vi.mock("../../src/services/symbol-graph-store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/services/symbol-graph-store.js")>();
+  return {
+    ...actual,
+    ensureSymbolGraphCollections: vi.fn(async () => undefined),
+    saveSymbolGraphMeta: vi.fn(async () => undefined),
+    saveNameShard: vi.fn(async () => undefined),
+    saveReverseShard: vi.fn(async () => undefined),
+    deleteSymbolGraphData: vi.fn(async () => undefined),
+    saveFilePayloads: vi.fn(async () => {
+      if (!symbolPersistFails.value) return undefined;
+      // Shaped like the real @qdrant/js-client-rest 400: message is only the
+      // HTTP status text, the reason lives in `data`.
+      throw Object.assign(new Error("Bad Request"), {
+        status: 400,
+        data: { status: { error: "JSON payload (36001578 bytes) is larger than allowed (limit: 33554432 bytes)" } },
+      });
+    }),
+  };
+});
+
+import {
+  ensureDynamicLanguages,
+  getLastGraphBuildCompleted,
+  invalidateGraphCache,
+  rebuildGraph,
+} from "../../src/services/code-graph.js";
+
+describe("symbol-graph failure is recorded and not silently cleared (#89)", () => {
+  let root: string;
+
+  beforeEach(() => {
+    ensureDynamicLanguages();
+    symbolPersistFails.value = true;
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "symerr-"));
+    fs.mkdirSync(path.join(root, "src"), { recursive: true });
+    fs.writeFileSync(path.join(root, "src", "a.ts"), "export function a() { return 1; }\n");
+    fs.writeFileSync(path.join(root, "src", "b.ts"), "import { a } from './a.js';\nexport const b = a();\n");
+    invalidateGraphCache(root);
+  });
+
+  it("records the server's real reason, not the bare HTTP status text", async () => {
+    await rebuildGraph(root);
+    const last = getLastGraphBuildCompleted(root);
+
+    expect(last?.symbolGraphError).toBeDefined();
+    // "Bad Request" alone is what used to be logged and is useless on its own.
+    expect(last?.symbolGraphError).toContain("larger than allowed");
+    expect(last?.symbolGraphError).toContain("33554432");
+    // The file-import graph itself still succeeded and is reported as built.
+    expect(last?.nodesCreated).toBeGreaterThan(0);
+    expect(last?.error).toBeUndefined();
+  });
+
+  it("keeps the failure recorded across an incremental (skipSymbolGraph) rebuild", async () => {
+    await rebuildGraph(root);
+    expect(getLastGraphBuildCompleted(root)?.symbolGraphError).toBeDefined();
+
+    // The watcher path: indexer.ts calls rebuildGraph(path, { skipSymbolGraph:
+    // useIncremental }) on ordinary file edits. It never attempts the symbol
+    // graph, so it must not report it healthy.
+    invalidateGraphCache(root);
+    await rebuildGraph(root, { skipSymbolGraph: true });
+
+    const last = getLastGraphBuildCompleted(root);
+    expect(last?.symbolGraphError).toBeDefined();
+    expect(last?.symbolGraphError).toContain("larger than allowed");
+  });
+
+  it("clears the failure only when a real symbol-graph persist succeeds", async () => {
+    await rebuildGraph(root);
+    expect(getLastGraphBuildCompleted(root)?.symbolGraphError).toBeDefined();
+
+    symbolPersistFails.value = false;
+    invalidateGraphCache(root);
+    await rebuildGraph(root);
+
+    expect(getLastGraphBuildCompleted(root)?.symbolGraphError).toBeUndefined();
+  });
+});

--- a/tests/unit/graph-symbol-error-record.test.ts
+++ b/tests/unit/graph-symbol-error-record.test.ts
@@ -97,6 +97,24 @@ describe("symbol-graph failure is recorded and not silently cleared (#89)", () =
     expect(last?.symbolGraphError).toContain("larger than allowed");
   });
 
+  it("keeps the failure recorded when a later build dies before the symbol phase", async () => {
+    await rebuildGraph(root);
+    expect(getLastGraphBuildCompleted(root)?.symbolGraphError).toBeDefined();
+
+    // A total build failure (here: the file-graph save blows up, as a transient
+    // Qdrant outage would) must not erase the symbol-graph failure, or the next
+    // incremental build carries the blank forward and reports it healthy.
+    const qdrant = await import("../../src/services/qdrant.js");
+    const saveSpy = vi.spyOn(qdrant, "saveGraphData").mockRejectedValueOnce(new Error("connect ECONNREFUSED"));
+    invalidateGraphCache(root);
+    await expect(rebuildGraph(root)).rejects.toThrow("ECONNREFUSED");
+    saveSpy.mockRestore();
+
+    const last = getLastGraphBuildCompleted(root);
+    expect(last?.error).toContain("ECONNREFUSED");
+    expect(last?.symbolGraphError).toContain("larger than allowed");
+  });
+
   it("clears the failure only when a real symbol-graph persist succeeds", async () => {
     await rebuildGraph(root);
     expect(getLastGraphBuildCompleted(root)?.symbolGraphError).toBeDefined();

--- a/tests/unit/qdrant-error-wrapping.test.ts
+++ b/tests/unit/qdrant-error-wrapping.test.ts
@@ -131,3 +131,47 @@ describe("qdrant error wrapping (issue #55)", () => {
     });
   });
 });
+
+// ── describeQdrantError (#89) ────────────────────────────────────────────
+//
+// A Qdrant 400 arrives as an ApiError whose `message` is only the HTTP status
+// text ("Bad Request"); the server's actual explanation lives in
+// `err.data.status.error`. Logging just `.message` is what made every failed
+// symbol-graph persist look identical and unactionable.
+
+describe("describeQdrantError", () => {
+  it("appends the server's reason from err.data.status.error", async () => {
+    const { describeQdrantError } = await import("../../src/services/qdrant.js");
+    const apiError = Object.assign(new Error("Bad Request"), {
+      status: 400,
+      data: { status: { error: "JSON payload (35651584 bytes) is larger than allowed (limit: 33554432 bytes)" } },
+    });
+    const described = describeQdrantError(apiError);
+    expect(described).toContain("Bad Request");
+    expect(described).toContain("larger than allowed");
+    expect(described).toContain("33554432");
+  });
+
+  it("finds the reason through a wrapped error's cause chain", async () => {
+    const { describeQdrantError } = await import("../../src/services/qdrant.js");
+    const inner = Object.assign(new Error("Bad Request"), {
+      data: { status: { error: "payload too large" } },
+    });
+    const outer = Object.assign(new Error("saveFilePayloads failed [status 400]: Bad Request"), { cause: inner });
+    expect(describeQdrantError(outer)).toContain("payload too large");
+  });
+
+  it("does not duplicate the reason when it is already in the message", async () => {
+    const { describeQdrantError } = await import("../../src/services/qdrant.js");
+    const err = Object.assign(new Error("failed: payload too large"), {
+      data: { status: { error: "payload too large" } },
+    });
+    expect(describeQdrantError(err)).toBe("failed: payload too large");
+  });
+
+  it("falls back to the plain message when there is no structured reason", async () => {
+    const { describeQdrantError } = await import("../../src/services/qdrant.js");
+    expect(describeQdrantError(new Error("Bad Request"))).toBe("Bad Request");
+    expect(describeQdrantError("not an error")).toBe("not an error");
+  });
+});

--- a/tests/unit/symbol-graph-upsert-budget.test.ts
+++ b/tests/unit/symbol-graph-upsert-budget.test.ts
@@ -33,6 +33,7 @@ import {
   SymbolGraphPointTooLargeError,
   saveFilePayloads,
   saveNameShard,
+  saveReverseShard,
 } from "../../src/services/symbol-graph-store.js";
 
 /** Build a payload whose serialized size is ~`targetBytes`. */
@@ -118,6 +119,15 @@ describe("symbol-graph-store: byte-aware upsert batching (#89)", () => {
     };
     await expect(saveNameShard("p", "b", nameToSymbols)).rejects.toThrow(SymbolGraphPointTooLargeError);
     await expect(saveNameShard("p", "b", nameToSymbols)).rejects.toThrow(/name index shard 'b'/);
+    expect(upserts).toHaveLength(0);
+  });
+
+  it("names the offending shard when a reverse-call shard cannot fit", async () => {
+    // Same guard as the name shard above; reverse shards reach it by a separate
+    // call path, so it is pinned separately.
+    const reverseEdges = { "src/Callee.java": ["x".repeat(QDRANT_MAX_REQUEST_BYTES + 1024)] };
+    await expect(saveReverseShard("p", 7, reverseEdges)).rejects.toThrow(SymbolGraphPointTooLargeError);
+    await expect(saveReverseShard("p", 7, reverseEdges)).rejects.toThrow(/reverse-call index shard 07/);
     expect(upserts).toHaveLength(0);
   });
 

--- a/tests/unit/symbol-graph-upsert-budget.test.ts
+++ b/tests/unit/symbol-graph-upsert-budget.test.ts
@@ -13,7 +13,7 @@ interface CapturedUpsert {
 }
 const upserts: CapturedUpsert[] = [];
 
-const mockUpsert = vi.fn(async (collName: string, body: CapturedUpsert["points"] extends never ? never : { points: CapturedUpsert["points"] }) => {
+const mockUpsert = vi.fn(async (collName: string, body: { points: CapturedUpsert["points"] }) => {
   upserts.push({ collName, points: body.points });
 });
 

--- a/tests/unit/symbol-graph-upsert-budget.test.ts
+++ b/tests/unit/symbol-graph-upsert-budget.test.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QDRANT_MAX_REQUEST_BYTES, QDRANT_UPSERT_BUDGET_BYTES } from "../../src/constants.js";
+import type { SymbolGraphFilePayload, SymbolNode } from "../../src/types.js";
+
+// ── qdrant.js mock: capture every upsert body ───────────────────────────
+
+interface CapturedUpsert {
+  collName: string;
+  points: Array<{ id: string; vector: number[]; payload: Record<string, unknown> }>;
+}
+const upserts: CapturedUpsert[] = [];
+
+const mockUpsert = vi.fn(async (collName: string, body: CapturedUpsert["points"] extends never ? never : { points: CapturedUpsert["points"] }) => {
+  upserts.push({ collName, points: body.points });
+});
+
+vi.mock("../../src/services/qdrant.js", () => ({
+  getClient: () => ({
+    upsert: (collName: string, body: { points: CapturedUpsert["points"] }) => mockUpsert(collName, body),
+    // ensureCollection() consults this; report the collection as already present
+    // so the tests exercise the upsert path only.
+    getCollections: async () => ({ collections: [{ name: "p_symgraph_file" }, { name: "p_symgraph_index" }] }),
+    createCollection: async () => undefined,
+  }),
+  describeQdrantError: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+}));
+
+import {
+  resetSymbolGraphCollectionCache,
+  SymbolGraphPointTooLargeError,
+  saveFilePayloads,
+  saveNameShard,
+} from "../../src/services/symbol-graph-store.js";
+
+/** Build a payload whose serialized size is ~`targetBytes`. */
+function payloadOfSize(file: string, targetBytes: number): SymbolGraphFilePayload {
+  // One long symbol name is the cheapest way to control serialized size.
+  const symbol: SymbolNode = {
+    id: `${file}::big`,
+    name: "x".repeat(Math.max(1, targetBytes)),
+    kind: "function",
+    file,
+    language: "java",
+    startLine: 1,
+    endLine: 2,
+  } as SymbolNode;
+  return { file, language: "java", contentHash: "h", symbols: [symbol], outgoingCalls: [] };
+}
+
+/** Serialized size of one upsert body, the quantity Qdrant limits. */
+function bodyBytes(u: CapturedUpsert): number {
+  return Buffer.byteLength(JSON.stringify({ points: u.points }), "utf-8");
+}
+
+describe("symbol-graph-store: byte-aware upsert batching (#89)", () => {
+  beforeEach(() => {
+    upserts.length = 0;
+    mockUpsert.mockClear();
+    resetSymbolGraphCollectionCache();
+  });
+
+  it("keeps the historic 50-points-per-request batching for ordinary small files", async () => {
+    // Regression guard: the byte budget must not change how normal repos batch.
+    const payloads = Array.from({ length: 120 }, (_, i) => payloadOfSize(`src/f${i}.java`, 100));
+    await saveFilePayloads("p", payloads);
+
+    expect(upserts.map((u) => u.points.length)).toEqual([50, 50, 20]);
+    expect(upserts.every((u) => bodyBytes(u) < QDRANT_UPSERT_BUDGET_BYTES)).toBe(true);
+  });
+
+  it("splits by BYTES when large files would otherwise exceed the request ceiling", async () => {
+    // Six ~6 MB payloads: the old count-based batching put all six (~36 MB) in
+    // one request, which is exactly the >32 MiB body Qdrant rejected with 400.
+    const payloads = Array.from({ length: 6 }, (_, i) => payloadOfSize(`src/Big${i}.java`, 6_000_000));
+    await saveFilePayloads("p", payloads);
+
+    expect(upserts.length).toBeGreaterThan(1); // would have been exactly 1 before
+    for (const u of upserts) {
+      expect(bodyBytes(u)).toBeLessThanOrEqual(QDRANT_MAX_REQUEST_BYTES);
+    }
+    // Nothing is dropped: every file is still written exactly once.
+    const written = upserts.flatMap((u) => u.points.map((p) => p.id));
+    expect(new Set(written).size).toBe(6);
+  });
+
+  it("gives an oversized-but-writable point a request of its own", async () => {
+    const payloads = [
+      payloadOfSize("src/Small.java", 100),
+      payloadOfSize("src/Huge.java", QDRANT_UPSERT_BUDGET_BYTES + 1_000_000),
+      payloadOfSize("src/Small2.java", 100),
+    ];
+    await saveFilePayloads("p", payloads);
+
+    const huge = upserts.find((u) => u.points.some((p) => JSON.stringify(p).length > QDRANT_UPSERT_BUDGET_BYTES));
+    expect(huge).toBeDefined();
+    expect(huge?.points).toHaveLength(1);
+    for (const u of upserts) expect(bodyBytes(u)).toBeLessThanOrEqual(QDRANT_MAX_REQUEST_BYTES);
+  });
+
+  it("throws a named error instead of a bare 400 when one point cannot ever fit", async () => {
+    const payloads = [payloadOfSize("src/Impossible.java", QDRANT_MAX_REQUEST_BYTES + 1024)];
+    await expect(saveFilePayloads("p", payloads)).rejects.toThrow(SymbolGraphPointTooLargeError);
+    await expect(saveFilePayloads("p", payloads)).rejects.toThrow(/src\/Impossible\.java/);
+    await expect(saveFilePayloads("p", payloads)).rejects.toThrow(/max_request_size_mb/);
+    // It must fail loudly rather than silently skipping the file.
+    expect(upserts).toHaveLength(0);
+  });
+
+  it("names the offending shard when a name-index shard cannot fit", async () => {
+    const nameToSymbols = {
+      big: Array.from({ length: 1 }, () => ({
+        file: "x".repeat(QDRANT_MAX_REQUEST_BYTES + 1024),
+        id: "s",
+      })),
+    };
+    await expect(saveNameShard("p", "b", nameToSymbols)).rejects.toThrow(SymbolGraphPointTooLargeError);
+    await expect(saveNameShard("p", "b", nameToSymbols)).rejects.toThrow(/name index shard 'b'/);
+    expect(upserts).toHaveLength(0);
+  });
+
+  it("writes an ordinary shard unchanged (single point, same payload shape)", async () => {
+    await saveNameShard("p", "a", { alpha: [{ file: "src/A.java", id: "src/A.java::alpha" }] });
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0].points).toHaveLength(1);
+    expect(upserts[0].points[0].payload).toEqual({
+      kind: "name",
+      shard: "a",
+      nameToSymbols: { alpha: [{ file: "src/A.java", id: "src/A.java::alpha" }] },
+    });
+  });
+});


### PR DESCRIPTION
Fixes #89.

## The bug

On repos with large source files, `codebase_graph_build` reported success while the symbol graph silently held nothing, so `codebase_impact` answered "0 callers" for every symbol. Three separate defects stacked up.

**1. Root cause: upserts were batched by count, not size.** `saveFilePayloads` sent a fixed 50 points per Qdrant request regardless of how big they were. A per-file payload scales with the source file (a ~900 KB Java file yields a ~6 MB point), so a few large files in one batch pushed the body past Qdrant's `service.max_request_size_mb` ceiling (32 MiB by default) and the server rejected the entire batch.

Reproduced against real Qdrant v1.17.0, six ~6 MB payloads in one request:

```
Bad Request | Payload error: JSON payload (36001578 bytes) is larger than allowed (limit: 33554432 bytes)
```

**2. The real reason was thrown away.** The Qdrant client puts the server's explanation in `err.data.status.error` while its `message` is only the HTTP status text, so the log said `Bad Request` and nothing else.

**3. The failure was recorded as a success.** The catch logged, did not rethrow, and the build then wrote an unqualified completion record. The persist also writes payloads, then shards, then metadata last with no rollback, so a mid-way failure leaves committed points but no metadata, which is what makes impact return 0 rather than error.

## The fix

- **Byte-aware packing.** Requests are now packed up to a byte budget (24 MiB, headroom under the 32 MiB ceiling) **as well as** the existing 50-point cap. Ordinary repos batch exactly as before; large files simply take more requests.
- **Loud failure instead of an anonymous 400.** A point that cannot fit even alone throws `SymbolGraphPointTooLargeError` naming the file or shard and the server knob that raises the limit, rather than being dropped. Name shards, the one structure that grows unbounded with repo size, are size-checked for the same reason.
- **Real reason surfaced.** `describeQdrantError` digs the server's explanation out of `err.data.status.error` (through a `cause` chain), the build records it on `GraphBuildCompleted.symbolGraphError`, and `codebase_graph_status` reports that symbol-level tools are incomplete until a rebuild succeeds.

## Backward compatibility (verified three ways)

1. **Stored data is byte-identical.** Point ids and payload shapes are untouched; only how points are split across HTTP requests changed. I wrote the same workload (120 files + a name shard + a reverse shard) on `main` and on this branch against a real Qdrant, dumped every persisted point with vectors and payloads, and diffed: **identical**. Nothing to migrate, existing graphs keep working.
2. **Ordinary batching is unchanged.** A regression test pins the historic 50/50/20 split for 120 small files.
3. **No API break.** `saveFilePayloads` keeps its signature; `symbolGraphError` is an optional additive field; the build still returns and saves the file-import graph when the symbol half fails, exactly as before.

## Deliberately not done

Splitting an oversized shard across multiple points would change the on-disk layout, so it is out of scope here; such a shard now fails with a named, actionable error instead. Happy to do it as a follow-up if you want it.

## Testing

- `npx tsc --noEmit` clean, `npm run lint` (biome) clean, `npm run build` succeeds
- Unit **983/983**, integration **167/167** (real Qdrant + Ollama)
- New unit coverage: byte packing, the oversized-point error, the ordinary-batching regression guard, and `describeQdrantError` (message/cause/no-duplicate/fallback)
- **Mutation-checked**: reverting the byte budget to count-only fails exactly the two tests that matter, so they genuinely guard the fix
- End-to-end against Qdrant v1.17.0: the old single request fails with the error above, the new path stores all 6 points
- CodeRabbit local review: **no findings**

> Note, unrelated to this PR: `npm audit` now reports 3 new advisories (`@hono/node-server` path traversal, `brace-expansion` DoS) that were published after the 1.9.1 lockfile refresh. They are present identically on `main`; this PR changes no dependencies. Worth a separate lockfile refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented whole-request failures during symbol-graph persistence by batching symbol upserts using a byte-budget (while preserving the legacy point-count cap).
  * Added clearer, targeted errors when an individual symbol point or name/reverse shard exceeds Qdrant limits.
  * Improved rebuild transparency: symbol-graph persistence failures now surface as warnings and in `codebase_graph_status`, including structured failure reasons.
* **Tests**
  * Added unit tests for byte-aware batching/splitting, oversized point/shard handling, and Qdrant error reason formatting.
* **Documentation**
  * Updated developer guidance for the new byte-budget behavior and half-built graph/persistence reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->