### PR TITLE
fix(indexer): never emit chunks with empty content

### DIFF
--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -360,13 +360,19 @@ function applyCharCap(chunks: FileChunk[]): FileChunk[] {
   // which reach chunkByLines and would otherwise yield a single blank chunk.
   // Safe to drop: chunk ids are sha256(relativePath + ":" + startLine), so
   // removing a chunk never renumbers any other.
-  chunks = chunks.filter((c) => c.content.trim().length > 0);
-  if (chunks.every((c) => c.content.length <= MAX_CHUNK_CHARS)) return chunks;
-  return chunks.map((c) =>
-    c.content.length > MAX_CHUNK_CHARS
-      ? { ...c, content: c.content.substring(0, MAX_CHUNK_CHARS) }
-      : c,
-  );
+  //
+  // ORDER MATTERS: cap first, then filter. Filtering first lets a chunk whose only
+  // non-whitespace content sits past MAX_CHUNK_CHARS pass the filter and then be
+  // truncated back into a blank chunk, so the invariant would not actually hold.
+  const capped =
+    chunks.every((c) => c.content.length <= MAX_CHUNK_CHARS)
+      ? chunks
+      : chunks.map((c) =>
+          c.content.length > MAX_CHUNK_CHARS
+            ? { ...c, content: c.content.substring(0, MAX_CHUNK_CHARS) }
+            : c,
+        );
+  return capped.filter((c) => c.content.trim().length > 0);
 }
 
 /**

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -353,6 +353,14 @@ function findAstBoundaries(source: string, lang: Lang | string): AstRegion[] {
  * defence; this cap ensures chunks are already within bounds before that.
  */
 function applyCharCap(chunks: FileChunk[]): FileChunk[] {
+  // Terminal invariant: never emit a chunk with no non-whitespace content.
+  // Four of the five `return` paths in chunkFileContent pass through here (the
+  // fifth returns []), so this is the one place that can guarantee the property
+  // for every chunking strategy — including zero-byte and whitespace-only files,
+  // which reach chunkByLines and would otherwise yield a single blank chunk.
+  // Safe to drop: chunk ids are sha256(relativePath + ":" + startLine), so
+  // removing a chunk never renumbers any other.
+  chunks = chunks.filter((c) => c.content.trim().length > 0);
   if (chunks.every((c) => c.content.length <= MAX_CHUNK_CHARS)) return chunks;
   return chunks.map((c) =>
     c.content.length > MAX_CHUNK_CHARS
@@ -506,7 +514,7 @@ function chunkByAstRegions(
   // Preamble: everything before the first declaration (imports, constants, comments)
   if (regions[0].startLine > 0) {
     const preambleLines = lines.slice(0, regions[0].startLine);
-    if (preambleLines.length > 0) {
+    if (preambleLines.some((line) => line.length > 0)) {
       chunks.push({
         id: chunkId(relativePath, 1),
         filePath,
@@ -592,7 +600,7 @@ function chunkByAstRegions(
   const lastEnd = regions[regions.length - 1].endLine;
   if (lastEnd < lines.length) {
     const epilogueLines = lines.slice(lastEnd);
-    if (epilogueLines.length > 0) {
+    if (epilogueLines.some((line) => line.length > 0)) {
       chunks.push({
         id: chunkId(relativePath, lastEnd + 1),
         filePath,

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -232,7 +232,7 @@ describe("indexer utilities", () => {
     // chunk embeds as a path-only document, BM25 length-normalisation floats it
     // to rank 1 — a blank top hit for an otherwise good query.
 
-    it("emits no blank chunk for a newline-terminated file (epilogue guard)", () => {
+    it("emits no blank chunk for a newline-terminated file", () => {
       // `lines.slice(lastEnd)` on a trailing "\n" yields [""], which is a
       // non-empty ARRAY of empty CONTENT. Guarding on array length is therefore
       // always true and emits content:"" at line N+1.
@@ -248,7 +248,7 @@ describe("indexer utilities", () => {
       expect(chunks.filter((c) => c.content.trim().length === 0)).toHaveLength(0);
     });
 
-    it("emits no blank chunk for a file whose first line is blank (preamble guard)", () => {
+    it("emits no blank chunk for a file whose first line is blank", () => {
       // Same tautology in the preamble branch: `lines.slice(0, startLine)` with
       // startLine > 0 is never an empty array, so a leading blank line emits
       // content:"" at 1-1.
@@ -270,6 +270,28 @@ describe("indexer utilities", () => {
       expect(chunkFileContent("/test/__init__.py", "__init__.py", "")).toHaveLength(0);
       expect(chunkFileContent("/test/blank.py", "blank.py", "\n\n\n")).toHaveLength(0);
       expect(chunkFileContent("/test/ws.txt", "ws.txt", "   \n\t\n  ")).toHaveLength(0);
+    });
+
+    it("does not let the character cap re-create a blank chunk", () => {
+      // applyCharCap must truncate BEFORE the blank filter. If it filters first, a
+      // chunk whose only non-whitespace content sits past MAX_CHUNK_CHARS passes the
+      // filter and is then truncated back into a blank chunk — so the invariant would
+      // hold at the filter and be violated by the time the chunk is returned.
+      // 99 lines x 23 spaces = 2376 chars of padding, real code only on line 100.
+      const padding = Array.from({ length: 99 }, () => " ".repeat(23)).join("\n");
+      const content = `${padding}\nrealCode();\n`;
+
+      const chunks = chunkFileContent("/test/padded.txt", "padded.txt", content);
+
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(chunks.filter((c) => c.content.trim().length === 0)).toHaveLength(0);
+    });
+
+    it("still truncates oversized chunks rather than dropping them", () => {
+      // Guards the other direction: cap-then-filter must not discard real content.
+      const chunks = chunkFileContent("/test/big.txt", "big.txt", "x".repeat(5000));
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(chunks[0].content.length).toBe(2000);
     });
 
     it("still chunks ordinary files normally", () => {

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -226,6 +226,59 @@ describe("indexer utilities", () => {
       }
     });
 
+    // ── empty-chunk invariant ──────────────────────────────────
+    //
+    // Three code paths could emit a chunk whose content is "". Because such a
+    // chunk embeds as a path-only document, BM25 length-normalisation floats it
+    // to rank 1 — a blank top hit for an otherwise good query.
+
+    it("emits no blank chunk for a newline-terminated file (epilogue guard)", () => {
+      // `lines.slice(lastEnd)` on a trailing "\n" yields [""], which is a
+      // non-empty ARRAY of empty CONTENT. Guarding on array length is therefore
+      // always true and emits content:"" at line N+1.
+      const functions = Array.from({ length: 40 }, (_, i) => {
+        const body = Array.from({ length: 3 }, (_, j) => `  const v${j} = ${i * j};`).join("\n");
+        return `export function fn${i}(): void {\n${body}\n}`;
+      });
+      const content = `${functions.join("\n\n")}\n`;
+
+      const chunks = chunkFileContent("/test/epilogue.ts", "epilogue.ts", content);
+
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(chunks.filter((c) => c.content.trim().length === 0)).toHaveLength(0);
+    });
+
+    it("emits no blank chunk for a file whose first line is blank (preamble guard)", () => {
+      // Same tautology in the preamble branch: `lines.slice(0, startLine)` with
+      // startLine > 0 is never an empty array, so a leading blank line emits
+      // content:"" at 1-1.
+      const functions = Array.from({ length: 40 }, (_, i) => {
+        const body = Array.from({ length: 3 }, (_, j) => `  const v${j} = ${i * j};`).join("\n");
+        return `export function fn${i}(): void {\n${body}\n}`;
+      });
+      const content = `\n${functions.join("\n\n")}\n`;
+
+      const chunks = chunkFileContent("/test/preamble.ts", "preamble.ts", content);
+
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(chunks.filter((c) => c.content.trim().length === 0)).toHaveLength(0);
+    });
+
+    it("emits no chunks at all for zero-byte and whitespace-only files", () => {
+      // These reach chunkByLines and would otherwise yield a single blank chunk.
+      // Real corpora contain them: Python package markers such as __init__.py.
+      expect(chunkFileContent("/test/__init__.py", "__init__.py", "")).toHaveLength(0);
+      expect(chunkFileContent("/test/blank.py", "blank.py", "\n\n\n")).toHaveLength(0);
+      expect(chunkFileContent("/test/ws.txt", "ws.txt", "   \n\t\n  ")).toHaveLength(0);
+    });
+
+    it("still chunks ordinary files normally", () => {
+      // Guards against an over-broad filter silently emptying the index.
+      const chunks = chunkFileContent("/test/ok.ts", "ok.ts", 'export const x = 1;\n');
+      expect(chunks.length).toBeGreaterThan(0);
+      expect(chunks[0].content).toContain("export const x = 1;");
+    });
+
     it("uses AST-aware chunking for Dart files (class and signature/body boundaries)", () => {
       // Two large Dart classes plus a top-level function, exceeding CHUNK_SIZE
       // lines. Dart splits a top-level function into sibling signature and


### PR DESCRIPTION
## Summary

`chunkFileContent` can emit chunks whose content is `""`. Because such a chunk embeds as a
path-only document, BM25 length-normalisation floats it to **rank 1** — so a good query returns a
blank top hit.

On a real four-repo corpus this was **1,371 of 25,065 chunks (5.5%)**, and it was invisible: the
chunks index and search cleanly, they just carry no text.

Three code paths produce them. Two are the same tautology — guarding on **array** length where
**content** length was meant:

```ts
// epilogue — lines.slice(lastEnd) on a trailing "\n" yields [""],
// a non-empty ARRAY of empty CONTENT, so this is always true
if (epilogueLines.length > 0) { … }        // → content: "" at line N+1

// preamble — lines.slice(0, startLine) with startLine > 0 is never empty
if (preambleLines.length > 0) { … }        // → content: "" at 1-1
```

The third is zero-byte and whitespace-only files (Python package markers like `__init__.py` are
the common real case), which reach `chunkByLines` and yield one blank chunk.

Minimal repro against `v1.9.2`:

```js
import { chunkFileContent } from "socraticode/dist/services/indexer.js";
import { ensureDynamicLanguages } from "socraticode/dist/services/code-graph.js";
await ensureDynamicLanguages();

const fns = Array.from({ length: 40 }, (_, i) =>
  `export function fn${i}(): void {\n  const v = ${i};\n}`).join("\n\n");

chunkFileContent("/t/a.ts", "a.ts", fns + "\n")          // epilogue  → 1 chunk with content ""
chunkFileContent("/t/b.ts", "b.ts", "\n" + fns + "\n")   // preamble  → 1 chunk with content ""
chunkFileContent("/t/__init__.py", "__init__.py", "")    // zero-byte → 1 chunk with content ""
```

## Changes

- Fix the epilogue guard to test content, not array length: `epilogueLines.some((line) => line.length > 0)`
- Fix the preamble guard the same way: `preambleLines.some((line) => line.length > 0)`
- Add a terminal invariant in `applyCharCap`: `chunks.filter((c) => c.content.trim().length > 0)`.
  Four of the five `return` paths in `chunkFileContent` pass through `applyCharCap` (the fifth
  returns `[]`), making it the one place that can guarantee the property for every chunking
  strategy — including `chunkByLines`, which the two guard fixes do not reach.
- Add four regression tests: one per site, plus one guarding against an over-broad filter.

I went with all three rather than only the two guards because fixing the guards alone still leaves
zero-byte files emitting blank chunks — the invariant would be "almost never empty", which is not
worth asserting. If you would prefer the guards alone without the `applyCharCap` change, that is an
easy trim; happy to resubmit.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test coverage improvement

## Testing

- [x] Unit tests pass (`npm run test:unit`) — 44 files, 992 tests
- [ ] Integration tests pass (`npm run test:integration`) — not run; requires Docker, and this
      change is confined to pure chunking logic with no I/O or Qdrant surface
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] New tests added for new/changed functionality
- [x] `npm run lint` (biome) clean — 100 files

The three new tests fail on `v1.9.2` and pass with the fix. The fourth passes both ways and exists
so an over-broad filter cannot silently empty the index:

```
× emits no blank chunk for a newline-terminated file (epilogue guard)
× emits no blank chunk for a file whose first line is blank (preamble guard)
× emits no chunks at all for zero-byte and whitespace-only files
  Tests  3 failed | 46 passed (49)     ← before
  Tests  49 passed (49)                ← after
```

### No re-index required

`chunkId` is `sha256(relativePath + ":" + startLine)` — position-derived, not sequential — so
dropping a chunk never renumbers another. Every surviving chunk keeps its exact id, which means an
existing index can be repaired with a filtered delete instead of a re-embed.

Measured by chunking four repos via `getIndexableFiles` under both builds, keyed **per repo**
(chunk ids are only unique within a collection — pooling repos produces false collisions):

| | pristine | fixed |
|---|---:|---:|
| chunks | 25,065 | 23,694 |
| removed | — | 1,371 (**all blank**) |
| added | — | **0** |
| contents changed | — | **0** |
| endLines changed | — | **0** |
| residual blank | — | **0** |

Per repo: 21,489→20,356 · 2,974→2,762 · 345→322 · 257→254. Cross-validated against a live Qdrant
instance — predicted post-fix counts of 2,762 / 322 / 254 match the actual point counts exactly for
the three collections that had been re-indexed.

### A variant I did not submit

There is a `lines.pop()` form that also corrects a genuine `endLine` off-by-one on small files. It
is arguably more correct, but measured **1,946 changed endLines, 466 changed chunk contents and 31
restructured files** on the same corpus — churn that only pays for itself alongside a re-index. I am
flagging it because it is the better fix if you are willing to take that cost, and submitting the
cheaper one silently would misrepresent the tradeoff. Happy to send it instead.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate
- [ ] I have updated documentation (README.md / DEVELOPER.md) if needed — no user-facing behaviour
      or configuration option changes, so nothing appeared to warrant an edit
- [ ] I have addressed all [CodeRabbit](https://coderabbit.ai) review comments — none yet
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

## Related issues

None that I could find — `gh issue list --state all` returns 32 issues for this repo, and none
mention empty chunks, blank results, or the epilogue/preamble guards. Filing as a fresh report
rather than linking an existing one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured generated chunks never include blank or whitespace-only content, including cases with trailing newlines and leading blank lines.
  * Prevented empty chunks from being produced during chunking and after character-level truncation.
  * Preserved chunking for large inputs by truncating when needed rather than dropping content.
* **Tests**
  * Added unit tests to enforce the “no empty chunks” invariant and cover truncation and chunking-order edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->