### PR TITLE
fix(graph): resolve shell source directives in the file graph

### DIFF
--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -332,6 +332,13 @@ function findGoModFiles(projectPath: string): string[] {
 /**
  * Resolve a module specifier to a relative file path within the project.
  * Returns null if the module is external (e.g., npm package, stdlib).
+ *
+ * `language` is a display label as produced by `getLanguageFromExtension`
+ * (e.g. "shell", "typescript") — that is what `buildCodeGraph` passes. "bash"
+ * has its own case below as a synonym for "shell". The capitalised `Lang`
+ * grammar names ("JavaScript", "TypeScript", "Tsx", "Html", "Css") match no
+ * case. Not every display label has one either, so a switch miss is always
+ * possible, and it returns the same null an external module does.
  */
 export function resolveImport(
   moduleSpecifier: string,
@@ -605,12 +612,21 @@ export function resolveImport(
       return null;
     }
 
+    case "shell":
     case "bash": {
-      // source ./script.sh
-      if (moduleSpecifier.startsWith("./") || moduleSpecifier.startsWith("../")) {
-        return resolveRelativePath(moduleSpecifier, sourceDir, projectPath, fileSet, [".sh", ".bash"]);
-      }
-      return null;
+      // `source ./script.sh` / `. ./script.sh` (see extractImports). Shell
+      // resolves the argument against the run-time cwd, so nothing here is
+      // exact; an explicit ./ or ../ is assumed script-relative by convention,
+      // which is the only form worth guessing. Anything else stays unresolved:
+      // a bare `source lib.sh` searches PATH and then the run-time cwd when bash
+      // is not in POSIX mode, and `source lib/x.sh` is cwd-relative too but
+      // carries no ./ to invoke that convention.
+      if (!moduleSpecifier.startsWith("./") && !moduleSpecifier.startsWith("../")) return null;
+      if (!hasLiteralShellPathShape(moduleSpecifier)) return null;
+
+      // No candidate extensions — shell loads the literal path, with no
+      // extension search.
+      return resolveRelativePath(moduleSpecifier, sourceDir, projectPath, fileSet, []);
     }
 
     case "dart": {
@@ -703,6 +719,46 @@ function resolveAliasPath(
     }
   }
   return null;
+}
+
+/**
+ * Whether a shell `source` specifier has the shape of a literal path. This reads
+ * the text only — a well-shaped specifier naming a file that does not exist is
+ * still true here, and fails later at the file-set lookup.
+ *
+ * None of the shapes below can be told apart from a literal path here, and each
+ * has to be screened before resolution rather than after, because normalising
+ * them lands on a file the shell would not open — and a match there is the
+ * failure being prevented rather than a salvage:
+ *
+ * - extractImports captures the whole argument list, so any whitespace-class
+ *   character means the text cannot be told apart from a word list or a path
+ *   still carrying its quotes. Bash splits on fewer of them than `\s` matches —
+ *   its default IFS is space, tab and newline — but skipping all of them errs
+ *   toward dropping an edge rather than inventing one.
+ * - A backslash is a shell escape and never a separator, so the unescaped path
+ *   is unknowable here; `path.resolve` treats it as a separator on win32, which
+ *   would cancel `./x\..\lib.sh` down to a file the script never names.
+ * - A trailing `/` or `/.` names a directory, which cannot be sourced, and
+ *   normalisation would drop that trailing segment, landing on the same-named
+ *   file.
+ * - A `..` following a named segment cancels it lexically during normalisation,
+ *   so `./x/../lib.sh` lands on lib.sh beside the script. The shell walks
+ *   components instead and loads nothing when `x` is absent or is not a
+ *   directory. Only a leading run of `.`/`..` anchors, and an empty segment from
+ *   `//` does not end that run.
+ *
+ * These screen the raw captured text, so a change that honours quoting and
+ * strips arguments has to unquote and split upstream of here.
+ */
+export function hasLiteralShellPathShape(specifier: string): boolean {
+  if (/\s/.test(specifier) || specifier.includes("\\")) return false;
+  if (specifier.endsWith("/") || specifier.endsWith("/.")) return false;
+  const segments = specifier.split("/");
+  const firstNamedIndex = segments.findIndex((s) => s !== "" && s !== "." && s !== "..");
+  // The index check is not redundant: a negative `fromIndex` counts back from
+  // the end, so dropping it would search only the last segment.
+  return firstNamedIndex === -1 || !segments.includes("..", firstNamedIndex);
 }
 
 /** Resolve a potentially extensionless path to an actual file */

--- a/tests/unit/code-graph-node-language.test.ts
+++ b/tests/unit/code-graph-node-language.test.ts
@@ -20,6 +20,10 @@ describe("buildCodeGraph node language", () => {
   beforeAll(() => {
     vi.stubEnv("INDEX_EXTENSIONLESS", "1"); // deterministic: content detection on
     ensureDynamicLanguages();
+    // Every fixture here is shared by all tests below, some of which assert an
+    // exact `progress.filesSkipped`. Adding a file that skips breaks those, not
+    // just your own — oversized, unreadable, or extensionless content that
+    // detects a grammar on the 8 KB head but not on the full read.
     fixture = createFixtureProject("node-language");
     addFileToFixture(fixture.root, "scripts/deploy", "#!/bin/bash\necho deploying\n");
 
@@ -34,6 +38,18 @@ describe("buildCodeGraph node language", () => {
     addFileToFixture(fixture.root, "zzz_target", oversizedPy());
     addFileToFixture(fixture.root, "aaa_target", oversizedPy());
     addFileToFixture(fixture.root, "zzz_import.py", "import aaa_target\n");
+
+    // Fixture pair for the shell source-directive edge. The unit tests in
+    // graph-resolution.test.ts call resolveImport directly, so only a full
+    // buildCodeGraph run pins the language label that reaches it.
+    addFileToFixture(fixture.root, "a.sh", "source ./b.sh\n");
+    addFileToFixture(fixture.root, "b.sh", "#!/bin/bash\necho hi\n");
+
+    // Literal resolution is the only path shell has, so an extensionless target
+    // must match on its own relative path. This pair carries its own target so
+    // neither test's target picks up a dependent belonging to the other.
+    addFileToFixture(fixture.root, "scripts/setup", "#!/bin/bash\necho setting up\n");
+    addFileToFixture(fixture.root, "scripts/run.sh", "source ./setup\n");
   });
 
   afterAll(() => {
@@ -74,5 +90,17 @@ describe("buildCodeGraph node language", () => {
     expect(target).toBeDefined();
     expect(target?.language).toBe("python");
     expect(progress.filesSkipped).toBe(2);
+  });
+
+  it("resolves a shell source directive to a graph edge", async () => {
+    const graph = await buildCodeGraph(fixture.root);
+    expect(graph.edges.some((e) => e.source === "a.sh" && e.target === "b.sh")).toBe(true);
+  });
+
+  it("resolves a shell source directive naming an extensionless target", async () => {
+    const graph = await buildCodeGraph(fixture.root);
+    expect(
+      graph.edges.some((e) => e.source === "scripts/run.sh" && e.target === "scripts/setup"),
+    ).toBe(true);
   });
 });

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -9,6 +9,7 @@ import {
   buildCsNamespaceMap,
   buildGoModuleInfo,
   buildJvmSuffixMap,
+  hasLiteralShellPathShape,
   resolveImport,
 } from "../../src/services/graph-resolution.js";
 
@@ -732,8 +733,11 @@ describe("graph-resolution", () => {
     });
   });
 
-  describe("Bash resolution", () => {
-    it("resolves relative source paths", () => {
+  describe("Shell resolution", () => {
+    // resolveImport accepts two spellings: the ast-grep grammar name ("bash")
+    // and the display name from getLanguageFromExtension ("shell"), which is
+    // what buildCodeGraph passes. Both must resolve.
+    it("resolves relative source paths for the ast-grep grammar spelling", () => {
       project = createTempProject({
         "run.sh": "",
         "config.sh": "",
@@ -748,6 +752,210 @@ describe("graph-resolution", () => {
       );
 
       expect(result).toBe("config.sh");
+    });
+
+    it("resolves relative source paths for the shell display-name spelling", () => {
+      project = createTempProject({
+        "run.sh": "",
+        "config.sh": "",
+      });
+
+      const result = resolveImport(
+        "./config.sh",
+        path.join(project.root, "run.sh"),
+        project.root,
+        project.fileSet,
+        "shell",
+      );
+
+      expect(result).toBe("config.sh");
+    });
+
+    it("resolves parent-relative source paths", () => {
+      project = createTempProject({
+        "nested/deep/run.sh": "",
+        "nested/helper.sh": "",
+        "helper.sh": "",
+      });
+
+      // A leading run of `.`/`..` anchors, so more than one level has to resolve,
+      // and an empty segment from `//` does not end the run.
+      for (const [specifier, expected] of [
+        ["../helper.sh", "nested/helper.sh"],
+        ["../../helper.sh", "helper.sh"],
+        [".//../helper.sh", "nested/helper.sh"],
+      ]) {
+        const result = resolveImport(
+          specifier,
+          path.join(project.root, "nested/deep/run.sh"),
+          project.root,
+          project.fileSet,
+          "shell",
+        );
+
+        expect(result, specifier).toBe(expected);
+      }
+    });
+
+    it("resolves a forward subdirectory path with a punctuated, mixed-case name", () => {
+      project = createTempProject({
+        "scripts/run.sh": "",
+        "scripts/lib/My_helper-2.sh": "",
+      });
+
+      // A literal path is matched verbatim, so ordinary filename punctuation and
+      // casing must survive the screens above the resolver.
+      const result = resolveImport(
+        "./lib/My_helper-2.sh",
+        path.join(project.root, "scripts/run.sh"),
+        project.root,
+        project.fileSet,
+        "shell",
+      );
+
+      expect(result).toBe("scripts/lib/My_helper-2.sh");
+    });
+
+    it("does not resolve a specifier without a ./ or ../ prefix", () => {
+      project = createTempProject({
+        "run.sh": "",
+        "config.sh": "",
+        "lib/util.sh": "",
+      });
+
+      // `source config.sh` searches PATH, then the run-time cwd when bash is not
+      // in POSIX mode, and `source lib/util.sh` is cwd-relative. Either can land
+      // on a same-named file, but never on one knowable at index time, so neither
+      // implies an edge to the sibling here.
+      for (const specifier of ["config.sh", "lib/util.sh"]) {
+        const result = resolveImport(
+          specifier,
+          path.join(project.root, "run.sh"),
+          project.root,
+          project.fileSet,
+          "shell",
+        );
+
+        expect(result, specifier).toBeNull();
+      }
+    });
+
+    // Shell performs no extension search, so resolution is literal: the two
+    // cases below are the shapes a candidate extension list would resolve, and
+    // each must stay null. The siblings cover both `.bash` and `.zsh`, and an
+    // extensionless specifier sits alongside, so these fail for any list
+    // containing `.sh`, `.bash`, or `.zsh`.
+    it("does not substitute a same-stem sibling for a missing source target", () => {
+      project = createTempProject({
+        "run.sh": "",
+        "config.bash": "",
+        "config.zsh": "",
+      });
+
+      const result = resolveImport(
+        "./config.sh",
+        path.join(project.root, "run.sh"),
+        project.root,
+        project.fileSet,
+        "shell",
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("does not append an extension to an extensionless source specifier", () => {
+      project = createTempProject({
+        "run.sh": "",
+        "config.sh": "",
+      });
+
+      const result = resolveImport(
+        "./config",
+        path.join(project.root, "run.sh"),
+        project.root,
+        project.fileSet,
+        "shell",
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("does not resolve a `..` that cancels a named segment", () => {
+      project = createTempProject({
+        "scripts/run.sh": "",
+        "scripts/lib.sh": "",
+      });
+
+      // Each of these normalises onto scripts/lib.sh, a file the script never
+      // names. The first needs no shell syntax at all — the segment simply does
+      // not exist, which the shell discovers by walking components.
+      for (const specifier of ["./nosuchdir/../lib.sh", "./$DIR/../lib.sh", "./*/../lib.sh"]) {
+        const result = resolveImport(
+          specifier,
+          path.join(project.root, "scripts/run.sh"),
+          project.root,
+          project.fileSet,
+          "shell",
+        );
+
+        expect(result, specifier).toBeNull();
+      }
+    });
+
+    it("does not normalise a directory-shaped specifier onto the same-named file", () => {
+      project = createTempProject({
+        "run.sh": "",
+        "lib.sh": "",
+      });
+
+      for (const specifier of ["./lib.sh/", "./lib.sh/."]) {
+        const result = resolveImport(
+          specifier,
+          path.join(project.root, "run.sh"),
+          project.root,
+          project.fileSet,
+          "shell",
+        );
+
+        expect(result, specifier).toBeNull();
+      }
+    });
+
+    // Asserted on the predicate rather than through resolveImport because the
+    // backslash screen only alters resolution on win32: `path.resolve` treats `\`
+    // as a separator there, while on POSIX it is an ordinary character and such a
+    // specifier misses the file set either way.
+    it("screens non-literal shapes and admits literal ones", () => {
+      for (const specifier of ["./x\\..\\lib.sh", "./x/../lib.sh", "./lib.sh/", "./lib.sh/.", "./a b/lib.sh"]) {
+        expect(hasLiteralShellPathShape(specifier), specifier).toBe(false);
+      }
+
+      for (const specifier of ["./lib.sh", "../lib.sh", "../../lib.sh", ".//../lib.sh", "./lib/My_helper-2.sh"]) {
+        expect(hasLiteralShellPathShape(specifier), specifier).toBe(true);
+      }
+    });
+
+    it("does not resolve a specifier containing whitespace", () => {
+      project = createTempProject({
+        "run.sh": "",
+        "lib.sh": "",
+        "dir name/lib.sh": "",
+      });
+
+      // The captured specifier is the whole argument list, so any whitespace-class
+      // character disqualifies it: unquoted, the shell word-splits and loads
+      // nothing; quoted, it is not a bare path.
+      for (const specifier of ["./dir name/lib.sh", "./lib.sh --verbose"]) {
+        const result = resolveImport(
+          specifier,
+          path.join(project.root, "run.sh"),
+          project.root,
+          project.fileSet,
+          "shell",
+        );
+
+        expect(result, specifier).toBeNull();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

`buildCodeGraph` uses two different names for the same language within a single iteration of its
file loop, and `resolveImport`'s switch only recognised one of them:

- **ast-grep grammar name** — `getAstGrepLang(ext)` (`code-graph.ts:812`) returns `"bash"` for `.sh`.
  This is what reaches `extractImports`, and `graph-imports.ts:351` has `case "bash":`, so extraction
  always worked and captured the specifier correctly.
- **display name** — `getLanguageFromExtension(ext)` (`code-graph.ts:888`) returns `"shell"` for
  `.sh`, `.bash`, and `.zsh`. This is what the loop passes to `resolveImport` as `resolutionLanguage`
  (`code-graph.ts:929`).

`resolveImport` switches on that raw string with no normalisation, and its shell branch was written
`case "bash":`. `"shell"` matched no case, so every shell specifier fell through to
`default: return null` and the edge was dropped silently. The result: **no shell `source` directive
has ever produced an import edge in the file graph** — a `.sh` file containing `source ./helper.sh`
yielded a node per file and no edge between them, in every project.

### Reviewer note — this changes graph output, at two levels

**File graph.** Shell import edges now appear in graphs that never had them. For any repository
containing shell scripts that source one another the file graph gains edges, which means **new cycles
are possible in `codebase_graph_circular` output**. Nothing about cycle detection changed; it is
simply now being fed edges that were previously discarded.

**Symbol graph.** The effect is not confined to the file graph. Tier-2 cross-file symbol resolution
walks each file's `dependencies` from the file graph (`graph-symbol-resolution.ts:44-70`), so shell
function calls now resolve across sourced files for the first time. `codebase_impact`,
`codebase_symbol` and `codebase_flow` output changes for shell-bearing repositories too.

This behaviour change is why the fix is submitted on its own rather than folded into unrelated graph
work.

### Why the existing tests missed it

Both halves of the pass were covered — in isolation, and both with `"bash"` passed directly:

- `tests/unit/graph-resolution.test.ts` called `resolveImport(...)` with `"bash"`, the ast-grep
  spelling, not the display name production actually passes.
- Extraction was covered the same way, also with `"bash"`.

Each half passed on its own. Nothing exercised the wiring between them, which is exactly where the
mismatch lived. This PR closes that gap: a resolver case using the display-name spelling, plus an
end-to-end case that runs `buildCodeGraph` over a real two-file fixture and asserts the edge, so the
seam is pinned rather than the halves.

Guarding the whole class mechanically — asserting that every display label a grammar-bearing
extension can produce is a label the resolver's switch handles — is the natural next step, and is
tracked as a follow-up rather than done here. Today it would need two exclusions: `html`, where
extraction yields no imports at all so a case would be dead code, and `.styl`, whose label is
`plaintext` and whose edges survive only because style imports carry `isCssImport` and route through
`case "css"`. The second exclusion would go stale immediately against a pending Stylus label fix, so
the guard is better written after that lands. I enumerated every grammar-bearing extension while
preparing this change and shell was the only live violation, so nothing else is broken today.

## Changes

- **`src/services/graph-resolution.ts`** — `case "shell":` added alongside `case "bash":`. Both
  spellings are accepted rather than changing what the caller passes: `resolveImport` is reachable
  from more than one path and the ast-grep spelling is a legitimate input for direct callers. The two
  are fully equivalent through the function — `isExternalModule` has no shell case either, so both
  spellings take the same `default: return false` path before the switch.
- **`src/services/graph-resolution.ts`** — the shell branch now passes **no** candidate extensions,
  matching `case "c": case "cpp":`, whose `#include` specifiers are likewise literal paths. This is
  deliberate and worth a moment: because the branch had never executed in a real build, adding
  `case "shell":` would otherwise switch on all of `resolveRelativePath`'s fuzzy strategies at once —
  appending an extension, swapping an existing one, probing for a directory index. Shell does none of
  those. `source ./x` loads exactly `./x`, so `./aliases` → `aliases.sh`, `./lib` → `lib/index.sh` and
  `./config.sh` → `config.zsh` would all be edges to files no script names. Literal-only resolution
  keeps every real `source ./helper.sh` working (it hits the direct match) while inventing nothing.
- **`src/services/graph-resolution.ts`** — the `language` parameter's JSDoc now states which vocabulary
  it expects, since that ambiguity is the root cause of this defect: it is a display label, `"bash"` has
  its own case as a synonym for `"shell"`, and the capitalised `Lang` grammar names match no case. It
  deliberately stops short of prescribing a remedy — not every display label has a case either (`html`
  has none), so a switch miss is always possible, and it returns the same `null` an external module
  does. That last sentence is the point: the return value is overloaded, and a caller cannot tell the
  two apart.
- **`src/services/graph-resolution.ts`** — a new `isSourceableLiteralPath()` screens four shapes that
  cannot be matched literally, because resolution normalises before matching:
  - **Raw whitespace** — the captured specifier is the whole argument list. Without this the unquoted
    `./dir name/lib.sh` that bash word-splits resolves, while the quoted form that actually works does
    not, so correctness is inverted. The class is JS `\s`, deliberately wider than bash's default IFS:
    a specifier carrying any of those characters cannot be told apart from an argument list, and
    skipping them all errs toward dropping an edge rather than inventing one.
  - **A backslash** — a shell escape, never a separator, so the unescaped path is unknowable here. It
    also matters on Windows specifically: `path.resolve` treats `\` as a separator on win32, cancelling
    `./x\..\lib.sh` onto a file the script never names.
  - **A trailing `/` or `/.`** — names a directory, which cannot be sourced, and normalisation would
    drop the trailing segment and land on the same-named file.
  - **A `..` after a named segment** — cancels it lexically, so `./x/../lib.sh` lands on `lib.sh`
    beside the script while the shell, walking components, loads nothing when `x` is absent or is not a
    directory. A leading run of `.`/`..` still anchors, and an empty segment from `//` does not end it.

  Screening structure rather than shell metacharacters is deliberate: `./nosuchdir/../lib.sh` reaches a
  wrong edge with no special characters at all, and a wrong edge is worse than a missing one, because
  tier-2 resolution reports it at `unique` confidence while marking the function the script genuinely
  calls `unresolved`. The predicate is exported so the screens can be asserted directly — the backslash
  one alters resolution only on win32, so a test driven through `resolveImport` would pass on POSIX
  whether the screen were there or not.
- **`tests/unit/graph-resolution.test.ts`** — ten cases under a `Shell resolution` describe, renamed
  from `Bash resolution` to match the vocabulary production uses. Positive: relative `source` paths
  under both spellings, a parent-relative path (single, double, and `//`-interrupted), and a punctuated
  mixed-case path in a forward subdirectory. Negative: no same-stem sibling substitution, no extension
  appended to an extensionless specifier, one per screen, and the predicate asserted directly.
- **`tests/unit/code-graph-node-language.test.ts`** — two end-to-end cases building a real graph: an
  `a.sh` → `b.sh` fixture, and a shebang-only extensionless target (`source ./setup`). The second
  matters because literal matching is now the only path shell has, so an extensionless target has to
  match on its own relative path.

Extensionless shell scripts are covered on both sides. As a *target* they resolve because
`getGraphableFiles` keys the file set on the bare relative path. As a *source*, `buildCodeGraph`
rewrites `ext` to the detected `.sh` (`code-graph.ts:827`) before deriving the display label, so a
shebang-only script that sources a sibling reaches the shell branch at all.

## Known limitation (pre-existing, not introduced here)

Only unquoted, `./`- or `../`-prefixed specifiers resolve. The bash extractor at
`graph-imports.ts:355` captures the remainder of the command verbatim, quotes included — it is the
only extractor in that file that does not strip them — so a quoted path fails the resolver's
relative-path gate and returns `null`:

```
source ./config.sh      -> "config.sh"   ✓
. ./config.sh           -> "config.sh"   ✓
source "./config.sh"    -> null          ✗  quotes retained in the specifier
source './config.sh'    -> null          ✗
source lib/config.sh    -> null          ✗  no ./ prefix
source "$DIR/config.sh" -> null              inherently unresolvable statically
```

Neither line involved is in this diff, and the behaviour is unchanged by it — but it was invisible
before, because no shell specifier resolved at all. Since shellcheck-clean scripts quote their paths,
a quoted script suite will still show no shell edges.

A `source` directive carrying arguments (`source ./lib.sh --verbose`) is unresolved for the same
reason — the arguments are part of the captured specifier, so it is not a literal path.

This is filed as a follow-up rather than fixed here, to keep this PR to the one defect. The fix is to
tokenise in the extractor — strip one matched pair of surrounding quotes and cut at the first unquoted
word — which handles the quoted, trailing-comment and argument-bearing forms together, and composes
cleanly with literal-only resolution: once the specifier is a bare path, the direct match resolves it
and no guessing is needed. Doing it in the extractor rather than widening the resolver is what keeps
the two concerns separate. Happy to fold it into this PR instead if you'd prefer them together.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test coverage improvement

## Testing

Rebased onto `main` and re-verified there. Full suite on Node 22: **55 files / 1187 tests passing**,
Biome clean across 100 files with zero warnings, `tsc` build clean.

- [x] Unit tests pass (`npm run test:unit`) — ran as part of the full `npm test`
- [x] Integration tests pass (`npm run test:integration`) — ran as part of the full `npm test`
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`) — via `npm run build`
- [x] New tests added for new/changed functionality

The cases that pin the defect itself were confirmed to fail against the unfixed resolver and pass with
it: both end-to-end cases find no edge beforehand, and the `"shell"`-spelling and parent-relative
resolver cases return `null` beforehand.

The negative cases pass against the unfixed resolver too, since that resolver returns `null` for every
shell specifier. They are regression pins rather than fix pins, so each was mutation-tested against the
change it exists to catch:

| mutation | test that fails |
|---|---|
| restore the `[".sh", ".bash"]` candidate list | same-stem sibling, extensionless specifier |
| drop the interior-`..` screen | `..` cancelling a named segment |
| drop the trailing-`/` screen (and the `/.` half alone) | directory-shaped specifier |
| drop the whitespace screen | specifier containing whitespace |
| drop the backslash screen | the predicate assertion |
| drop the empty-segment exemption | parent-relative paths |
| widen the screens to reject `_` or `-` | punctuated mixed-case path |
| replace the screens with a `[a-z./]` whitelist | punctuated mixed-case path |

Three test choices are deliberate, and each was arrived at by finding the weaker version first — every
one of them initially passed for the wrong reason:

- The same-stem sibling fixture carries **both** `config.bash` and `config.zsh`. With only `config.zsh`
  the test stayed green through the very revert it existed to catch, because `.zsh` was never in the
  candidate list.
- The positive case carries `_`, `-` and uppercase, because every other positive specifier in the suite
  is drawn from `[a-z./]`, which left a screen-widening regression invisible.
- The backslash screen is asserted on the exported predicate rather than through `resolveImport`,
  because it alters resolution only on win32 — driven through the resolver, the test passed on POSIX
  with the screen removed.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate — `resolveImport`'s `language` parameter
      now documents which vocabulary it expects; the signature and contract are otherwise unchanged
- [x] I have updated documentation (README.md / DEVELOPER.md) if needed — no change needed. All three
      extensions `DEVELOPER.md` lists under Shell resolve as targets: they are indexed and carry the
      `shell` label already, and literal resolution matches whatever the directive names, so
      `source ./helper.zsh` resolves without the resolver enumerating extensions
- [x] I have addressed all [CodeRabbit](https://coderabbit.ai) review comments (or marked as resolved with explanation)
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

## Related issues

None. Found while working on unrelated graph-build changes and split out so the graph-output change
gets its own review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell import resolution for both `bash` and `shell` language labels.
  * Shell imports now resolve only valid literal relative paths, avoiding incorrect extension substitutions and directory matches.
  * Added support for extensionless shell targets, such as `source ./setup`.
  * Improved code graph edges for shell `source` directives.

* **Tests**
  * Expanded coverage for shell path validation and resolution edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->