### PR TITLE
feat(indexing): index Stylus (.styl) files and label them stylus

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -292,7 +292,7 @@ When `SOCRATICODE_BRANCH_AWARE=true`, the current git branch is detected via `gi
 
 `loadLinkedProjects()` reads `.socraticode.json` and `SOCRATICODE_LINKED_PROJECTS` env var. `resolveLinkedCollections()` maps linked paths to `{ name, label }` descriptors for `searchMultipleCollections()`. The current project is always first (highest dedup priority).
 
-### Supported File Extensions (54)
+### Supported File Extensions (55)
 
 | Category | Extensions |
 |----------|-----------|
@@ -307,7 +307,7 @@ When `SOCRATICODE_BRANCH_AWARE=true`, the current git branch is detected via `gi
 | PHP | `.php` |
 | Swift | `.swift` |
 | Shell | `.sh`, `.bash`, `.zsh` |
-| Web | `.html`, `.htm`, `.css`, `.scss`, `.sass`, `.less`, `.vue`, `.svelte` |
+| Web | `.html`, `.htm`, `.css`, `.scss`, `.sass`, `.less`, `.styl`, `.vue`, `.svelte` |
 | Config | `.json`, `.yaml`, `.yml`, `.toml`, `.xml`, `.ini`, `.cfg` |
 | Documentation | `.md`, `.mdx`, `.rst`, `.txt` |
 | SQL | `.sql` |

--- a/README.md
+++ b/README.md
@@ -983,13 +983,13 @@ Dart: symbols (classes, mixins, enums, extensions, typedefs, functions, getters,
 
 ### Code Graph via Regex + Indexing
 
-Lua (require/dofile/loadfile), SASS, LESS (CSS `@import` extraction)
+Lua (require/dofile/loadfile), SASS, LESS, Stylus (CSS `@import`/`@require` extraction)
 
 ### Indexing Only (hybrid search, line-based chunking)
 
 JSON, YAML, TOML, XML, INI/CFG, Markdown/MDX, RST, SQL, R, Dockerfile, TXT, and any file matching a supported extension or special filename (Dockerfile, Makefile, Gemfile, Rakefile, etc.)
 
-**54 file extensions** + 8 special filenames supported out of the box.
+**55 file extensions** + 8 special filenames supported out of the box.
 
 Extensionless files (Unix scripts, health probes, sourced libraries) are also indexed via content-based language detection when `INDEX_EXTENSIONLESS` is enabled (the default) — see that environment variable below.
 

--- a/skills/codebase-management/references/tool-reference.md
+++ b/skills/codebase-management/references/tool-reference.md
@@ -240,7 +240,7 @@ List all projects that have been indexed.
 - Session resume: watcher restarts on first tool use for previously indexed projects
 
 ### Supported file extensions
-**Built-in:** `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`, `.py`, `.pyw`, `.pyi`, `.java`, `.kt`, `.kts`, `.scala`, `.c`, `.h`, `.cpp`, `.hpp`, `.cc`, `.hh`, `.cxx`, `.cs`, `.go`, `.rs`, `.rb`, `.php`, `.swift`, `.sh`, `.bash`, `.zsh`, `.html`, `.htm`, `.css`, `.scss`, `.sass`, `.less`, `.vue`, `.svelte`, `.json`, `.yaml`, `.yml`, `.toml`, `.xml`, `.ini`, `.cfg`, `.md`, `.mdx`, `.rst`, `.txt`, `.sql`, `.dart`, `.lua`, `.r`, `.R`, `.dockerfile`
+**Built-in:** `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`, `.py`, `.pyw`, `.pyi`, `.java`, `.kt`, `.kts`, `.scala`, `.c`, `.h`, `.cpp`, `.hpp`, `.cc`, `.hh`, `.cxx`, `.cs`, `.go`, `.rs`, `.rb`, `.php`, `.swift`, `.sh`, `.bash`, `.zsh`, `.html`, `.htm`, `.css`, `.scss`, `.sass`, `.less`, `.styl`, `.vue`, `.svelte`, `.json`, `.yaml`, `.yml`, `.toml`, `.xml`, `.ini`, `.cfg`, `.md`, `.mdx`, `.rst`, `.txt`, `.sql`, `.dart`, `.lua`, `.r`, `.R`, `.dockerfile`
 
 **Special files:** `Dockerfile`, `Makefile`, `Rakefile`, `Gemfile`, `Procfile`, `.env.example`, `.gitignore`, `.dockerignore`
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -296,7 +296,7 @@ const EXTENSION_TO_LANGUAGE: Record<string, string> = {
   ".swift": "swift",
   ".sh": "shell", ".bash": "shell", ".zsh": "shell",
   ".html": "html", ".htm": "html",
-  ".css": "css", ".scss": "scss", ".sass": "sass", ".less": "less",
+  ".css": "css", ".scss": "scss", ".sass": "sass", ".less": "less", ".styl": "stylus",
   ".vue": "vue", ".svelte": "svelte",
   ".json": "json", ".yaml": "yaml", ".yml": "yaml",
   ".toml": "toml", ".xml": "xml",
@@ -337,7 +337,7 @@ const LANGUAGE_TO_CANONICAL_EXT: Record<string, string> = {
   lua: ".lua",
   shell: ".sh", bash: ".sh", sh: ".sh",
   html: ".html",
-  css: ".css", scss: ".scss", sass: ".sass", less: ".less",
+  css: ".css", scss: ".scss", sass: ".sass", less: ".less", stylus: ".styl",
   vue: ".vue",
   svelte: ".svelte",
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -220,7 +220,7 @@ export const SUPPORTED_EXTENSIONS = new Set([
   // Shell
   ".sh", ".bash", ".zsh",
   // Web
-  ".html", ".htm", ".css", ".scss", ".sass", ".less", ".vue", ".svelte",
+  ".html", ".htm", ".css", ".scss", ".sass", ".less", ".styl", ".vue", ".svelte",
   // Config/Data
   ".json", ".yaml", ".yml", ".toml", ".xml", ".ini", ".cfg",
   // Docs

--- a/tests/unit/code-graph-node-language.test.ts
+++ b/tests/unit/code-graph-node-language.test.ts
@@ -50,6 +50,15 @@ describe("buildCodeGraph node language", () => {
     // neither test's target picks up a dependent belonging to the other.
     addFileToFixture(fixture.root, "scripts/setup", "#!/bin/bash\necho setting up\n");
     addFileToFixture(fixture.root, "scripts/run.sh", "source ./setup\n");
+
+    // Stylus is graphed through the CSS grammar, so a .styl file is parsed and
+    // its @require edges resolve; the node carries the Stylus label. Both are
+    // small and grammar-bearing, so neither adds to `progress.filesSkipped`.
+    // The @require deliberately omits the extension: resolveRelativePath tries a
+    // direct fileSet match first, so spelling it "./base.styl" would resolve on
+    // that and never reach the extension-append loop that consults `.styl`.
+    addFileToFixture(fixture.root, "theme.styl", '@require "./base"\n');
+    addFileToFixture(fixture.root, "base.styl", ".btn { color: red; }\n");
   });
 
   afterAll(() => {
@@ -102,5 +111,16 @@ describe("buildCodeGraph node language", () => {
     expect(
       graph.edges.some((e) => e.source === "scripts/run.sh" && e.target === "scripts/setup"),
     ).toBe(true);
+  });
+
+  it("labels .styl nodes stylus", async () => {
+    const graph = await buildCodeGraph(fixture.root);
+    expect(graph.nodes.find((n) => n.relativePath === "theme.styl")?.language).toBe("stylus");
+    expect(graph.nodes.find((n) => n.relativePath === "base.styl")?.language).toBe("stylus");
+  });
+
+  it("resolves @require edges between .styl files", async () => {
+    const graph = await buildCodeGraph(fixture.root);
+    expect(graph.edges.some((e) => e.source === "theme.styl" && e.target === "base.styl")).toBe(true);
   });
 });

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -177,6 +177,7 @@ describe("constants", () => {
       expect(SUPPORTED_EXTENSIONS.has(".html")).toBe(true);
       expect(SUPPORTED_EXTENSIONS.has(".css")).toBe(true);
       expect(SUPPORTED_EXTENSIONS.has(".scss")).toBe(true);
+      expect(SUPPORTED_EXTENSIONS.has(".styl")).toBe(true);
       expect(SUPPORTED_EXTENSIONS.has(".vue")).toBe(true);
       expect(SUPPORTED_EXTENSIONS.has(".svelte")).toBe(true);
     });

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -283,6 +283,10 @@ describe("constants", () => {
       expect(getLanguageFromExtension(".sh")).toBe("shell");
     });
 
+    it("maps .styl to stylus", () => {
+      expect(getLanguageFromExtension(".styl")).toBe("stylus");
+    });
+
     it("maps .md to markdown", () => {
       expect(getLanguageFromExtension(".md")).toBe("markdown");
     });
@@ -348,6 +352,14 @@ describe("constants", () => {
       const { map, invalid } = parseExtensionLanguageMap(".inc:php");
       expect(map.get(".inc")).toBe(".php");
       expect(invalid).toEqual([]);
+    });
+
+    it("accepts stylus as a target language, like its CSS siblings", () => {
+      const { map, invalid } = parseExtensionLanguageMap(".styles:stylus,.sheet:less");
+      expect(map.get(".styles")).toBe(".styl");
+      expect(map.get(".sheet")).toBe(".less");
+      expect(invalid).toEqual([]);
+      expect(getLanguageFromExtension(".styles", map)).toBe("stylus");
     });
 
     it("normalizes the extension (lowercases, adds leading dot)", () => {

--- a/tests/unit/indexer.test.ts
+++ b/tests/unit/indexer.test.ts
@@ -94,6 +94,7 @@ describe("indexer utilities", () => {
       expect(isIndexableFile("main.py")).toBe(true);
       expect(isIndexableFile("index.js")).toBe(true);
       expect(isIndexableFile("styles.css")).toBe(true);
+      expect(isIndexableFile("theme.styl")).toBe(true);
       expect(isIndexableFile("data.json")).toBe(true);
       expect(isIndexableFile("readme.md")).toBe(true);
     });


### PR DESCRIPTION
## Summary

Stylus (`.styl`) was wired almost everywhere in the codebase but was missing from both extension maps, which produced two separate user-visible symptoms from one root cause:

1. **`.styl` nodes were labelled `plaintext`** in `codebase_graph_stats` and the interactive visualisation, because `getLanguageFromExtension(".styl")` had no entry and fell through to the default.
2. **`.styl` files were never indexed** — they were parsed into the code graph but never chunked or embedded, so `codebase_search` could not find them, while all four sibling CSS dialects were searchable.

Everything else Stylus needs was already in place before this PR: the CSS grammar covers `.styl` (`code-graph.ts`, `Lang.Css`), the resolver lists `.styl` among its CSS candidate extensions, the import extractor understands `@require`, and `resolveImport` already carried a `"stylus"` case. Only the two maps in `src/constants.ts` were missing it.

**This PR is deliberately two commits, and they are independently useful — see [Why two commits](#why-two-commits) below.**

## Changes

**`fix(graph): label .styl files stylus instead of plaintext`**

- `EXTENSION_TO_LANGUAGE` gains `".styl": "stylus"`. `.styl` was the only extension in the codebase with an ast-grep grammar and no language label. Unlike the extensionless case, `nodeLanguage()` cannot repair this — it falls back to path derivation, and the extension *is* present.
- `LANGUAGE_TO_CANONICAL_EXT` gains `stylus: ".styl"`. Without it, `EXTENSION_LANGUAGE_MAP=".foo:stylus"` was rejected while `.foo:css` was accepted — an asymmetry that only became reachable once `"stylus"` was a real label.
- Tests: `.styl` nodes carry the `stylus` label, `@require` edges resolve between `.styl` files, and `stylus` is accepted as an `EXTENSION_LANGUAGE_MAP` target.

**`feat(indexing): index Stylus (.styl) files`**

- `SUPPORTED_EXTENSIONS` gains `".styl"`. Both the indexer and the watcher gate on this set, so no watcher or chunking change is needed. Chunking and symbol extraction need nothing new either: `TOP_LEVEL_KINDS` has no `Css` entry and `graph-symbols.ts` has no `Css` branch, so all five CSS dialects use line-based chunking exactly as before.
- Updates all three checked-in copies of the supported-extension list, which is duplicated across the repo: the `DEVELOPER.md` table **and its heading count** (54 → 55), the `README.md` count (54 → 55) plus its "Code Graph via Regex + Indexing" tier list, and the 55-item enumeration in `skills/codebase-management/references/tool-reference.md`.

Resolution behaviour is unchanged by either commit: style imports carry `isCssImport`, which routes them through `case "css"` regardless of the node's label. The pre-existing `case "stylus":` in `resolveImport` therefore remains unreachable via the CSS-import path — adding the label makes that branch coherent rather than vestigial, but it is not expected to fire.

## Why two commits

The label fix and the indexing change are separable, and the second is a behaviour change while the first is not:

- **The label fix is a pure correction.** It changes only how existing `.styl` graph nodes are described. No file is newly read, chunked, or embedded.
- **The indexing change adds work for every indexed repo that contains Stylus files.** Those files will now be chunked and embedded on every index and re-indexed by the watcher on change. I have not measured the added embedding cost; it should be small, since Stylus files are rare and typically short, but it is a real behaviour change and not something to slip in unannounced.

Splitting them means **the first commit can be taken without the second** if the indexing behaviour change is unwanted — the label fix stands alone, is green on its own (verified: 57 files / 1213 tests at the first commit), and does not depend on the second in either direction. The two subjects also land in different auto-generated changelog sections (Bug Fixes / Features), which is the accurate description of what each does.

Happy to drop the second commit, or to split it into its own PR, if you'd prefer to take these separately.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement

## Testing

Rebased onto `main` at v1.10.0. Full suite, lint, and build are green on Node 22 at both commits — **57 test files / 1213 tests passing**, `biome check` clean across 102 files with zero warnings, `tsc` clean.

- [x] Unit tests pass (`npm run test:unit`)
- [x] Integration tests pass (`npm run test:integration`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] New tests added for new/changed functionality

New coverage:

- `tests/unit/code-graph-node-language.test.ts` — `.styl` nodes are labelled `stylus`; an extensionless `@require "./base"` resolves to `base.styl`. The fixture deliberately omits the extension: `resolveRelativePath` tries a direct `fileSet` match first, so spelling it `"./base.styl"` would resolve on that and never reach the extension-append loop that consults `.styl`. Confirmed non-vacuous by mutation — removing `.styl` from the resolver's `cssExtensions` fails this test.
- `tests/unit/constants.test.ts` — `getLanguageFromExtension(".styl")` returns `stylus`; `SUPPORTED_EXTENSIONS` contains `.styl`; `parseExtensionLanguageMap` accepts `stylus` as a target language, asserted alongside a CSS sibling in the same call so the parity with `css`/`scss`/`sass`/`less` is actually exercised rather than just claimed.
- `tests/unit/indexer.test.ts` — `isIndexableFile("theme.styl")` is true.

The test count is identical at both commits because the second commit adds assertions to existing `it` blocks rather than new ones.

I also re-verified all three checked-in copies of the extension list against `SUPPORTED_EXTENSIONS` element-by-element, not just by count — all three agree at 55 with no drift in either direction. Worth noting for future changes: nothing in the test suite guards those three copies against the actual set, so they can only drift silently. Adding such a test felt out of scope here, but I'm glad to add one if you'd like it.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate
- [x] I have updated documentation (README.md / DEVELOPER.md) if needed
- [x] I have addressed all [CodeRabbit](https://coderabbit.ai) review comments (or marked as resolved with explanation)
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

## Related issues

None.

## Note on the README language tiers

The README's "Full Support (indexing + code graph + AST chunking)" tier lists CSS and SCSS, even though CSS dialects get line-based chunking like the lower tier. That is pre-existing and I left it alone — re-tiering languages is outside this PR. I did place Stylus in the "Code Graph via Regex + Indexing" tier beside SASS and LESS, and widened that tier's parenthetical to "CSS `@import`/`@require` extraction", which matches how the code actually treats all five dialects.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stylus (`.styl`) support for code-graph extraction, indexing, and language detection.
  * Stylus imports and `@require` directives are now recognized, including extensionless references.

* **Documentation**
  * Updated supported-language documentation and extension counts to include Stylus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->