### PR TITLE
fix: resolve PHP imports and call sites through language-aware rules

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -520,6 +520,11 @@ When `codebase_graph_build` is called:
    ├── Handle relative paths: ./foo → foo.ts, foo/index.ts, etc.
    ├── Try path alias resolution: $lib/foo → src/lib/foo.ts, @/bar → src/bar.ts
    ├── Try extension variations per language (JS/TS extensions or CSS extensions)
+   ├── PHP: PSR-4 prefixes from every in-repo composer.json (once per build)
+   │   ├── Root manifest + each package manifest; autoload and autoload-dev
+   │   ├── Longest matching prefix wins (Acme\Auth\Db\ beats Acme\Auth\)
+   │   ├── vendor/ skipped — path repositories symlink it back to the source
+   │   └── Falls back to the directory-shaped guess when no prefix matches
    ├── SCSS partial resolution: @import "vars" → _vars.scss
    ├── CSS imports from <style> blocks → resolved with CSS extensions (.css/.scss/.sass/.less/.styl)
    ├── Check against known file set for existence

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -14,7 +14,7 @@ import type {
 import { detectExtensionFromSource, resolveExtensionlessExtension } from "./extensionless.js";
 import { loadPathAliases } from "./graph-aliases.js";
 import { extractImports } from "./graph-imports.js";
-import { buildCsNamespaceMap, buildGoModuleInfo, buildJvmSuffixMap, resolveImport } from "./graph-resolution.js";
+import { buildCsNamespaceMap, buildGoModuleInfo, buildJvmSuffixMap, buildPhpPsr4Map, resolveImport } from "./graph-resolution.js";
 import { computeUnresolvedPct, resolveCallSites } from "./graph-symbol-resolution.js";
 import { extractSymbolsAndCalls, rawCallsToUnresolvedEdges } from "./graph-symbols.js";
 import { createIgnoreFilter, shouldIgnore } from "./ignore.js";
@@ -789,6 +789,14 @@ export async function buildCodeGraph(
   });
   const jvmSuffixMap = hasJvm ? buildJvmSuffixMap(fileSet) : undefined;
 
+  // Build the PSR-4 prefix map for PHP projects. A namespace carries no path
+  // information, so without the declared mapping every `use` statement that
+  // does not happen to mirror the directory layout resolved to null — which is
+  // all of them in a Composer monorepo, where each package declares its own
+  // PSR-4 root under `packages/<name>/src`.
+  const hasPhp = files.some((f) => path.extname(f).toLowerCase() === ".php");
+  const phpPsr4Map = hasPhp ? buildPhpPsr4Map(resolvedPath) : undefined;
+
   // Build a namespace lookup map for C# projects. Each `namespace X.Y.Z` block
   // (or file-scoped `namespace X.Y.Z;`) is recorded so `using X.Y.Z;` directives
   // can be resolved to the file(s) that contribute to that namespace. Without
@@ -927,7 +935,7 @@ export async function buildCodeGraph(
       // Try to resolve to a project file
       // CSS imports from <style> blocks use CSS resolution even when the source file is Svelte/Vue
       const resolutionLanguage = imp.isCssImport ? "css" : language;
-      const resolved = resolveImport(imp.moduleSpecifier, absolutePath, resolvedPath, fileSet, resolutionLanguage, aliases, jvmSuffixMap, csNamespaceMap, goModuleInfo);
+      const resolved = resolveImport(imp.moduleSpecifier, absolutePath, resolvedPath, fileSet, resolutionLanguage, aliases, jvmSuffixMap, csNamespaceMap, goModuleInfo, phpPsr4Map);
       if (resolved) {
         node.dependencies.push(resolved);
 

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -127,6 +127,131 @@ export function buildCsNamespaceMap(
 }
 
 /**
+ * Discover every `composer.json` under `projectPath`, project-relative and
+ * forward-slash-normalized.
+ *
+ * `composer.json` is not a graphable file, so it is never in the set returned
+ * by `getGraphableFiles` — this walk is independent of that set, exactly like
+ * {@link findGoModFiles}. The same ignore filter (`createIgnoreFilter` /
+ * `shouldIgnore`) `getGraphableFiles` uses is applied, with the same
+ * trailing-slash convention for directories, so a manifest under
+ * `node_modules/`, `.git/` or any gitignored or `.socraticodeignore`d path is
+ * skipped — matching what the graphable walk would do.
+ *
+ * `vendor/` is additionally skipped unconditionally. It is absent from
+ * DEFAULT_IGNORE_PATTERNS, and a Composer path repository symlinks
+ * `vendor/<pkg>` back to the in-repo source, so a manifest read through it
+ * would register a second directory for a prefix the in-repo manifest already
+ * declared — pointing at a path whose files were indexed under their real
+ * location.
+ */
+function findComposerManifests(projectPath: string): string[] {
+  const ig = createIgnoreFilter(projectPath);
+  const results: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const relPath = toForwardSlash(path.relative(projectPath, path.join(dir, entry.name)));
+      if (shouldIgnore(ig, entry.isDirectory() ? `${relPath}/` : relPath)) continue;
+      if (entry.isDirectory()) {
+        if (entry.name === "vendor") continue;
+        walk(path.join(dir, entry.name));
+      } else if (entry.name === "composer.json") {
+        // Mirrors findGoModFiles: readdirSync Dirents do not follow symlinks,
+        // so a symlinked manifest reports isFile()===false and would be missed.
+        let isFile = entry.isFile();
+        if (!isFile && entry.isSymbolicLink()) {
+          try {
+            isFile = statSync(path.join(dir, entry.name)).isFile();
+          } catch {
+            continue;
+          }
+        }
+        if (isFile) results.push(relPath);
+      }
+    }
+  };
+  walk(projectPath);
+  // Sorted so the directory list for a prefix declared by several manifests is
+  // deterministic across machines — resolveImport tries them in order.
+  return results.sort();
+}
+
+/**
+ * Build a PSR-4 prefix map for PHP projects from every in-repo `composer.json`.
+ *
+ * PHP namespaces carry no path information — `App\Models\User` only maps to
+ * `app/Models/User.php` because `composer.json` says so. The convention-based
+ * fallback in `resolveImport` guesses that mapping from the directory layout,
+ * which works for a single-package project whose namespace root happens to
+ * match a real directory name, and silently drops every import that does not:
+ *
+ *   - `Database\Seeders\Foo`  → the directory is `database/seeders`, lowercase,
+ *                               so the case-sensitive guess misses it
+ *   - `Acme\Auth\Models\Role` → lives in `packages/auth/src/Models/Role.php`,
+ *                               a path no namespace-shaped guess can reach
+ *
+ * The second case is the norm in Composer monorepos (path repositories), where
+ * every domain package declares its own PSR-4 root. Those imports resolved to
+ * nothing, so package-to-package edges were absent from the graph entirely and
+ * impact analysis reported "no callers" for code with many callers.
+ *
+ * Reads the root manifest plus each nested one (`autoload` and `autoload-dev`),
+ * mapping every prefix to directories relative to the manifest that declared
+ * it.
+ *
+ * Call this once per graph build and pass the result to resolveImport.
+ */
+export function buildPhpPsr4Map(projectPath: string): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  const root = path.resolve(projectPath);
+
+  for (const relManifest of findComposerManifests(root)) {
+    const manifest = path.join(root, relManifest);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(manifest, "utf8"));
+    } catch {
+      continue; // malformed manifest — the other manifests still count
+    }
+    if (typeof parsed !== "object" || parsed === null) continue;
+
+    const manifestDir = path.dirname(manifest);
+    const doc = parsed as Record<string, unknown>;
+    const blocks = [doc.autoload, doc["autoload-dev"]];
+
+    for (const block of blocks) {
+      if (typeof block !== "object" || block === null) continue;
+      const psr4 = (block as Record<string, unknown>)["psr-4"];
+      if (typeof psr4 !== "object" || psr4 === null) continue;
+
+      for (const [prefix, target] of Object.entries(psr4 as Record<string, unknown>)) {
+        // PSR-4 allows a string or an array of directories per prefix.
+        const targets = Array.isArray(target) ? target : [target];
+        for (const rawTarget of targets) {
+          if (typeof rawTarget !== "string") continue;
+          const abs = path.resolve(manifestDir, rawTarget);
+          const rel = toForwardSlash(path.relative(root, abs)).replace(/\/+$/, "");
+          // A manifest outside the indexed tree (path.relative escapes upward)
+          // cannot contribute resolvable files.
+          if (rel.startsWith("..")) continue;
+          const list = map.get(prefix) ?? [];
+          if (!list.includes(rel)) list.push(rel);
+          map.set(prefix, list);
+        }
+      }
+    }
+  }
+
+  return map;
+}
+
+/**
  * Information needed to resolve Go imports to local files for ONE module.
  *
  * A project may contain several Go modules (a monorepo with nested
@@ -350,6 +475,7 @@ export function resolveImport(
   jvmSuffixMap?: Map<string, string>,
   csNamespaceMap?: Map<string, string[]>,
   goModuleInfo?: GoModuleInfo[] | null,
+  phpPsr4Map?: Map<string, string[]>,
 ): string | null {
   // Skip obvious external/stdlib modules. Go is excluded from this
   // pre-check because its external classifier in `isExternalModule`
@@ -533,6 +659,28 @@ export function resolveImport(
     case "php": {
       // PSR-4: App\Models\User → app/Models/User.php
       if (moduleSpecifier.includes("\\")) {
+        // Declared PSR-4 first — composer.json is the authority on where a
+        // namespace lives, and the heuristics below can only guess. Longest
+        // matching prefix wins so `Acme\Auth\Database\Seeders\` beats the
+        // shorter `Acme\Auth\` that also prefixes it.
+        if (phpPsr4Map && phpPsr4Map.size > 0) {
+          const namespaced = moduleSpecifier.replace(/^\\+/, "");
+          let bestPrefix = "";
+          for (const prefix of phpPsr4Map.keys()) {
+            if (namespaced.startsWith(prefix) && prefix.length > bestPrefix.length) {
+              bestPrefix = prefix;
+            }
+          }
+          if (bestPrefix) {
+            const relative = namespaced.slice(bestPrefix.length).replace(/\\/g, "/");
+            for (const dir of phpPsr4Map.get(bestPrefix) ?? []) {
+              const candidate = dir ? `${dir}/${relative}` : relative;
+              const hit = resolveRelativePath(candidate, projectPath, projectPath, fileSet, [".php"]);
+              if (hit) return hit;
+            }
+          }
+        }
+
         const filePath = moduleSpecifier.replace(/\\/g, "/");
         // Try exact case first
         const exact = resolveRelativePath(filePath, projectPath, projectPath, fileSet, [".php"]);

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -688,6 +688,34 @@ function extractCalleeNameJs(text: string): string | null {
   return /^[A-Za-z_$][\w$]*$/.test(last) ? last : null;
 }
 
+/**
+ * Callee name for a PHP call expression.
+ *
+ * PHP separates a callee from its receiver with `::` (static) or `->`
+ * (instance), neither of which appears in the JS chain pattern `[\w$.]+`.
+ * Running PHP calls through `extractCalleeNameJs` therefore returned null for
+ * every method and static call — the match stopped dead at the `:` of
+ * `Cls::method(` or the `-` of `$obj->method(` — so only bare
+ * `function_call_expression` nodes survived, which in practice means stdlib
+ * calls. Every cross-file PHP call edge was dropped, leaving `codebase_impact`
+ * and `codebase_symbol` reporting no callers for code with many.
+ *
+ * Takes the identifier immediately before the call's opening parenthesis, which
+ * is the callee however deep the receiver chain is:
+ *
+ *   foo(…)                   → "foo"
+ *   Cls::make(…)             → "make"
+ *   $this->svc->blacklist(…) → "blacklist"
+ *   Acme\Support\Cls::of(…)  → "of"
+ */
+function extractCalleeNamePhp(text: string): string | null {
+  const paren = text.indexOf("(");
+  if (paren <= 0) return null;
+  const receiver = text.slice(0, paren).trimEnd();
+  const m = receiver.match(/([A-Za-z_]\w*)$/);
+  return m ? m[1] : null;
+}
+
 // ── Python ───────────────────────────────────────────────────────────────
 
 function extractFromPython(
@@ -1227,7 +1255,7 @@ function extractFromPhp(
   const rawCalls: ExtractedSymbols["rawCalls"] = [];
   for (const k of ["function_call_expression", "member_call_expression", "scoped_call_expression"]) {
     for (const node of safeFindAll(root, k)) {
-      const calleeName = extractCalleeNameJs(node.text());
+      const calleeName = extractCalleeNamePhp(node.text());
       if (!calleeName) continue;
       const r = node.range();
       const callLine = r.start.line + 1;

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -700,18 +700,47 @@ function extractCalleeNameJs(text: string): string | null {
  * calls. Every cross-file PHP call edge was dropped, leaving `codebase_impact`
  * and `codebase_symbol` reporting no callers for code with many.
  *
- * Takes the identifier immediately before the call's opening parenthesis, which
- * is the callee however deep the receiver chain is:
+ * The callee is the identifier before *this* call's own argument list, which is
+ * the last top-level parenthesis group in the node's text. Taking the first `(`
+ * instead names the wrong method on a fluent chain: ast-grep reports one node
+ * per link, and each node's text starts at the head of the chain, so
+ * `Model::where('x')->orderBy('y')->get()` would yield `where` three times
+ * rather than `where`, `orderBy`, `get`.
  *
- *   foo(…)                   → "foo"
- *   Cls::make(…)             → "make"
- *   $this->svc->blacklist(…) → "blacklist"
- *   Acme\Support\Cls::of(…)  → "of"
+ * Quoted sections are skipped so a parenthesis inside a string literal —
+ * `where('a)b')` — cannot unbalance the scan.
+ *
+ *   foo(…)                                 → "foo"
+ *   Cls::make(…)                           → "make"
+ *   $this->svc->blacklist(…)               → "blacklist"
+ *   Acme\Support\Cls::of(…)                → "of"
+ *   Model::where(…)->orderBy(…)->get()     → "get"   (outermost node)
  */
 function extractCalleeNamePhp(text: string): string | null {
-  const paren = text.indexOf("(");
-  if (paren <= 0) return null;
-  const receiver = text.slice(0, paren).trimEnd();
+  let depth = 0;
+  let quote: string | null = null;
+  let lastTopLevelOpen = -1;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+
+    if (quote !== null) {
+      if (ch === "\\") i++; // escaped char — consume the pair
+      else if (ch === quote) quote = null;
+      continue;
+    }
+
+    if (ch === "'" || ch === '"') quote = ch;
+    else if (ch === "(") {
+      if (depth === 0) lastTopLevelOpen = i;
+      depth++;
+    } else if (ch === ")") {
+      depth--;
+    }
+  }
+
+  if (lastTopLevelOpen <= 0) return null;
+  const receiver = text.slice(0, lastTopLevelOpen).trimEnd();
   const m = receiver.match(/([A-Za-z_]\w*)$/);
   return m ? m[1] : null;
 }

--- a/tests/unit/graph-resolution-php-psr4.test.ts
+++ b/tests/unit/graph-resolution-php-psr4.test.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildPhpPsr4Map, resolveImport } from "../../src/services/graph-resolution.js";
+
+/**
+ * PHP namespaces carry no path information, so `composer.json` is the only
+ * authority on where one lives. Before the PSR-4 map, resolution guessed from
+ * the directory layout: it handled `App\` → `app/` and missed everything else,
+ * which in a Composer monorepo is every cross-package import.
+ */
+describe("PHP PSR-4 resolution", () => {
+  let root: string;
+  const fileSet = new Set<string>();
+
+  const write = (rel: string, body: string): void => {
+    const abs = path.join(root, rel);
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  };
+
+  beforeAll(() => {
+    root = mkdtempSync(path.join(tmpdir(), "psr4-"));
+
+    // Host app: the conventional layout, plus a lowercase directory whose
+    // namespace segment is capitalised (`Database\Seeders\` → `database/seeders`).
+    write("composer.json", JSON.stringify({
+      autoload: {
+        "psr-4": {
+          "App\\": "app/",
+          "Database\\Seeders\\": "database/seeders/",
+        },
+      },
+      "autoload-dev": { "psr-4": { "Tests\\": "tests/" } },
+    }));
+
+    // An in-repo package, consumed via a Composer path repository.
+    write("packages/auth/composer.json", JSON.stringify({
+      autoload: {
+        "psr-4": {
+          "Acme\\Auth\\": "src/",
+          "Acme\\Auth\\Database\\Seeders\\": "database/seeders/",
+        },
+      },
+    }));
+
+    // A vendor copy that must never win: path repositories symlink
+    // vendor/<pkg> back to the source, so indexing it would duplicate files.
+    write("vendor/acme/auth/composer.json", JSON.stringify({
+      autoload: { "psr-4": { "Acme\\Auth\\": "src/" } },
+    }));
+
+    for (const rel of [
+      "app/Http/Controllers/BaseController.php",
+      "database/seeders/DatabaseSeeder.php",
+      "tests/TestCase.php",
+      "packages/auth/src/Models/Role.php",
+      "packages/auth/database/seeders/AuthSeeder.php",
+    ]) {
+      write(rel, "<?php\n");
+      fileSet.add(rel);
+    }
+  });
+
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  const resolve = (spec: string): string | null =>
+    resolveImport(
+      spec, path.join(root, "app/Http/Controllers/Caller.php"), root,
+      fileSet, "php", undefined, undefined, undefined, undefined,
+      buildPhpPsr4Map(root),
+    );
+
+  it("collects prefixes from the root manifest and every in-repo package", () => {
+    const map = buildPhpPsr4Map(root);
+    expect(map.get("App\\")).toEqual(["app"]);
+    expect(map.get("Acme\\Auth\\")).toEqual(["packages/auth/src"]);
+    // autoload-dev counts too — test suites import each other.
+    expect(map.get("Tests\\")).toEqual(["tests"]);
+  });
+
+  it("skips vendor manifests so a symlinked path repo cannot duplicate a package", () => {
+    expect(buildPhpPsr4Map(root).get("Acme\\Auth\\")).not.toContain("vendor/acme/auth/src");
+  });
+
+  it("honours .socraticodeignore so an excluded package contributes no prefixes", () => {
+    // A directory the project excluded from indexing has no indexed files, so
+    // prefixes pointing into it could only ever resolve to nothing.
+    const ignored = mkdtempSync(path.join(tmpdir(), "psr4-ignored-"));
+    try {
+      mkdirSync(path.join(ignored, "packages/legacy"), { recursive: true });
+      writeFileSync(path.join(ignored, "composer.json"), JSON.stringify({
+        autoload: { "psr-4": { "App\\": "app/" } },
+      }));
+      writeFileSync(path.join(ignored, "packages/legacy/composer.json"), JSON.stringify({
+        autoload: { "psr-4": { "Legacy\\": "src/" } },
+      }));
+      writeFileSync(path.join(ignored, ".socraticodeignore"), "packages/legacy/\n");
+
+      const map = buildPhpPsr4Map(ignored);
+      expect(map.get("App\\")).toEqual(["app"]);
+      expect(map.has("Legacy\\")).toBe(false);
+    } finally {
+      rmSync(ignored, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves a cross-package import that no directory-shaped guess can reach", () => {
+    expect(resolve("Acme\\Auth\\Models\\Role")).toBe("packages/auth/src/Models/Role.php");
+  });
+
+  it("prefers the longest matching prefix", () => {
+    // `Acme\Auth\` also prefixes this; picking it would look under
+    // packages/auth/src/Database/Seeders and find nothing.
+    expect(resolve("Acme\\Auth\\Database\\Seeders\\AuthSeeder"))
+      .toBe("packages/auth/database/seeders/AuthSeeder.php");
+  });
+
+  it("resolves a prefix whose directory case differs from the namespace", () => {
+    // The old lowercase-first-segment guess produced `database/Seeders/…`.
+    expect(resolve("Database\\Seeders\\DatabaseSeeder")).toBe("database/seeders/DatabaseSeeder.php");
+  });
+
+  it("still resolves the conventional layout", () => {
+    expect(resolve("App\\Http\\Controllers\\BaseController"))
+      .toBe("app/Http/Controllers/BaseController.php");
+  });
+
+  it("returns null for a namespace no manifest declares", () => {
+    expect(resolve("Nope\\Missing\\Thing")).toBeNull();
+  });
+
+  it("is a no-op when the project has no composer.json", () => {
+    const empty = mkdtempSync(path.join(tmpdir(), "psr4-empty-"));
+    try {
+      expect(buildPhpPsr4Map(empty).size).toBe(0);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/graph-symbols-php-calls.test.ts
+++ b/tests/unit/graph-symbols-php-calls.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import { beforeAll, describe, expect, it } from "vitest";
+import { ensureDynamicLanguages } from "../../src/services/code-graph.js";
+import { extractSymbolsAndCalls } from "../../src/services/graph-symbols.js";
+
+/**
+ * PHP call edges. `extractFromPhp` collects `member_call_expression` and
+ * `scoped_call_expression` nodes, but used to name them with the JavaScript
+ * extractor, whose chain pattern `[\w$.]+` stops at the `:` of `Cls::method(`
+ * and the `-` of `$obj->method(`. Every method and static call therefore
+ * resolved to null and was dropped, so only bare function calls survived and
+ * `codebase_impact` reported no callers for any PHP symbol.
+ */
+describe("PHP call-site extraction", () => {
+  // PHP is a dynamically-registered ast-grep grammar. Without this the parse
+  // throws, `safeFindAll` swallows it, and every assertion sees an empty list —
+  // a silent pass-by-vacuum rather than a failure.
+  beforeAll(() => ensureDynamicLanguages());
+
+  const callsIn = (php: string): string[] => {
+    // Signature is (source, lang, ext, relativePath). Passing the path as
+    // `lang` silently routes to the regex fallback, which handles `::`/`->`
+    // already — so a wrong-arity call here would pass while testing nothing.
+    const { rawCalls } = extractSymbolsAndCalls(php, "php", ".php", "t.php");
+    return rawCalls.map((c) => c.calleeName);
+  };
+
+  it("names a static call by its method, not its class", () => {
+    expect(callsIn("<?php\nAuthCookies::forgetAccess();\n")).toContain("forgetAccess");
+  });
+
+  it("names an instance call through a receiver chain", () => {
+    expect(callsIn("<?php\n$this->revoker->blacklistToken($t);\n")).toContain("blacklistToken");
+  });
+
+  it("handles a fully-qualified static call", () => {
+    expect(callsIn("<?php\n\\Acme\\Support\\Cookie::make('a');\n")).toContain("make");
+  });
+
+  it("still handles a plain function call", () => {
+    expect(callsIn("<?php\nstrlen($x);\n")).toContain("strlen");
+  });
+
+  it("captures every call in a realistic method body", () => {
+    const names = callsIn(`<?php
+class LogoutController {
+    public function __invoke(Request $request): JsonResponse {
+        $this->revoker->blacklistToken($accessToken);
+        $response->headers->setCookie(AuthCookies::forgetAccess());
+        return $response;
+    }
+}`);
+    expect(names).toEqual(expect.arrayContaining([
+      "blacklistToken", "setCookie", "forgetAccess",
+    ]));
+  });
+
+  it("drops nothing silently — a method call yields exactly one callee name", () => {
+    // Regression guard: the old JS extractor returned null here.
+    expect(callsIn("<?php\nCls::of($a);\n")).toEqual(["of"]);
+  });
+});

--- a/tests/unit/graph-symbols-php-calls.test.ts
+++ b/tests/unit/graph-symbols-php-calls.test.ts
@@ -73,12 +73,18 @@ class LogoutController {
 
   it("is not confused by a parenthesis inside a string literal", () => {
     // A depth scan that ignores quoting unbalances here and mis-slices.
-    expect(new Set(callsIn("<?php\nModel::where('a)b')->get();\n")))
-      .toEqual(new Set(["where", "get"]));
+    const names = callsIn("<?php\nModel::where('a)b')->get();\n");
+
+    // Length before the set: `new Set` collapses duplicates, so a partially
+    // wrong ["where", "where", "get"] would satisfy the set alone.
+    expect(names).toHaveLength(2);
+    expect(new Set(names)).toEqual(new Set(["where", "get"]));
   });
 
   it("names a nested call by its own callee, not the enclosing one", () => {
-    expect(new Set(callsIn("<?php\nFoo::bar(Baz::qux($v));\n")))
-      .toEqual(new Set(["bar", "qux"]));
+    const names = callsIn("<?php\nFoo::bar(Baz::qux($v));\n");
+
+    expect(names).toHaveLength(2);
+    expect(new Set(names)).toEqual(new Set(["bar", "qux"]));
   });
 });

--- a/tests/unit/graph-symbols-php-calls.test.ts
+++ b/tests/unit/graph-symbols-php-calls.test.ts
@@ -60,4 +60,25 @@ class LogoutController {
     // Regression guard: the old JS extractor returned null here.
     expect(callsIn("<?php\nCls::of($a);\n")).toEqual(["of"]);
   });
+
+  it("names each link of a fluent chain distinctly", () => {
+    // ast-grep reports one node per link and each node's text starts at the
+    // head of the chain, so keying on the FIRST "(" names the outermost call
+    // `where` — three times — instead of where/orderBy/get.
+    const names = callsIn("<?php\nModel::where('x')->orderBy('y')->get();\n");
+
+    expect(names).toHaveLength(3);
+    expect(new Set(names)).toEqual(new Set(["where", "orderBy", "get"]));
+  });
+
+  it("is not confused by a parenthesis inside a string literal", () => {
+    // A depth scan that ignores quoting unbalances here and mis-slices.
+    expect(new Set(callsIn("<?php\nModel::where('a)b')->get();\n")))
+      .toEqual(new Set(["where", "get"]));
+  });
+
+  it("names a nested call by its own callee, not the enclosing one", () => {
+    expect(new Set(callsIn("<?php\nFoo::bar(Baz::qux($v));\n")))
+      .toEqual(new Set(["bar", "qux"]));
+  });
 });


### PR DESCRIPTION
## Summary

PHP is the only supported language whose import resolution and call-site naming both run on another language's rules.
The result is a file graph with almost no PHP edges and a symbol graph with no PHP callers at all, so `codebase_impact`
and `codebase_symbol` confidently answer **"No callers found — nothing else depends on this"** for code with many
callers.

**Imports** were resolved by guessing a path from the namespace shape rather than reading `composer.json`, which is the
only authority on where a namespace lives. That works for a single-package app whose namespace root happens to match a
directory name, and silently drops everything else — including every cross-package import in a Composer monorepo.

**Call sites** were named with the JavaScript extractor, whose chain pattern `[\w$.]+` contains neither `:` nor `>`. The
match stopped dead at the `:` of `Cls::method(` and the `-` of `$obj->method(`, so every method and static call was
discarded and only bare function calls survived — in practice, stdlib.

Measured on a 3,454-file Laravel monorepo (16 in-repo packages via path repositories):

|                                  | Before           | After                   |
|----------------------------------|------------------|-------------------------|
| File-graph edges                 | 483              | **7,969**               |
| Orphan files                     | 3,196            | **733**                 |
| Avg dependencies/file            | 0.1              | **2.3**                 |
| First-party PHP imports resolved | 297 / 7,121 (4%) | **6,763 / 7,121 (95%)** |

Before, the most-connected files were TypeScript from an unrelated subproject. After, they are the domain layer that was
previously invisible — a shared contracts interface at 230 connections, domain models at ~150.

Two independent defects, one language, hence one PR. Happy to split if you'd prefer.

## Changes

- **`buildPhpPsr4Map()`** (`graph-resolution.ts`) — reads `autoload` and `autoload-dev` `psr-4` blocks from the root
  manifest and every in-repo manifest, resolving targets relative to the manifest that declared them. Longest matching
  prefix wins, so `Acme\Auth\Database\Seeders\` beats the shorter `Acme\Auth\` that also prefixes it. Multi-directory
  prefixes are supported (a repo where `App\` maps to both `app/` and a legacy `old-slim/src/` resolves from both).
- **`findComposerManifests()`** (`graph-resolution.ts`) — deliberately mirrors `findGoModFiles()`. `composer.json` is not
  a graphable file, so it is never in `getGraphableFiles`' set and needs its own walk, applying the same ignore filter
  and trailing-slash convention, handling symlinked manifests via `statSync`, and returning sorted results so
  multi-directory prefixes resolve deterministically.
- **`vendor/` skipped unconditionally**, documented inline: it is absent from `DEFAULT_IGNORE_PATTERNS`, and a Composer
  path repository symlinks `vendor/<pkg>` back to the in-repo source, so a manifest read through it would register a
  second directory for a prefix the real manifest already declared.
- **`resolveImport`** (`graph-resolution.ts`) — tries the declared PSR-4 map first, falling back to the existing
  directory-shaped heuristics when no prefix matches. New optional `phpPsr4Map` parameter; all other languages unchanged.
- **`buildCodeGraph`** (`code-graph.ts`) — builds the map once per graph build, gated on `hasPhp`, mirroring how
  `buildJvmSuffixMap` and `buildGoModuleInfo` are wired.
- **`extractCalleeNamePhp()`** (`graph-symbols.ts`) — takes the identifier immediately before the call's opening
  parenthesis, so receiver depth is irrelevant. Used by `extractFromPhp` in place of `extractCalleeNameJs`; JS/TS and the
  nine other languages using the JS extractor are untouched.

| Expression               | Old      | New             |
|--------------------------|----------|-----------------|
| `Mail::to($e->email)`    | `null`   | `to`            |
| `$this->svc->doIt($a)`   | `null`   | `doIt`          |
| `Foo::bar(Baz::qux($v))` | `null`   | `bar` and `qux` |
| `strlen($x)`             | `strlen` | `strlen`        |

- **`DEVELOPER.md`** — documents PHP PSR-4 resolution in the `RESOLVE IMPORTS` pipeline, alongside the existing tsconfig
  alias and SCSS partial entries.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test coverage improvement

## Testing

- [x] Unit tests pass (`npm run test:unit`) — 1,037 tests / 48 files
- [x] Integration tests pass (`npm run test:integration`) — 167 tests / 10 files
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] New tests added for new/changed functionality

`tests/unit/graph-resolution-php-psr4.test.ts` (9) — cross-package resolution, longest-prefix, case-mismatched directory,
`vendor/` exclusion, `.socraticodeignore` respected, `autoload-dev`, conventional layout still works, unknown namespace
returns null, no-`composer.json` no-op.

`tests/unit/graph-symbols-php-calls.test.ts` (6) — static, chained instance, fully qualified, plain function, realistic
method body, single-callee regression guard.

Both mutation-checked: reverting `extractCalleeNamePhp` to `extractCalleeNameJs` fails 5 of 6 (the `strlen` case
correctly still passes, since bare function calls always worked); removing the PSR-4 map fails the cross-package cases.

**Note for reviewers:** PHP is a dynamically registered grammar, so the call-site test calls `ensureDynamicLanguages()`
in `beforeAll`. Without it `parse("php")` throws, `safeFindAll` swallows it, and every assertion compares against `[]` —
passing while testing nothing. I hit exactly that while writing this, which is worth knowing for any future test
touching a dynamic grammar.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate
- [x] I have updated documentation (README.md / DEVELOPER.md) if needed
- [x] I have addressed all [CodeRabbit](https://coderabbit.ai) review comments (or marked as resolved with explanation)
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

### Performance note

`buildPhpPsr4Map` costs ~3.9s on the 3,454-file repo, of which 1.3–2.4s is `createIgnoreFilter` (its nested-`.gitignore`
walk) — the same cost `findGoModFiles` already pays for Go. Gated on `hasPhp`, so non-PHP projects pay nothing.
Memoizing `createIgnoreFilter` per project path would benefit Go, PHP, the indexer, and the watcher alike; deliberately
left out here since ignore files can change mid-session and the watcher depends on fresh reads.

### Not addressed

PHP call extraction also picks up `declare(...)`, method *declarations*, and words followed by parens inside comments. I
verified old and new extractors behave identically on all of those, so this PR neither adds nor removes that noise.
Worth a separate issue.

## Related issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved PHP project analysis using Composer PSR-4 mappings from production and development autoload configurations.
  * Improved recognition of PHP instance, static, chained, and function calls.

* **Bug Fixes**
  * Added fallback handling for unresolved namespaces and malformed Composer configurations.
  * Improved resolution for nested namespaces, case variations, and supported project layouts.

* **Tests**
  * Added coverage for PHP namespace resolution and call-site detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->