### PR TITLE
fix(graph): name Ruby calls from the grammar's method field

### DIFF
--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -1220,7 +1220,17 @@ function extractFromRuby(
 
   const rawCalls: ExtractedSymbols["rawCalls"] = [];
   for (const node of safeFindAll(root, "call")) {
-    const calleeName = extractCalleeNameJs(node.text());
+    // Ask the grammar, not the text. tree-sitter-ruby's `call` node carries the
+    // callee in its `method` field for every call shape — parenthesised or not,
+    // command style (`has_many :posts`), safe navigation (`a&.b`), block calls,
+    // and each link of a fluent chain as its own node. The previous
+    // extractCalleeNameJs(text) parse required a `(` before the name, so every
+    // parenthesis-less call — the dominant Ruby idiom — was silently dropped
+    // and Ruby files contributed almost no call edges. (A bare receiverless,
+    // argumentless `helper` parses as a plain identifier, indistinguishable
+    // from a variable read, so it is not a `call` node and stays out.)
+    const methodNode = node.field("method");
+    const calleeName = methodNode ? methodNode.text() : extractCalleeNameJs(node.text());
     if (!calleeName) continue;
     const r = node.range();
     const callLine = r.start.line + 1;

--- a/tests/unit/graph-symbols-ruby-calls.test.ts
+++ b/tests/unit/graph-symbols-ruby-calls.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import { beforeAll, describe, expect, it } from "vitest";
+import { ensureDynamicLanguages } from "../../src/services/code-graph.js";
+import { extractSymbolsAndCalls } from "../../src/services/graph-symbols.js";
+
+/**
+ * Ruby call edges. `extractFromRuby` collects `call` nodes, but used to name
+ * them with the JavaScript extractor, which requires a `(` before the callee.
+ * Ruby lets you omit parentheses, and idiomatic Ruby overwhelmingly does —
+ * Rails DSL (`has_many :posts`), callbacks (`run_callbacks :save`), plain
+ * receiver calls (`logger.info msg`). All of those resolved to null and were
+ * dropped, so Ruby files contributed almost no call edges and
+ * `codebase_impact` under-reported callers throughout Ruby codebases. The
+ * callee now comes from the grammar's `method` field, which names every call
+ * shape.
+ */
+describe("Ruby call-site extraction", () => {
+  // Ruby is a dynamically-registered ast-grep grammar. Without this the parse
+  // throws, `safeFindAll` swallows it, and every assertion sees an empty list —
+  // a silent pass-by-vacuum rather than a failure.
+  beforeAll(() => ensureDynamicLanguages());
+
+  const callsIn = (rb: string): string[] => {
+    // Signature is (source, lang, ext, relativePath) — see the PHP suite for
+    // why the argument order matters to what is actually tested.
+    const { rawCalls } = extractSymbolsAndCalls(rb, "ruby", ".rb", "t.rb");
+    return rawCalls.map((c) => c.calleeName);
+  };
+
+  it("names a parenthesis-less receiver call", () => {
+    const calls = callsIn("logger.info 'saved'\n");
+    expect(calls).toEqual(["info"]);
+  });
+
+  it("names a command-style DSL call with a symbol argument", () => {
+    const calls = callsIn("class User\n  has_many :posts\n  validates :name\nend\n");
+    expect(calls).toHaveLength(2);
+    expect(calls.sort()).toEqual(["has_many", "validates"]);
+  });
+
+  it("still names parenthesised calls exactly as before", () => {
+    const calls = callsIn("class A\n  def run\n    helper()\n    obj.method(1)\n  end\nend\n");
+    expect(calls).toHaveLength(2);
+    expect(calls.sort()).toEqual(["helper", "method"]);
+  });
+
+  it("names each link of a fluent chain as its own call", () => {
+    const calls = callsIn("Model.where(x: 1).order(:y).first\n");
+    // One call node per link — the count matters: a first-`(`-based parse
+    // would collapse or drop links.
+    expect(calls).toHaveLength(3);
+    expect(calls.sort()).toEqual(["first", "order", "where"]);
+  });
+
+  it("names a block call and the calls inside the block", () => {
+    const calls = callsIn("items.each do |i|\n  process i\nend\n");
+    expect(calls).toHaveLength(2);
+    expect(calls.sort()).toEqual(["each", "process"]);
+  });
+
+  it("names a safe-navigation call", () => {
+    expect(callsIn("user&.destroy\n")).toEqual(["destroy"]);
+  });
+
+  it("attributes calls to the enclosing method scope", () => {
+    const src = "class User\n  def save!\n    run_callbacks :save\n  end\nend\n";
+    const { rawCalls } = extractSymbolsAndCalls(src, "ruby", ".rb", "user.rb");
+    expect(rawCalls).toHaveLength(1);
+    expect(rawCalls[0].calleeName).toBe("run_callbacks");
+    expect(rawCalls[0].callerId).toContain("save!");
+  });
+
+  it("does not invent a call for a bare identifier (grammar-ambiguous with a variable read)", () => {
+    // `helper` with no receiver, no args and no parens parses as a plain
+    // identifier. Recording it would fabricate edges from every variable
+    // mention, which is worse than the missing edge.
+    expect(callsIn("helper\n")).toEqual([]);
+  });
+
+  it("captures every call in a realistic Rails-style body, with counts", () => {
+    const src = [
+      "class User",
+      "  has_many :posts",
+      "  validates :name",
+      "  def save!",
+      "    run_callbacks :save",
+      "    persist(self)",
+      "    logger.info 'saved'",
+      "  end",
+      "end",
+      "",
+    ].join("\n");
+    const calls = callsIn(src);
+    // Count, not just the distinct set: duplicates or dropped links would
+    // otherwise pass unnoticed (same lesson as the PHP suite).
+    expect(calls).toHaveLength(5);
+    expect(calls.sort()).toEqual(["has_many", "info", "persist", "run_callbacks", "validates"]);
+  });
+});


### PR DESCRIPTION
## Summary

Ruby is the second language whose call sites were named by the JavaScript extractor, and it loses even more than PHP did (#101): `extractCalleeNameJs` locates the callee as the identifier before a `(`, and idiomatic Ruby overwhelmingly omits parentheses — Rails DSL declarations (`has_many :posts`), callbacks (`run_callbacks :save`), plain receiver calls (`logger.info msg`). Every one of those resolved to `null` and was silently dropped, so Ruby files contributed almost no call edges and `codebase_impact` under-reported callers throughout Ruby codebases.

Measured on a Rails-style class body containing `has_many`, `validates`, `run_callbacks`, `logger.info` and one parenthesised `persist()`: **before, only `persist` was extracted; after, all five.**

## The fix

Take the callee from the `call` node's **`method` field** instead of parsing text: tree-sitter-ruby names it for every call shape — parenthesised or not, command style, safe navigation (`a&.b`), block calls, and each link of a fluent chain as its own node. The JS text parse remains only as a fallback when the field is absent. Structural beats textual here; there is no bracket-matching to get wrong.

## Known limitation (grammar-level, documented in the code)

A bare receiverless, argumentless call (`helper` alone on a line) parses as a plain `identifier`, indistinguishable from a variable read, so it is not a `call` node and still produces no edge. Recording it would fabricate edges from every variable mention, which is worse than the missing edge.

## Backwards compatibility

- Every other language produces **byte-identical** extraction output (diffed against `main` with fixtures for ts/py/go/php/java): only the Ruby path changes.
- More Ruby names now reach `resolveCallSites`; names with no in-project definition (DSL methods like `has_many`) resolve to `unresolved` exactly as unknown names always have.

## Testing

- 9 new tests in `tests/unit/graph-symbols-ruby-calls.test.ts`: paren-less receiver calls, command-style DSL, parenthesised calls unchanged, fluent chains (with counts — each link its own call), block calls, safe navigation, scope attribution, the bare-identifier non-case, and a realistic Rails body asserting count and set
- **Mutation-checked**: reverting to the text parse fails 7 of the 9
- `tsc` clean, biome clean, full unit suite passes
- Adversarially verified in an isolated worktree (heredocs, string interpolation, `save!`/`valid?` names, setter sends, endless methods): no wrong-name cases found


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ruby call detection so more kinds of method calls are recognized, including command-style calls, safe navigation, block calls, fluent chains, and parenthesis-less usage.
  * Preserved existing behavior when detailed call information is unavailable, reducing missed results in Ruby code analysis.

* **Tests**
  * Added broader coverage for Ruby call extraction, including common Rails-style and DSL patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->