### PR TITLE
fix(graph): stop one class from erasing a plain-JS file's symbol graph

### DIFF
--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -44,6 +44,26 @@ function safeFindAll(node: any, kind: string): any[] {
   }
 }
 
+/**
+ * Single-node counterpart of {@link safeFindAll}. ast-grep REJECTS a kind the
+ * grammar does not define — it throws rather than returning null — so a direct
+ * `node.find({rule:{kind}})` written with a `?? find(otherKind)` fallback never
+ * reaches its fallback on the grammars that need it. The concrete casualty:
+ * `.js`/`.jsx`/`.mjs`/`.cjs` all parse with the JavaScript grammar, which has
+ * no `type_identifier`, so one `class` in a plain-JS file aborted the whole
+ * extraction and the file contributed a bare module symbol and zero calls.
+ * Returning null keeps every existing fallback chain meaningful.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+function safeFind(node: any, kind: string): any | null {
+  if (!node) return null;
+  try {
+    return node.find({ rule: { kind } }) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 interface ScopeFrame {
   name: string;
   /** Line at which this scope begins (used to limit call-site attribution). */
@@ -574,8 +594,15 @@ function extractFromTsLike(
 
   // Class declarations
   for (const node of safeFindAll(root, "class_declaration")) {
-    const nameNode = node.find({ rule: { kind: "type_identifier" } })
-      ?? node.find({ rule: { kind: "identifier" } });
+    // The name FIELD, not a subtree search: safeFind's recursive DFS reaches a
+    // decorator's identifier before the class's own name, so `@sealed class X`
+    // would extract as a class named `sealed` and collide with the real
+    // decorator function at resolution time. The field is grammar-precise on
+    // JS (identifier) and TS/TSX (type_identifier) alike; the searches remain
+    // only as a belt for grammars without the field.
+    const nameNode = node.field("name")
+      ?? safeFind(node, "type_identifier")
+      ?? safeFind(node, "identifier");
     if (!nameNode) continue;
     const name = nameNode.text();
     const range = node.range();
@@ -588,9 +615,26 @@ function extractFromTsLike(
     symbols.push(sym);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
 
-    // Methods inside the class
-    for (const m of safeFindAll(node, "method_definition")) {
-      const mName = m.find({ rule: { kind: "property_identifier" } })?.text();
+    // Methods inside the class — DIRECT children of the class body only. A
+    // recursive scan fabricates phantom methods: an object-literal shorthand
+    // handler inside a field initializer or a call argument, or a nested
+    // class's methods, would all be stamped onto THIS class and persisted into
+    // the name index, corrupting name-based resolution and impact seeds.
+    const body = node.field("body");
+    // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+    let members: any[] = [];
+    try {
+      // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+      members = body ? body.children().filter((c: any) => c.kind() === "method_definition") : [];
+    } catch {
+      members = [];
+    }
+    for (const m of members) {
+      // Name from the field, accepting only a literal property name: a
+      // computed name like `[Symbol.iterator]` has no static identity, and
+      // searching inside it used to persist a method that does not exist.
+      const mNameNode = m.field("name");
+      const mName = mNameNode?.kind() === "property_identifier" ? mNameNode.text() : null;
       if (!mName) continue;
       const mr = m.range();
       const mStart = mr.start.line + 1;
@@ -609,7 +653,7 @@ function extractFromTsLike(
 
   // Top-level function declarations
   for (const node of safeFindAll(root, "function_declaration")) {
-    const nameNode = node.find({ rule: { kind: "identifier" } });
+    const nameNode = safeFind(node, "identifier");
     if (!nameNode) continue;
     const name = nameNode.text();
     const r = node.range();
@@ -625,7 +669,7 @@ function extractFromTsLike(
 
   // Generator function declarations
   for (const node of safeFindAll(root, "generator_function_declaration")) {
-    const nameNode = node.find({ rule: { kind: "identifier" } });
+    const nameNode = safeFind(node, "identifier");
     if (!nameNode) continue;
     const name = nameNode.text();
     const r = node.range();
@@ -642,11 +686,11 @@ function extractFromTsLike(
   // Named arrow functions: `const foo = (...) => {...}` or `const foo = function(...) {...}`
   for (const node of safeFindAll(root, "lexical_declaration")) {
     for (const decl of safeFindAll(node, "variable_declarator")) {
-      const idNode = decl.find({ rule: { kind: "identifier" } });
+      const idNode = safeFind(decl, "identifier");
       if (!idNode) continue;
       const name = idNode.text();
-      const arrow = decl.find({ rule: { kind: "arrow_function" } });
-      const fnExpr = decl.find({ rule: { kind: "function_expression" } });
+      const arrow = safeFind(decl, "arrow_function");
+      const fnExpr = safeFind(decl, "function_expression");
       const fn = arrow ?? fnExpr;
       if (!fn) continue;
       const r = fn.range();
@@ -759,7 +803,7 @@ function extractFromPython(
 
   // Classes
   for (const cls of safeFindAll(root, "class_definition")) {
-    const nameNode = cls.find({ rule: { kind: "identifier" } });
+    const nameNode = safeFind(cls, "identifier");
     if (!nameNode) continue;
     const className = nameNode.text();
     const r = cls.range();
@@ -774,7 +818,7 @@ function extractFromPython(
 
     // Methods
     for (const fn of safeFindAll(cls, "function_definition")) {
-      const fnName = fn.find({ rule: { kind: "identifier" } })?.text();
+      const fnName = safeFind(fn, "identifier")?.text();
       if (!fnName) continue;
       const fr = fn.range();
       const fStart = fr.start.line + 1;
@@ -793,7 +837,7 @@ function extractFromPython(
 
   // Top-level functions (those not nested inside classes)
   for (const fn of safeFindAll(root, "function_definition")) {
-    const fnName = fn.find({ rule: { kind: "identifier" } })?.text();
+    const fnName = safeFind(fn, "identifier")?.text();
     if (!fnName) continue;
     const r = fn.range();
     const startLine = r.start.line + 1;
@@ -837,7 +881,7 @@ function extractFromGo(
   const scopes: ScopeFrame[] = [];
 
   for (const fn of safeFindAll(root, "function_declaration")) {
-    const nameNode = fn.find({ rule: { kind: "identifier" } });
+    const nameNode = safeFind(fn, "identifier");
     if (!nameNode) continue;
     const name = nameNode.text();
     const r = fn.range();
@@ -851,7 +895,7 @@ function extractFromGo(
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
   }
   for (const fn of safeFindAll(root, "method_declaration")) {
-    const nameNode = fn.find({ rule: { kind: "field_identifier" } });
+    const nameNode = safeFind(fn, "field_identifier");
     if (!nameNode) continue;
     const name = nameNode.text();
     const r = fn.range();
@@ -892,7 +936,7 @@ function extractFromRust(
   const scopes: ScopeFrame[] = [];
 
   for (const fn of safeFindAll(root, "function_item")) {
-    const nameNode = fn.find({ rule: { kind: "identifier" } });
+    const nameNode = safeFind(fn, "identifier");
     if (!nameNode) continue;
     const name = nameNode.text();
     const r = fn.range();
@@ -918,7 +962,7 @@ function extractFromRust(
     });
   }
   for (const node of safeFindAll(root, "macro_invocation")) {
-    const nameNode = node.find({ rule: { kind: "identifier" } });
+    const nameNode = safeFind(node, "identifier");
     if (!nameNode) continue;
     const r = node.range();
     const callLine = r.start.line + 1;
@@ -1053,7 +1097,7 @@ function extractFromCSharp(
 
   for (const k of ["class_declaration", "interface_declaration", "record_declaration", "struct_declaration"]) {
     for (const cls of safeFindAll(root, k)) {
-      const nameNode = cls.find({ rule: { kind: "identifier" } });
+      const nameNode = safeFind(cls, "identifier");
       if (!nameNode) continue;
       const name = nameNode.text();
       const r = cls.range();
@@ -1072,7 +1116,7 @@ function extractFromCSharp(
   }
   for (const k of ["method_declaration", "constructor_declaration"]) {
     for (const m of safeFindAll(root, k)) {
-      const nameNode = m.find({ rule: { kind: "identifier" } });
+      const nameNode = safeFind(m, "identifier");
       if (!nameNode) continue;
       const name = nameNode.text();
       const r = m.range();
@@ -1119,7 +1163,7 @@ function extractFromCFamily(
   if (langKey === "cpp") {
     for (const k of ["class_specifier", "struct_specifier"]) {
       for (const cls of safeFindAll(root, k)) {
-        const nameNode = cls.find({ rule: { kind: "type_identifier" } });
+        const nameNode = safeFind(cls, "type_identifier");
         if (!nameNode) continue;
         const name = nameNode.text();
         const r = cls.range();
@@ -1138,9 +1182,9 @@ function extractFromCFamily(
   }
 
   for (const fn of safeFindAll(root, "function_definition")) {
-    const declarator = fn.find({ rule: { kind: "function_declarator" } });
-    const nameNode = declarator?.find({ rule: { kind: "identifier" } })
-      ?? declarator?.find({ rule: { kind: "qualified_identifier" } });
+    const declarator = safeFind(fn, "function_declarator");
+    const nameNode = safeFind(declarator, "identifier")
+      ?? safeFind(declarator, "qualified_identifier");
     if (!nameNode) continue;
     const fullName = nameNode.text();
     const name = fullName.split("::").pop() ?? fullName;
@@ -1185,8 +1229,8 @@ function extractFromRuby(
 
   for (const k of ["class", "module"]) {
     for (const cls of safeFindAll(root, k)) {
-      const nameNode = cls.find({ rule: { kind: "constant" } })
-        ?? cls.find({ rule: { kind: "identifier" } });
+      const nameNode = safeFind(cls, "constant")
+        ?? safeFind(cls, "identifier");
       if (!nameNode) continue;
       const name = nameNode.text();
       const r = cls.range();
@@ -1203,7 +1247,7 @@ function extractFromRuby(
     }
   }
   for (const m of safeFindAll(root, "method")) {
-    const nameNode = m.find({ rule: { kind: "identifier" } });
+    const nameNode = safeFind(m, "identifier");
     if (!nameNode) continue;
     const name = nameNode.text();
     const r = m.range();
@@ -1256,7 +1300,7 @@ function extractFromPhp(
 
   for (const k of ["class_declaration", "interface_declaration", "trait_declaration"]) {
     for (const cls of safeFindAll(root, k)) {
-      const nameNode = cls.find({ rule: { kind: "name" } });
+      const nameNode = safeFind(cls, "name");
       if (!nameNode) continue;
       const name = nameNode.text();
       const r = cls.range();
@@ -1274,7 +1318,7 @@ function extractFromPhp(
   }
   for (const k of ["function_definition", "method_declaration"]) {
     for (const m of safeFindAll(root, k)) {
-      const nameNode = m.find({ rule: { kind: "name" } });
+      const nameNode = safeFind(m, "name");
       if (!nameNode) continue;
       const name = nameNode.text();
       const r = m.range();
@@ -1321,8 +1365,8 @@ function extractFromSwift(
 
   for (const k of ["class_declaration", "struct_declaration", "protocol_declaration", "enum_declaration"]) {
     for (const cls of safeFindAll(root, k)) {
-      const nameNode = cls.find({ rule: { kind: "type_identifier" } })
-        ?? cls.find({ rule: { kind: "identifier" } });
+      const nameNode = safeFind(cls, "type_identifier")
+        ?? safeFind(cls, "identifier");
       if (!nameNode) continue;
       const name = nameNode.text();
       const r = cls.range();
@@ -1341,8 +1385,8 @@ function extractFromSwift(
     }
   }
   for (const fn of safeFindAll(root, "function_declaration")) {
-    const nameNode = fn.find({ rule: { kind: "simple_identifier" } })
-      ?? fn.find({ rule: { kind: "identifier" } });
+    const nameNode = safeFind(fn, "simple_identifier")
+      ?? safeFind(fn, "identifier");
     if (!nameNode) continue;
     const name = nameNode.text();
     const r = fn.range();
@@ -1384,7 +1428,7 @@ function extractFromBash(
   const scopes: ScopeFrame[] = [];
 
   for (const fn of safeFindAll(root, "function_definition")) {
-    const nameNode = fn.find({ rule: { kind: "word" } });
+    const nameNode = safeFind(fn, "word");
     if (!nameNode) continue;
     const name = nameNode.text();
     const r = fn.range();
@@ -1401,7 +1445,7 @@ function extractFromBash(
 
   const rawCalls: ExtractedSymbols["rawCalls"] = [];
   for (const node of safeFindAll(root, "command")) {
-    const nameNode = node.find({ rule: { kind: "command_name" } });
+    const nameNode = safeFind(node, "command_name");
     if (!nameNode) continue;
     const name = nameNode.text();
     if (!/^[A-Za-z_][\w]*$/.test(name)) continue;

--- a/tests/unit/graph-symbols-js-classes.test.ts
+++ b/tests/unit/graph-symbols-js-classes.test.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import { Lang } from "@ast-grep/napi";
+import { beforeAll, describe, expect, it } from "vitest";
+import { ensureDynamicLanguages } from "../../src/services/code-graph.js";
+import { extractSymbolsAndCalls, resetSymbolExtractionWarnings } from "../../src/services/graph-symbols.js";
+
+/**
+ * Plain-JS files with a `class` used to contribute a bare module symbol and
+ * zero call edges. The class-name lookup asked for `type_identifier`, a kind
+ * the TypeScript grammar defines and the JavaScript grammar does not — and
+ * ast-grep throws on an unknown kind rather than returning null, so the
+ * `?? identifier` fallback written for exactly this case never ran; the throw
+ * escaped to the outer catch, which discarded the whole file's extraction.
+ * `.js`, `.jsx`, `.mjs` and `.cjs` all parse with the JavaScript grammar, so
+ * every plain-JS codebase with classes silently lost its symbol graph.
+ */
+describe("plain-JS class extraction", () => {
+  beforeAll(() => {
+    ensureDynamicLanguages();
+    resetSymbolExtractionWarnings();
+  });
+
+  const JS_WITH_CLASS = [
+    "function alpha() { return beta(); }",
+    "function beta() { return 1; }",
+    "class Gamma {",
+    "  constructor() { this.n = 0; }",
+    "  run() { return alpha(); }",
+    "}",
+    "alpha();",
+  ].join("\n");
+
+  it("extracts the class, its methods, and the surrounding functions", () => {
+    const { symbols } = extractSymbolsAndCalls(JS_WITH_CLASS, Lang.JavaScript, ".js", "f.js");
+    const names = symbols.map((s) => s.qualifiedName);
+    expect(names).toContain("Gamma");
+    expect(names).toContain("Gamma.run");
+    expect(names).toContain("Gamma.constructor");
+    expect(names).toContain("alpha");
+    expect(names).toContain("beta");
+  });
+
+  it("keeps the call edges a class used to destroy", () => {
+    const { rawCalls } = extractSymbolsAndCalls(JS_WITH_CLASS, Lang.JavaScript, ".js", "f.js");
+    // The exact loss mode was zero calls for the entire file.
+    expect(rawCalls.length).toBeGreaterThanOrEqual(3);
+    const names = rawCalls.map((c) => c.calleeName);
+    expect(names).toContain("alpha");
+    expect(names).toContain("beta");
+  });
+
+  it("attributes a call inside a method to that method, not the module", () => {
+    const { symbols, rawCalls } = extractSymbolsAndCalls(JS_WITH_CLASS, Lang.JavaScript, ".js", "f.js");
+    const run = symbols.find((s) => s.qualifiedName === "Gamma.run");
+    const fromRun = rawCalls.find((c) => c.calleeName === "alpha" && c.callerId === run?.id);
+    expect(fromRun).toBeDefined();
+  });
+
+  it("names a decorated class by its own name, not its decorator's", () => {
+    // A recursive search reaches the decorator's identifier first, so this
+    // used to extract as a class named `sealed`.
+    const src = "function sealed(c) { return c; }\n@sealed\nclass DecoTarget {\n  go() { return 1; }\n}\n";
+    const { symbols } = extractSymbolsAndCalls(src, Lang.JavaScript, ".js", "f.js");
+    const names = symbols.map((s) => s.qualifiedName);
+    expect(names).toContain("DecoTarget");
+    expect(names).toContain("DecoTarget.go");
+    expect(symbols.filter((s) => s.name === "sealed" && s.kind === "class")).toHaveLength(0);
+  });
+
+  it("does not stamp object-literal handlers onto the class as methods", () => {
+    // Shorthand methods in a field initializer are the dominant plain-JS
+    // handler idiom; a subtree scan persisted them as phantom class methods.
+    const src = [
+      "class Config {",
+      "  handlers = { onDone() { return 1; }, onFail() { return 2; } };",
+      "  real() { return 3; }",
+      "}",
+    ].join("\n");
+    const { symbols } = extractSymbolsAndCalls(src, Lang.JavaScript, ".js", "f.js");
+    const names = symbols.map((s) => s.qualifiedName);
+    expect(names).toContain("Config.real");
+    expect(names).not.toContain("Config.onDone");
+    expect(names).not.toContain("Config.onFail");
+  });
+
+  it("does not double-stamp a nested class's methods onto the outer class", () => {
+    const src = [
+      "class Outer {",
+      "  make() { return class Inner { innerRun() { return 1; } }; }",
+      "}",
+    ].join("\n");
+    const { symbols } = extractSymbolsAndCalls(src, Lang.JavaScript, ".js", "f.js");
+    const names = symbols.map((s) => s.qualifiedName);
+    expect(names).toContain("Outer.make");
+    expect(names).not.toContain("Outer.innerRun");
+  });
+
+  it("skips a computed method name instead of persisting a name that does not exist", () => {
+    const src = "class Members {\n  [Symbol.iterator]() { return null; }\n  real() { return 1; }\n}\n";
+    const { symbols } = extractSymbolsAndCalls(src, Lang.JavaScript, ".js", "f.js");
+    const names = symbols.map((s) => s.qualifiedName);
+    expect(names).toContain("Members.real");
+    expect(names).not.toContain("Members.iterator");
+  });
+
+  it("still extracts TypeScript classes through the type_identifier path", () => {
+    // The TS grammar DOES define type_identifier; the guard must not have
+    // changed which node names a TS class.
+    const ts = "class Keeper { move(): number { return help(); } }\nfunction help(): number { return 1; }\n";
+    const { symbols } = extractSymbolsAndCalls(ts, Lang.TypeScript, ".ts", "f.ts");
+    const keeper = symbols.find((s) => s.qualifiedName === "Keeper");
+    expect(keeper).toBeDefined();
+    expect(keeper?.kind).toBe("class");
+    expect(symbols.map((s) => s.qualifiedName)).toContain("Keeper.move");
+  });
+
+  it("handles an anonymous class expression without inventing a name", () => {
+    // No name field, no identifier of its own: must be skipped, not crash and
+    // not steal the name of something nearby.
+    const src = "const x = class { m() { return 1; } };\nfunction real() { return 2; }\n";
+    const { symbols } = extractSymbolsAndCalls(src, Lang.JavaScript, ".js", "f.js");
+    expect(symbols.map((s) => s.qualifiedName)).toContain("real");
+  });
+});


### PR DESCRIPTION
## Summary

A single `class` anywhere in a plain-JS file (`.js`, `.jsx`, `.mjs`, `.cjs`) erased the file's entire contribution to the symbol graph: one bare `<module>` symbol, zero call edges, at most one warn per process. Plain-JS codebases silently got an almost-empty symbol graph, and `codebase_impact` had nothing to answer with — the same user-visible symptom PHP (#101) and Ruby (#103) had, by a third mechanism.

**Root cause:** ast-grep **throws** on a node kind the grammar does not define, rather than returning null. The class-name lookup asked for `type_identifier` first — a kind only the TypeScript grammar has — with an `?? identifier` fallback written for exactly the JavaScript case. The throw meant that fallback never ran, and the exception escaped to the outer catch, which discarded the whole file's extraction.

Reproduced with production inputs (all four extensions map to the JavaScript grammar):

| | symbols | calls |
|---|---|---|
| JS file, functions only | `<module>, alpha, beta` | 2 |
| same file plus one class (before) | **`<module>`** | **0** |
| same file plus one class (after) | `<module>, Gamma, Gamma.run, Gamma.constructor, alpha, beta, arrow` | 3+ |

## The fix

`safeFind` — the single-node mirror of the existing `safeFindAll`, returning null for a kind the grammar rejects — applied to **all 32** direct find-by-kind sites in `graph-symbols.ts`. Several already carry `??` fallback chains that only make sense under null-on-invalid semantics; now they have them, and this class of bug cannot recur for any other grammar pair. (One latent instance it retires for free: `qualified_identifier` is invalid in the C grammar.)

Adversarial review of the newly-live JS path then surfaced **two naming defects, fixed here** in the same function:

- **A decorated class took its decorator's name.** The recursive search reached `@sealed`'s identifier before the class's own, extracting `class DecoTarget` as a class named `sealed` that collides with the real decorator function at resolution time. The name now comes from the grammar's **name field**.
- **Phantom methods.** The method scan covered the whole class subtree, so object-literal shorthand handlers in field initializers (`handlers = { onDone() {...} }` — a dominant plain-JS idiom) and nested classes' methods were stamped onto the enclosing class and persisted into the name index, corrupting name-based resolution and impact seeds. Collection is now scoped to **direct children of the class body**, and a computed name like `[Symbol.iterator]` is skipped instead of persisting a method that does not exist.

## Backwards compatibility

- **Thirteen other languages byte-identical to main**, verified fixture by fixture across every converted site (TS/TSX classes still name via `type_identifier`; Go `field_identifier`, Swift `simple_identifier` chains, C/CPP declarators, Ruby, PHP, Bash, etc. unchanged).
- No API, schema or index change. Existing graphs gain the missing JS symbols on their next rebuild.
- Known limitations documented during review, deliberately out of scope as fast-follows: class *expressions* (`const X = class {...}`, `module.exports = class {...}`) still produce no class symbol (pre-existing, also true on TS), `#private` methods get no symbols, and a syntax error near the top of a file still degrades extraction (different cause, same symptom).

## Testing

- 9 tests in `tests/unit/graph-symbols-js-classes.test.ts`: the collapse case, call-edge survival, method-scope attribution, decorated class, object-literal phantoms, nested-class phantoms, computed names, TS regression, anonymous class expression
- **Mutation-checked**: unguarded `safeFind` fails 3; DFS-first naming fails 1; recursive method scan fails 2
- `tsc` clean, biome clean, **1073 unit + 167 integration** pass
- Adversarially verified in isolated worktrees: 14-language regression sweep (byte-identical except JS), hostile-JS probes end to end through the real graph build including Qdrant persistence and impact reverse edges, and a hunk-by-hunk audit of all 32 conversions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved code symbol extraction for JavaScript, TypeScript, Ruby, and PHP.
  - Prevented unsupported syntax from interrupting extraction.
  - Reduced false positives involving decorators, nested classes, object literals, and computed method names.
  - Improved recognition of Ruby and PHP calls, including chained, namespaced, static, and instance calls.

- **Tests**
  - Added coverage for JavaScript and TypeScript class, method, and call extraction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->