### PR TITLE
fix(startup): refuse Node 26 only when the installed qdrant client breaks there

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,36 +2,38 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 
-// Pre-flight: refuse to start on Node versions known to break @qdrant/js-client-rest.
-// The qdrant client bundles its own undici ^6 and constructs an undici.Agent it passes to
-// Node's built-in fetch() as init.dispatcher. On Node 26+ the built-in fetch is undici 8,
-// whose request handler renamed the legacy `onError` hook to `onResponseError`. qdrant's
-// bundled undici 6 Agent still validates that handler for a function `onError`, does not
-// find one, and throws `UND_ERR_INVALID_ARG: invalid onError method` on the first qdrant
-// call. (It is qdrant's old undici rejecting Node 26's new handler, not Node rejecting the
-// v6 Agent.)
+// Pre-flight: refuse to start on the PAIR known to break — Node 26+ with
+// @qdrant/js-client-rest older than 1.19. Those clients bundle undici 6, whose Agent
+// (handed to Node's built-in fetch as init.dispatcher) fails Node 26's undici-8 handler
+// validation, so every qdrant call dies with `UND_ERR_INVALID_ARG: invalid onError
+// method`. Upstream fixed this in client 1.19 by moving to undici 7
+// (https://github.com/qdrant/qdrant-js/issues/134), verified working on Node 26 against a
+// live Qdrant, so Node 26+ with client >= 1.19 starts normally; a fresh install resolves
+// a >= 1.19 client on Node 26 and never sees this refusal. The refusal remains for stale
+// installs (an old lockfile pinning a pre-1.19 client) and for an undeterminable client
+// version, where booting would trade this message for the opaque undici error later.
 //
 // This runtime guard is deliberately the ONLY gate. Do NOT add an upper bound to
 // `engines.node` in package.json. An upper bound is actively harmful here: a bare
 // `npx socraticode` install resolves a version range, and npm engine-filters that range,
 // so a `<26.0.0` bound makes Node 26 silently resolve to the newest version *below* the
 // bound (which predates this guard) and boot into the broken client instead of refusing.
-// With no upper bound, Node 26 installs the guarded version and hits this loud exit.
 //
 // (Imports below are evaluated before this check per ESM semantics, but qdrant-js's
 // module-init is side-effect-light: only an actual request triggers the undici path, so
 // exiting here is enough to spare users the opaque error later.)
-// Tracked upstream: https://github.com/qdrant/qdrant-js/issues/134 (PRs #123, #128).
-// Remove or relax this check when qdrant-js supports the undici bundled in Node 26+.
 const nodeMajor = Number.parseInt(process.versions.node.split(".")[0], 10);
-if (Number.isFinite(nodeMajor) && nodeMajor >= 26) {
+const installedClient = readInstalledQdrantClientVersion();
+if (qdrantClientBreaksOnThisNode(nodeMajor, installedClient)) {
   // fs.writeSync(2, …) is the canonical Node idiom for "print fatal error then die":
   // blocking (no truncation when stderr is piped — every MCP host pipes stderr) and
   // synchronous (so process.exit(1) runs before any further top-level code).
   const msg =
-    `socraticode: Node ${process.versions.node} is not supported.\n` +
-    "  @qdrant/js-client-rest is incompatible with the undici bundled in Node 26+.\n" +
-    "  Use Node 22.x (via nvm: `nvm install 22 && nvm use 22`, or `brew install node@22` on macOS).\n" +
+    `socraticode: Node ${process.versions.node} needs @qdrant/js-client-rest 1.19 or newer ` +
+    `(installed: ${installedClient ?? "undeterminable"}).\n` +
+    "  Clients before 1.19 bundle an undici incompatible with Node 26+.\n" +
+    "  Reinstall socraticode (or update its lockfile) to pick up a current client,\n" +
+    "  or use Node 22.x (via nvm: `nvm install 22 && nvm use 22`).\n" +
     "  See https://github.com/qdrant/qdrant-js/issues/134.\n";
   writeSync(2, msg);
   process.exit(1);
@@ -43,6 +45,10 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { EXTENSION_LANGUAGE_MAP_INVALID, SOCRATICODE_VERSION } from "./constants.js";
 import { logger, setMcpLogSender } from "./services/logger.js";
+import {
+  qdrantClientBreaksOnThisNode,
+  readInstalledQdrantClientVersion,
+} from "./services/qdrant-client-compat.js";
 import { autoResumeIndexedProjects, gracefulShutdown } from "./services/startup.js";
 import { handleContextTool } from "./tools/context-tools.js";
 import { handleGraphTool } from "./tools/graph-tools.js";

--- a/src/services/qdrant-client-compat.ts
+++ b/src/services/qdrant-client-compat.ts
@@ -75,7 +75,11 @@ export function qdrantClientBreaksOnThisNode(
 ): boolean {
   if (!Number.isFinite(nodeMajor) || nodeMajor < 26) return false;
   if (clientVersion === null) return true;
-  const match = clientVersion.match(/^(\d+)\.(\d+)\./);
+  // Full semver shape required (prerelease/build tags allowed): a partial
+  // match like `1.19.not-a-version` is NOT a version the registry could
+  // have served, so it fails closed with every other unparseable string
+  // rather than being half-read as a 1.19.
+  const match = clientVersion.match(/^(\d+)\.(\d+)\.\d+(?:[-+].*)?$/);
   if (!match) return true;
   const major = Number.parseInt(match[1], 10);
   const minor = Number.parseInt(match[2], 10);

--- a/src/services/qdrant-client-compat.ts
+++ b/src/services/qdrant-client-compat.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+/**
+ * Support facts this module encodes (each verified by running the client
+ * against a live Qdrant on the real Node majors):
+ *
+ *   - @qdrant/js-client-rest < 1.19 bundles undici 6, whose Agent the client
+ *     hands to Node's built-in fetch. Node 26's built-in fetch (undici 8)
+ *     renamed the legacy `onError` handler hook, so the v6 Agent fails
+ *     validation and every request dies with
+ *     `UND_ERR_INVALID_ARG: invalid onError method`.
+ *   - 1.19+ bundles undici 7 and works on Node 26+
+ *     (https://github.com/qdrant/qdrant-js/issues/134, fixed in 1.19).
+ *
+ * So "does this process break?" is a property of the PAIR (node major,
+ * installed client version), not of the Node version alone. The startup
+ * guard in index.ts uses these helpers to refuse only the pair that
+ * actually breaks.
+ */
+
+const QDRANT_CLIENT_PACKAGE = "@qdrant/js-client-rest";
+
+/**
+ * Version of the installed @qdrant/js-client-rest, or null when it cannot
+ * be determined.
+ *
+ * The package's `exports` map exposes only `.`, so
+ * `require("@qdrant/js-client-rest/package.json")` throws
+ * ERR_PACKAGE_PATH_NOT_EXPORTED; instead the entry file is resolved and the
+ * walk goes upward to the nearest package.json that declares the package's
+ * own name (the entry sits inside dist/, whose parent directories may hold
+ * unrelated package.json files, hence the name check).
+ */
+export function readInstalledQdrantClientVersion(): string | null {
+  let entry: string;
+  try {
+    entry = createRequire(import.meta.url).resolve(QDRANT_CLIENT_PACKAGE);
+  } catch {
+    return null; // not installed / not resolvable from here
+  }
+  let dir = path.dirname(entry);
+  // Walk toward the filesystem root; the package root is at most a few
+  // levels above the entry file.
+  for (;;) {
+    try {
+      const parsed = JSON.parse(readFileSync(path.join(dir, "package.json"), "utf8"));
+      if (parsed?.name === QDRANT_CLIENT_PACKAGE && typeof parsed.version === "string") {
+        return parsed.version;
+      }
+    } catch {
+      // no package.json at this level (or unreadable/malformed) — keep walking
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * Whether the (node major, installed client version) pair is the one that
+ * breaks: Node 26+ with a client older than 1.19.
+ *
+ * An undeterminable version on Node 26+ refuses too (returns true): the
+ * alternative is booting into a possibly-broken client whose first request
+ * dies with an opaque undici error, which is exactly what the guard exists
+ * to prevent. On Node < 26 the client version is irrelevant.
+ */
+export function qdrantClientBreaksOnThisNode(
+  nodeMajor: number,
+  clientVersion: string | null,
+): boolean {
+  if (!Number.isFinite(nodeMajor) || nodeMajor < 26) return false;
+  if (clientVersion === null) return true;
+  const match = clientVersion.match(/^(\d+)\.(\d+)\./);
+  if (!match) return true;
+  const major = Number.parseInt(match[1], 10);
+  const minor = Number.parseInt(match[2], 10);
+  return major < 1 || (major === 1 && minor < 19);
+}

--- a/tests/unit/qdrant-client-compat.test.ts
+++ b/tests/unit/qdrant-client-compat.test.ts
@@ -61,8 +61,10 @@ describe("qdrant-client-compat", () => {
       // UND_ERR_INVALID_ARG at the first qdrant call.
       expect(qdrantClientBreaksOnThisNode(26, null)).toBe(true);
       expect(qdrantClientBreaksOnThisNode(26, "not-a-version")).toBe(true);
-      // A half-valid string must not be half-read as its leading 1.19.
+      // A half-valid string must not be half-read as its leading 1.19,
+      // whether the garbage starts at the patch or trails after it.
       expect(qdrantClientBreaksOnThisNode(26, "1.19.not-a-version")).toBe(true);
+      expect(qdrantClientBreaksOnThisNode(26, "1.19.0garbage")).toBe(true);
     });
 
     it("reads prerelease and build-metadata versions normally", () => {

--- a/tests/unit/qdrant-client-compat.test.ts
+++ b/tests/unit/qdrant-client-compat.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  qdrantClientBreaksOnThisNode,
+  readInstalledQdrantClientVersion,
+} from "../../src/services/qdrant-client-compat.js";
+
+/**
+ * The startup guard refuses only the PAIR that breaks: Node 26+ with
+ * @qdrant/js-client-rest < 1.19 (undici 6 vs Node 26's fetch). These tests
+ * pin the pair logic and the version reader; getting either wrong turns the
+ * guard back into what it replaced — a blanket Node 26 refusal that turns
+ * away working installs, or a silent boot into a client whose first request
+ * dies with an opaque undici error.
+ */
+describe("qdrant-client-compat", () => {
+  describe("readInstalledQdrantClientVersion", () => {
+    it("reads the version of the actually installed client", () => {
+      // The package's exports map exposes only ".", so the reader resolves
+      // the entry and walks up; the result must equal what node_modules
+      // really contains, not a guess.
+      const expected = JSON.parse(
+        fs.readFileSync(
+          path.join(process.cwd(), "node_modules/@qdrant/js-client-rest/package.json"),
+          "utf8",
+        ),
+      ).version;
+
+      expect(readInstalledQdrantClientVersion()).toBe(expected);
+    });
+  });
+
+  describe("qdrantClientBreaksOnThisNode", () => {
+    it("never breaks below Node 26, whatever the client", () => {
+      for (const version of ["1.18.0", "1.19.0", null]) {
+        for (const major of [18, 20, 22, 24, 25]) {
+          expect(qdrantClientBreaksOnThisNode(major, version), `${major}/${version}`).toBe(false);
+        }
+      }
+    });
+
+    it("breaks on Node 26+ with a pre-1.19 client", () => {
+      expect(qdrantClientBreaksOnThisNode(26, "1.18.0")).toBe(true);
+      expect(qdrantClientBreaksOnThisNode(26, "1.17.0")).toBe(true);
+      expect(qdrantClientBreaksOnThisNode(27, "1.18.5")).toBe(true);
+    });
+
+    it("does not break on Node 26+ with 1.19 or newer", () => {
+      // The whole point of the versioned guard: a working install must not
+      // be turned away.
+      expect(qdrantClientBreaksOnThisNode(26, "1.19.0")).toBe(false);
+      expect(qdrantClientBreaksOnThisNode(26, "1.20.3")).toBe(false);
+      expect(qdrantClientBreaksOnThisNode(27, "2.0.0")).toBe(false);
+    });
+
+    it("fails closed on Node 26+ when the version is unknown or unparseable", () => {
+      // Booting anyway would trade the guard's clear message for the opaque
+      // UND_ERR_INVALID_ARG at the first qdrant call.
+      expect(qdrantClientBreaksOnThisNode(26, null)).toBe(true);
+      expect(qdrantClientBreaksOnThisNode(26, "not-a-version")).toBe(true);
+    });
+
+    it("treats a non-finite node major as not breaking", () => {
+      // An unparseable process.versions.node must not brick startup on
+      // Node versions the guard was never about.
+      expect(qdrantClientBreaksOnThisNode(Number.NaN, "1.18.0")).toBe(false);
+    });
+  });
+});

--- a/tests/unit/qdrant-client-compat.test.ts
+++ b/tests/unit/qdrant-client-compat.test.ts
@@ -61,6 +61,15 @@ describe("qdrant-client-compat", () => {
       // UND_ERR_INVALID_ARG at the first qdrant call.
       expect(qdrantClientBreaksOnThisNode(26, null)).toBe(true);
       expect(qdrantClientBreaksOnThisNode(26, "not-a-version")).toBe(true);
+      // A half-valid string must not be half-read as its leading 1.19.
+      expect(qdrantClientBreaksOnThisNode(26, "1.19.not-a-version")).toBe(true);
+    });
+
+    it("reads prerelease and build-metadata versions normally", () => {
+      // The strict shape must not reject the tagged versions the registry
+      // legitimately serves.
+      expect(qdrantClientBreaksOnThisNode(26, "1.19.0-rc.1")).toBe(false);
+      expect(qdrantClientBreaksOnThisNode(26, "1.18.2+build.5")).toBe(true);
     });
 
     it("treats a non-finite node major as not breaking", () => {


### PR DESCRIPTION
## Problem

The startup guard added in #87 refuses every Node 26+ process. That was correct when every installable @qdrant/js-client-rest bundled undici 6, which fails Node 26's fetch handler validation (`UND_ERR_INVALID_ARG: invalid onError method` on the first call). Upstream fixed this in client 1.19 by moving to undici 7 ([qdrant/qdrant-js#134](https://github.com/qdrant/qdrant-js/issues/134)), and a fresh install resolves a 1.19+ client on Node 26. The guard's own docstring said to relax it when that happened; it happened, so the blanket refusal now turns away installs that work.

## Fix

The guard refuses only the pair that actually breaks: **Node 26+ with a client older than 1.19**.

- New `qdrant-client-compat` service: reads the installed client's version (resolving the entry file and walking up to its own package.json, since the package's `exports` map exposes only `.`) and a pure pair-decision function.
- Node 26+ with client >= 1.19 starts normally. Node 26+ with an older client (a stale lockfile-pinned install) or an undeterminable version gets a clear refusal telling it to reinstall or use Node 22; booting anyway would trade that message for the opaque undici error at the first Qdrant call. Below Node 26 nothing changes.
- The docstring's warning against `engines.node` upper bounds is preserved; the runtime guard stays the only gate.

## Verification

- Executed on real Node 26.7.0 containers running the built `dist/index.js`: with client 1.18.0 the process exits 1 with the new message; after `npm i --no-save @qdrant/js-client-rest@1.19.0` it starts with no refusal and shuts down cleanly on stdin close.
- The underlying compatibility matrix was executed cell by cell against a live Qdrant: client 1.18.0 works on Node 18/20/22 and fails on 26; client 1.19.0 fails on Node 18 at module load and works on 20/22/26. This change alters behavior only on Node 26+.
- Six new unit tests for the reader and pair logic; mutation-checked (an off-by-one on the 1.19 threshold and a fail-open on unknown version each fail a test). Full suite green: 1096 unit, 167 integration, tsc, biome, CodeRabbit CLI and snyk clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated startup compatibility checks to allow Node.js 26+ with Qdrant client version 1.19 or newer.
  * Added clear diagnostics for outdated, unknown, or undetectable Qdrant client versions.
  * Preserved support for earlier Node.js versions.

* **Tests**
  * Added coverage for supported, unsupported, unknown, and malformed version combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->