### PR TITLE
fix(graph): resolve Rust imports through Cargo-declared crate roots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,27 @@ jobs:
           npm init --yes
           npm install --engine-strict "$package_file"
           test -f node_modules/socraticode/dist/index.js
+
+  # The one test that asks the compiler instead of asserting what we believe.
+  # It lives under tests/integration/ because it runs a real `cargo check`, and
+  # the unit job above does not reach it — so it gets a job of its own rather
+  # than being counted as covered while never running.
+  #
+  # It skips itself where cargo is absent, which is what makes this job's
+  # `rustc --version` step matter: without it a toolchain that quietly stopped
+  # being installed would turn the test into a silent no-op, and a silent no-op
+  # is how the two regressions this test exists to catch reached main in the
+  # first place.
+  rust-graph-vs-cargo:
+    name: Rust graph vs cargo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Fail if the Rust toolchain is missing
+        run: rustc --version && cargo --version
+      - run: npm ci
+      - run: npx vitest run tests/integration/rust-graph-vs-cargo.test.ts

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -1012,11 +1012,21 @@ export async function buildCodeGraph(
     // and the declaration is the only evidence of that in the source: matching
     // a neighbouring file by name instead let a third-party head capture the
     // import whenever a file of that name happened to exist.
+    //
+    // The name comes from the declaration itself and not from its specifier.
+    // Reading the specifier's last segment got both ends wrong: a
+    // `#[path = "custom.rs"] mod foo;` recorded `custom.rs` and lost every
+    // `use foo::Item;` in that file, and a `mod bar;` written inside
+    // `mod outer { … }` recorded `bar` as if the file declared it — which
+    // handed a same-named neighbouring file back the capture this gate exists
+    // to stop. Both checked with cargo 1.70.0 and 1.98.0: the attribute form
+    // compiles with `foo` in scope, and at the file's own level a name
+    // declared inside an inline block reaches the dependency instead, or
+    // fails with E0432 when there is none.
     const declaredMods = new Set<string>();
     for (const imp of importInfos) {
-      if (imp.isModuleDeclaration) {
-        const segments = imp.moduleSpecifier.split("::");
-        declaredMods.add(segments[segments.length - 1]);
+      if (imp.isModuleDeclaration && imp.declaredName) {
+        declaredMods.add(imp.declaredName);
       }
     }
 

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -1023,13 +1023,15 @@ export async function buildCodeGraph(
     // compiles with `foo` in scope, and at the file's own level a name
     // declared inside an inline block reaches the dependency instead, or
     // fails with E0432 when there is none.
-    // Only a declaration carries a declared name, so asking for the name is
-    // the whole question — pairing it with `isModuleDeclaration` would add a
-    // condition no tree can make false, and a guard nothing can fail is a
-    // guard nobody can check.
-    const declaredMods = new Set<string>();
+    // The map carries the file with the name, because half the declarations
+    // move it: `#[path = "custom.rs"] mod foo;` names `foo` and files it at
+    // `custom.rs`, and a resolver holding only the name looks for `src/foo.rs`,
+    // finds nothing, and falls through to a library called `foo` if the
+    // workspace has one — an edge into an unrelated crate. Where the
+    // declaration does not move anything, the value is the name itself.
+    const declaredMods = new Map<string, string>();
     for (const imp of importInfos) {
-      if (imp.declaredName) declaredMods.add(imp.declaredName);
+      if (imp.declaredName) declaredMods.set(imp.declaredName, imp.moduleSpecifier);
     }
 
     for (const imp of importInfos) {
@@ -1038,7 +1040,7 @@ export async function buildCodeGraph(
       // Try to resolve to a project file
       // CSS imports from <style> blocks use CSS resolution even when the source file is Svelte/Vue
       const resolutionLanguage = imp.isCssImport ? "css" : language;
-      const resolved = resolveImport(imp.moduleSpecifier, absolutePath, resolvedPath, fileSet, resolutionLanguage, aliases, jvmSuffixMap, csNamespaceMap, goModuleInfo, phpPsr4Map, dartPackageMap, pythonRootsFor(relPath), elixirModuleMap, phpFqcnMap, rustCrates, declaredMods);
+      const resolved = resolveImport(imp.moduleSpecifier, absolutePath, resolvedPath, fileSet, resolutionLanguage, aliases, jvmSuffixMap, csNamespaceMap, goModuleInfo, phpPsr4Map, dartPackageMap, pythonRootsFor(relPath), elixirModuleMap, phpFqcnMap, rustCrates, declaredMods, imp.isModuleDeclaration === true);
       if (resolved) {
         node.dependencies.push(resolved);
 

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -1007,13 +1007,26 @@ export async function buildCodeGraph(
       });
     }
 
+    // Which modules this file brings into the tree by declaring them. A Rust
+    // path with an unanchored head can only reach a module the file declares,
+    // and the declaration is the only evidence of that in the source: matching
+    // a neighbouring file by name instead let a third-party head capture the
+    // import whenever a file of that name happened to exist.
+    const declaredMods = new Set<string>();
+    for (const imp of importInfos) {
+      if (imp.isModuleDeclaration) {
+        const segments = imp.moduleSpecifier.split("::");
+        declaredMods.add(segments[segments.length - 1]);
+      }
+    }
+
     for (const imp of importInfos) {
       node.imports.push(imp.moduleSpecifier);
 
       // Try to resolve to a project file
       // CSS imports from <style> blocks use CSS resolution even when the source file is Svelte/Vue
       const resolutionLanguage = imp.isCssImport ? "css" : language;
-      const resolved = resolveImport(imp.moduleSpecifier, absolutePath, resolvedPath, fileSet, resolutionLanguage, aliases, jvmSuffixMap, csNamespaceMap, goModuleInfo, phpPsr4Map, dartPackageMap, pythonRootsFor(relPath), elixirModuleMap, phpFqcnMap, rustCrates);
+      const resolved = resolveImport(imp.moduleSpecifier, absolutePath, resolvedPath, fileSet, resolutionLanguage, aliases, jvmSuffixMap, csNamespaceMap, goModuleInfo, phpPsr4Map, dartPackageMap, pythonRootsFor(relPath), elixirModuleMap, phpFqcnMap, rustCrates, declaredMods);
       if (resolved) {
         node.dependencies.push(resolved);
 

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -506,6 +506,13 @@ export async function getGraphStatus(projectPath: string): Promise<{
 // ── Register dynamic language grammars ───────────────────────────────────
 
 let dynamicLangsRegistered = false;
+/**
+ * The declaration map a path written inside an inline `mod { … }` block is
+ * answered with: empty, because the file's own declarations are not in that
+ * block's scope. Shared and never written.
+ */
+const EMPTY_DECLARED_MODS: Map<string, string> = new Map();
+
 const loadedDynamicLanguages = new Set<string>();
 const failedDynamicLanguages = new Map<string, string>();
 
@@ -1029,6 +1036,8 @@ export async function buildCodeGraph(
     // finds nothing, and falls through to a library called `foo` if the
     // workspace has one — an edge into an unrelated crate. Where the
     // declaration does not move anything, the value is the name itself.
+    // Shared and never written: one empty map for every inline-block path in
+    // the build, instead of one per import.
     const declaredMods = new Map<string, string>();
     for (const imp of importInfos) {
       if (imp.declaredName) declaredMods.set(imp.declaredName, imp.moduleSpecifier);
@@ -1040,7 +1049,15 @@ export async function buildCodeGraph(
       // Try to resolve to a project file
       // CSS imports from <style> blocks use CSS resolution even when the source file is Svelte/Vue
       const resolutionLanguage = imp.isCssImport ? "css" : language;
-      const resolved = resolveImport(imp.moduleSpecifier, absolutePath, resolvedPath, fileSet, resolutionLanguage, aliases, jvmSuffixMap, csNamespaceMap, goModuleInfo, phpPsr4Map, dartPackageMap, pythonRootsFor(relPath), elixirModuleMap, phpFqcnMap, rustCrates, declaredMods, imp.isModuleDeclaration === true);
+      // A bare path written inside an inline `mod { … }` block is answered
+      // without the file's declarations: they are not in that block's scope,
+      // and handing them over drew an edge rustc rejects with E0432. The map is
+      // emptied rather than omitted — omitting it turns the gate off entirely,
+      // which is the looser reading, not a stricter one. Edition 2015 is
+      // unaffected: there the path is absolute from the crate root and never
+      // consulted the map to begin with.
+      const scopedMods = imp.fromInlineBlock ? EMPTY_DECLARED_MODS : declaredMods;
+      const resolved = resolveImport(imp.moduleSpecifier, absolutePath, resolvedPath, fileSet, resolutionLanguage, aliases, jvmSuffixMap, csNamespaceMap, goModuleInfo, phpPsr4Map, dartPackageMap, pythonRootsFor(relPath), elixirModuleMap, phpFqcnMap, rustCrates, scopedMods, imp.isModuleDeclaration === true);
       if (resolved) {
         node.dependencies.push(resolved);
 

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -15,7 +15,7 @@ import { ensureElixirTemplateParsers, isElixirTemplateExtension } from "./elixir
 import { detectExtensionFromSource, resolveExtensionlessExtension } from "./extensionless.js";
 import { loadPathAliases } from "./graph-aliases.js";
 import { extractImports } from "./graph-imports.js";
-import { buildCsNamespaceMap, buildDartPackageMap, buildElixirModuleMap, buildGoModuleInfo, buildJvmSuffixMap, buildPhpFqcnMap, buildPhpPsr4Map, buildPythonManifests, pythonRootsForFile, resolveImport } from "./graph-resolution.js";
+import { buildCsNamespaceMap, buildDartPackageMap, buildElixirModuleMap, buildGoModuleInfo, buildJvmSuffixMap, buildPhpFqcnMap, buildPhpPsr4Map, buildPythonManifests, buildRustCrateMap, pythonRootsForFile, resolveImport } from "./graph-resolution.js";
 import { computeUnresolvedPct, resolveCallSites } from "./graph-symbol-resolution.js";
 import { extractSymbolsAndCalls, rawCallsToUnresolvedEdges } from "./graph-symbols.js";
 import { createIgnoreFilter, shouldIgnore } from "./ignore.js";
@@ -881,6 +881,17 @@ export async function buildCodeGraph(
   const hasElixir = files.some((f) => [".ex", ".exs"].includes(path.extname(f).toLowerCase()));
   const elixirModuleMap = hasElixir ? buildElixirModuleMap(fileSet, resolvedPath) : undefined;
 
+  // Record every crate the tree declares, from each Cargo.toml (discovered by
+  // walking, like go.mod and pubspec.yaml — Cargo.toml is never in the
+  // graphable file set). A Rust path names a position in a module tree
+  // (`crate::`, `super::`) or another crate by name, neither of which the
+  // resolver could follow without knowing where each crate's root module sits:
+  // every specifier containing `::` resolved to null, so the file graph held
+  // only bare `mod` declarations. An empty list keeps `mod`, `super` and `self`
+  // resolving from the file's own position, as before.
+  const hasRust = files.some((f) => path.extname(f).toLowerCase() === ".rs");
+  const rustCrates = hasRust ? buildRustCrateMap(fileSet, resolvedPath) : undefined;
+
   for (const relPath of files) {
     let ext = path.extname(relPath).toLowerCase();
     let lang = getAstGrepLang(ext);
@@ -1002,7 +1013,7 @@ export async function buildCodeGraph(
       // Try to resolve to a project file
       // CSS imports from <style> blocks use CSS resolution even when the source file is Svelte/Vue
       const resolutionLanguage = imp.isCssImport ? "css" : language;
-      const resolved = resolveImport(imp.moduleSpecifier, absolutePath, resolvedPath, fileSet, resolutionLanguage, aliases, jvmSuffixMap, csNamespaceMap, goModuleInfo, phpPsr4Map, dartPackageMap, pythonRootsFor(relPath), elixirModuleMap, phpFqcnMap);
+      const resolved = resolveImport(imp.moduleSpecifier, absolutePath, resolvedPath, fileSet, resolutionLanguage, aliases, jvmSuffixMap, csNamespaceMap, goModuleInfo, phpPsr4Map, dartPackageMap, pythonRootsFor(relPath), elixirModuleMap, phpFqcnMap, rustCrates);
       if (resolved) {
         node.dependencies.push(resolved);
 

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -1036,8 +1036,6 @@ export async function buildCodeGraph(
     // finds nothing, and falls through to a library called `foo` if the
     // workspace has one — an edge into an unrelated crate. Where the
     // declaration does not move anything, the value is the name itself.
-    // Shared and never written: one empty map for every inline-block path in
-    // the build, instead of one per import.
     const declaredMods = new Map<string, string>();
     for (const imp of importInfos) {
       if (imp.declaredName) declaredMods.set(imp.declaredName, imp.moduleSpecifier);

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -1023,11 +1023,13 @@ export async function buildCodeGraph(
     // compiles with `foo` in scope, and at the file's own level a name
     // declared inside an inline block reaches the dependency instead, or
     // fails with E0432 when there is none.
+    // Only a declaration carries a declared name, so asking for the name is
+    // the whole question — pairing it with `isModuleDeclaration` would add a
+    // condition no tree can make false, and a guard nothing can fail is a
+    // guard nobody can check.
     const declaredMods = new Set<string>();
     for (const imp of importInfos) {
-      if (imp.isModuleDeclaration && imp.declaredName) {
-        declaredMods.add(imp.declaredName);
-      }
+      if (imp.declaredName) declaredMods.add(imp.declaredName);
     }
 
     for (const imp of importInfos) {

--- a/src/services/graph-imports.ts
+++ b/src/services/graph-imports.ts
@@ -240,20 +240,141 @@ function splitRustUseList(inner: string): string[] {
 }
 
 /**
+ * The module a raw identifier names. `mod r#async;` declares the module
+ * `async`, whose file rustc looks for as `async.rs` — the `r#` is how the
+ * source escapes a keyword, not part of the name. Without stripping it, the
+ * path `crate::r#async::poll` resolves to nothing and falls back to the crate
+ * root, which draws an edge at the wrong file.
+ */
+function stripRawIdent(segment: string): string {
+  return segment.startsWith("r#") ? segment.slice(2) : segment;
+}
+
+/**
  * One leaf of a `use` tree as a module path: the alias is dropped, and so are
  * trailing `self` and `*`, which name the module the path already reached
  * rather than something under it.
  */
 function rustUseLeafPath(leaf: string): string {
   const segments = leaf
-    .replace(/\s+as\s+(?:\w+)\s*$/, "")
+    .replace(/\s+as\s+(?:r#)?\w+\s*$/, "")
     .split("::")
-    .map((segment) => segment.trim())
+    .map((segment) => stripRawIdent(segment.trim()))
     .filter(Boolean);
   while (segments.length > 0 && ["self", "*"].includes(segments[segments.length - 1])) {
     segments.pop();
   }
   return segments.join("::");
+}
+
+/**
+ * Strip comments from a `use` declaration before its text is parsed as a path.
+ *
+ * A `use` tree may be spread over several lines with comments between the
+ * leaves, and the text of the AST node carries them. Left in, they become path
+ * segments: `crate::{ // note\n models::User }` yields the specifier
+ * `crate::// note\n    models::User`, which names no module and falls back to
+ * the crate root. A `use` holds no string literals, so removing comment spans
+ * from the raw text is safe.
+ */
+function stripRustComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/[^\n]*/g, " ");
+}
+
+/**
+ * The chain of inline `mod` blocks enclosing a node, outermost first.
+ *
+ * `mod tests { … }` opens a module without opening a file, so a path written
+ * inside it is relative to a position one level below the file. The chain is
+ * what lets that position be reconstructed; it is empty for the overwhelming
+ * majority of declarations, which sit at the top of a file.
+ */
+function rustInlineModules(node: SgNodeLike): string[] {
+  const chain: string[] = [];
+  let current = node.parent();
+  while (current) {
+    if (current.kind() === "mod_item") {
+      const name = current.field("name")?.text();
+      if (name) chain.unshift(stripRawIdent(name));
+    }
+    current = current.parent();
+  }
+  return chain;
+}
+
+/** The subset of the ast-grep node API this module reads. */
+interface SgNodeLike {
+  kind(): string;
+  text(): string;
+  parent(): SgNodeLike | null;
+  prev(): SgNodeLike | null;
+  field(name: string): SgNodeLike | null;
+}
+
+/**
+ * Rewrite a path written inside inline modules so it means the same thing when
+ * read from the file's own position.
+ *
+ * `self` and `super` count module levels, and an inline `mod` is a level that
+ * the file system does not show. `use super::open_store;` inside
+ * `mod tests { … }` in `store/open.rs` names that very file — but counted from
+ * the file it reads as the parent module, and an edge is drawn at
+ * `store.rs`, which the source never imports. That edge also closes a cycle
+ * with the `mod open;` declaration pointing the other way, and `#[cfg(test)]
+ * mod tests` sits in a large share of all Rust files.
+ *
+ * Returns null when the path names the file itself, which is not an edge.
+ * Paths anchored at `crate` are unaffected, and a bare head is left alone:
+ * inside `mod tests`, `use some_crate::Thing;` is how a test reaches another
+ * crate of the project, and rebasing it would lose that edge.
+ */
+function rustPathFromInline(path: string, inline: string[]): string | null {
+  if (inline.length === 0) return path;
+  const segments = path.split("::").filter(Boolean);
+  if (segments.length === 0) return null;
+  if (segments[0] === "crate") return path;
+
+  let climbed = 0;
+  let rest = segments;
+  if (rest[0] === "self") {
+    rest = rest.slice(1);
+  } else {
+    while (rest.length > 0 && rest[0] === "super") {
+      climbed++;
+      rest = rest.slice(1);
+    }
+    if (climbed === 0) return path;
+  }
+
+  // Each `super` first consumes an inline level; only what is left of the
+  // climb reaches the file system.
+  const remainingClimb = Math.max(0, climbed - inline.length);
+  const prefix = inline.slice(0, Math.max(0, inline.length - climbed));
+  if (remainingClimb > 0) {
+    return [...Array(remainingClimb).fill("super"), ...rest].join("::");
+  }
+  const rebased = [...prefix, ...rest];
+  return rebased.length === 0 ? null : ["self", ...rebased].join("::");
+}
+
+/**
+ * The file a `#[path = "…"]` attribute points at, relative to the directory
+ * the declaring file sits in — never to the directory that file's submodules
+ * live in. Both `src/a/b.rs` and `src/a/mod.rs` resolve `#[path = "moved.rs"]`
+ * to `src/a/moved.rs`.
+ *
+ * Attributes are siblings preceding the `mod` in the tree, and several may
+ * stack (`#[cfg(test)]` above `#[path = …]`), so the walk goes back through
+ * all of them.
+ */
+function rustPathAttribute(node: SgNodeLike): string | null {
+  let previous = node.prev();
+  while (previous?.kind() === "attribute_item") {
+    const match = previous.text().match(/^#\[\s*path\s*=\s*"([^"]+)"\s*\]$/);
+    if (match) return match[1];
+    previous = previous.prev();
+  }
+  return null;
 }
 
 /**
@@ -456,20 +577,51 @@ export function extractImports(source: string, lang: Lang | string, ext: string)
         // before reaching the resolver, and re-exports are how a Rust crate
         // publishes its own modules.
         for (const node of sgNode.findAll({ rule: { kind: "use_declaration" } })) {
-          const text = node.text();
+          const text = stripRustComments(node.text());
           const match = text.match(/^(?:pub\s*(?:\([^)]*\)\s*)?)?use\s+([\s\S]+?)\s*;?\s*$/);
           if (!match) continue;
+          const inline = rustInlineModules(node as unknown as SgNodeLike);
           for (const spec of expandRustUseTree(match[1])) {
-            imports.push({ moduleSpecifier: spec, isDynamic: false });
+            const fromInline = rustPathFromInline(spec, inline);
+            if (fromInline) imports.push({ moduleSpecifier: fromInline, isDynamic: false });
           }
         }
-        // mod foo;  /  pub mod foo;  /  pub(crate) mod foo;
+        // mod foo;  /  pub mod foo;  /  pub(crate) mod foo;  /  mod r#async;
         for (const node of sgNode.findAll({ rule: { kind: "mod_item" } })) {
-          const text = node.text();
-          if (text.includes("{")) continue; // inline mod definition, not an import
-          const match = text.match(/^(?:pub\s*(?:\([^)]*\)\s*)?)?mod\s+(\w+)\s*;/);
-          if (match) {
-            imports.push({ moduleSpecifier: match[1], isDynamic: false });
+          // A body makes it a module definition, not a declaration pointing at
+          // another file. Reading the field rather than looking for a brace in
+          // the text keeps an attribute that happens to carry one out of it.
+          if (node.field("body")) continue;
+          const match = node
+            .text()
+            .match(/^(?:pub\s*(?:\([^)]*\)\s*)?)?mod\s+((?:r#)?\w+)\s*;/);
+          if (!match) continue;
+          const typed = node as unknown as SgNodeLike;
+          // `#[path = "…"]` moves the file away from every convention, and only
+          // the attribute says where. It travels as a path with its extension,
+          // which no module path ever has, and the resolver reads it as one.
+          const declaredPath = rustPathAttribute(typed);
+          if (declaredPath) {
+            imports.push({ moduleSpecifier: declaredPath, isDynamic: false });
+            continue;
+          }
+          const inline = rustInlineModules(typed);
+          const name = stripRawIdent(match[1]);
+          // Declared inside `mod outer { … }`, the file sits under `outer/`,
+          // not beside the declaring file.
+          const spec = inline.length === 0 ? name : ["self", ...inline, name].join("::");
+          imports.push({ moduleSpecifier: spec, isDynamic: false });
+        }
+        // extern crate serde;  /  #[macro_use] extern crate log as logging;
+        //
+        // The 2015 way of naming a dependency, still written today above a
+        // `#[macro_use]`. The crate it names cannot collide with a local
+        // module of the same name — rustc rejects that — so the bare name is
+        // safe to resolve the way a `mod` declaration is.
+        for (const node of sgNode.findAll({ rule: { kind: "extern_crate_declaration" } })) {
+          const name = node.field("name")?.text();
+          if (name && name !== "self") {
+            imports.push({ moduleSpecifier: stripRawIdent(name), isDynamic: false });
           }
         }
         break;

--- a/src/services/graph-imports.ts
+++ b/src/services/graph-imports.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
-import { Lang, parse } from "@ast-grep/napi";
+import { Lang, parse, type SgNode } from "@ast-grep/napi";
 import { analyzeElixirTemplate, isElixirTemplateExtension } from "./elixir-templates.js";
 import { logger } from "./logger.js";
 
@@ -744,17 +744,44 @@ export function expandRustUseTree(tree: string): string[] {
  * cargo 1.98.0 with a `compile_error!` in it, where the crate builds clean and
  * the dep-info lists `src/lib.rs` alone.
  *
- * Returns null when there was nothing to unwrap, which is the common case.
+ * **And only while recovery stays inside the macro.** What the head and braces
+ * hide is not always item syntax: `cfg_if!` writes its arms as
+ *
+ *     cfg_if! {
+ *         if #[cfg(unix)] { mod arm_a; } else { mod arm_b; }
+ *     }
+ *
+ * and an `if` carrying an attribute is not Rust anywhere. Blanking it hands the
+ * parser a fragment it has to recover from, and recovery does not stop at the
+ * macro: inside `mod inner { … }` it closes the block after the first arm and
+ * re-parents everything after it to file level. On a cargo-verified crate that
+ * builds clean the graph drew `src/lib.rs -> src/arm_b.rs` twice and
+ * `src/lib.rs -> src/after.rs` — three edges into files carrying
+ * `compile_error!`, one of them a module that belongs to the block, while
+ * `mod after;` lost the edge it should have had.
+ *
+ * So the rewritten source is parsed before it is used, and it is kept only when
+ * every ERROR node sits inside a macro that was unwrapped. Where one does not,
+ * the pass is redone with the bodies that parse as items on their own — the
+ * rest stay the token trees they were. `recoveryStaysInside` carries why the
+ * test is drawn there and not around the ERROR itself.
+ *
+ * The admission rule still decides what a body means: an `if #[cfg(…)]` is not
+ * something the language guarantees, it is what one library spells its
+ * condition with, and nothing here reads it as arms. What the graph keeps is
+ * only what the parser puts where it was written.
+ *
+ * Returns null when there was nothing to unwrap, which is the common case, and
+ * otherwise the rewritten source together with the tree the check already had
+ * to build from it — the caller reads its imports off that tree rather than
+ * parsing the same text a second time.
  */
-function rustSourceWithMacroBodiesInlined(source: string, root: SgNodeLike): string | null {
-  const chars = source.split("");
-  const blank = (at: number): void => {
-    // Newlines stay: a line comment must keep ending where it ended, or what
-    // follows it on the next line is swallowed.
-    if (chars[at] !== "\n" && chars[at] !== "\r") chars[at] = " ";
-  };
-
-  let changed = false;
+function rustSourceWithMacroBodiesInlined(
+  source: string,
+  root: SgNodeLike,
+  carried: MacroRegion[],
+): UnwrappedSource | null {
+  const regions: MacroRegion[] = [];
   for (const node of root.findAll({ rule: { kind: "macro_invocation" } })) {
     if (!standsWhereAnItemMay(node)) continue;
     const text = node.text();
@@ -762,17 +789,174 @@ function rustSourceWithMacroBodiesInlined(source: string, root: SgNodeLike): str
     if (open === -1) continue;
     // The last brace has to close the invocation itself. Where it does not, the
     // delimiter is `(` or `[` and the `{` found above is inside the arguments.
-    const trimmed = text.trimEnd();
-    if (!trimmed.endsWith("}")) continue;
+    if (!text.trimEnd().endsWith("}")) continue;
     const close = text.lastIndexOf("}");
     if (close <= open) continue;
 
     const start = node.range().start.index;
-    for (let i = 0; i <= open; i++) blank(start + i);
-    blank(start + close);
-    changed = true;
+    regions.push({
+      start,
+      open: start + open,
+      close: start + close,
+      insideBlock: node.parent()?.kind() === "declaration_list",
+    });
   }
-  return changed ? chars.join("") : null;
+  if (regions.length === 0) return null;
+
+  const attempts: MacroRegion[][] = [regions];
+
+  // Recovery reached past a macro's own text, so the tree around it can no
+  // longer be trusted — but the macro that let it out is one of the few written
+  // inside a block, where an early `}` has a `mod` or an `impl` to close. The
+  // ones at file level are dropped only if that is not enough.
+  //
+  // Dropping every unparsable body at the first sign of trouble costs whole
+  // files: one `cfg_if!` written in an `impl` took with it every declaration the
+  // `cfg_if!`s at file level carried. Across the 153 crates of a registry cache
+  // that hold the shape, that was 78 distinct dependencies lost against HEAD;
+  // narrowing the retry this way brings it to 56 and leaves ahash and dashmap
+  // as they were. What stays lost is the file blanking breaks outright —
+  // libc's `freebsd/mod.rs` parses as one ERROR from line 1 once its fifteen
+  // `cfg_if!`s are blanked — and no reading of that tree would be worth
+  // trusting.
+  const dirty = (r: MacroRegion): boolean =>
+    !rustBodyIsItemsOnItsOwn(source.slice(r.open + 1, r.close));
+  const outsideBlocks = regions.filter((r) => !(r.insideBlock && dirty(r)));
+  if (outsideBlocks.length < regions.length) attempts.push(outsideBlocks);
+  const clean = regions.filter((r) => !dirty(r));
+  if (clean.length < outsideBlocks.length) attempts.push(clean);
+
+  for (const attempt of attempts) {
+    if (attempt.length === 0) continue;
+    const rewritten = rustSourceWithRegionsBlanked(source, attempt);
+    // Every macro unwrapped so far counts, not only this pass's own: the second
+    // pass reads what the first one rewrote, so a `cfg_if!` kept there has its
+    // ERROR standing in this pass's input. Blanking preserves every index —
+    // characters become spaces, none are removed — so the regions carried from
+    // the earlier pass still say where its text is.
+    const unwrapped = carried.concat(attempt);
+    const kept = recoveryStaysInside(rewritten, unwrapped);
+    if (kept) return { source: rewritten, root: kept, regions: unwrapped };
+  }
+  return null;
+}
+
+interface UnwrappedSource {
+  /** The rewritten Rust source. */
+  source: string;
+  /** Its tree, already built by the check that accepted it. */
+  root: SgNodeLike;
+  /** Every macro region blanked in it, this pass's and the earlier ones'. */
+  regions: MacroRegion[];
+}
+
+interface MacroRegion {
+  /**
+   * Whether the invocation is written inside a `mod`, `impl` or `trait` body —
+   * the only place an early `}` produced by recovery has something to close,
+   * and so the only place the damage can leave the macro.
+   */
+  insideBlock: boolean;
+  /** Index of the first character of the invocation. */
+  start: number;
+  /** Index of the `{` that opens the body. */
+  open: number;
+  /** Index of the `}` that closes it. */
+  close: number;
+}
+
+/** The source with the head and the braces of each region replaced by spaces. */
+function rustSourceWithRegionsBlanked(source: string, regions: MacroRegion[]): string {
+  const chars = source.split("");
+  const blank = (at: number): void => {
+    // Newlines stay: a line comment must keep ending where it ended, or what
+    // follows it on the next line is swallowed.
+    if (chars[at] !== "\n" && chars[at] !== "\r") chars[at] = " ";
+  };
+  for (const region of regions) {
+    for (let i = region.start; i <= region.open; i++) blank(i);
+    blank(region.close);
+  }
+  return chars.join("");
+}
+
+/**
+ * Whether the rewritten source leaves the parser recovering only *inside* the
+ * macros that were unwrapped.
+ *
+ * This is the test that decides whether the pass is usable, and it is the one
+ * that matches the defect: what went wrong was never the ERROR node itself, it
+ * was recovery reaching past the macro and re-parenting other people's items.
+ * An `if #[cfg(…)]` written at file level leaves an ERROR on the attribute and
+ * nothing else moves, so the declarations in the arms are read where they were
+ * written — which is where rustc reads them too. The same arms inside
+ * `mod inner { … }` close the block early, and everything after them lands at
+ * file level: `src/lib.rs -> src/arm_b.rs` for a file carrying
+ * `compile_error!`, plus a module of the block drawn as the file's own, both
+ * verified against a clean `cargo build`.
+ *
+ * The distinction is worth drawing. Across a 1,256-crate registry cache, 449
+ * macro bodies that carry declarations do not parse as items on their own — and
+ * 431 of them stand at file level, where the pass is right. Refusing all of them
+ * to close the 18 would pay for the fix with the case that works: `js-sys`,
+ * `backtrace`, `ahash` and `aes` each lose real module edges.
+ *
+ * `regions` is every macro unwrapped so far, the earlier passes' included, and
+ * nothing else earns an exemption. Tolerating the ERROR nodes a source already
+ * had is the obvious-looking shortcut and it opens the defect back up: a file
+ * carrying an unresolved merge marker inside `mod inner { … }` has an ERROR at
+ * the same index the recovery produces, so the damaged pass was accepted and
+ * `mod after;` was drawn at file level again. Measured on the live version
+ * before this was tightened.
+ *
+ * A source that does not parse cleanly for reasons of its own therefore gets no
+ * unwrapping at all, which is the conservative side to fall on: 1,771 of 34,655
+ * `.rs` files in a registry cache are in that state, and not one of them carries
+ * a declaration inside a macro body.
+ *
+ * Returns the tree when the source is usable, so the caller reads its imports
+ * off it instead of parsing the same text again, which is what keeps the check
+ * affordable. What it still costs, measured on tokio with nine runs a side
+ * alternating between the two: 2,013 ms before this change, 2,123 ms after,
+ * against 1,304 ms on `main` — so the guard is 5% of the graph build, on top of
+ * the 54% the rest of the Rust work already costs.
+ */
+function recoveryStaysInside(rewritten: string, regions: MacroRegion[]): SgNodeLike | null {
+  let root: SgNodeLike;
+  try {
+    root = parse("rust" as unknown as Lang, rewritten).root() as unknown as SgNodeLike;
+  } catch {
+    return null;
+  }
+  for (const error of root.findAll({ rule: { kind: "ERROR" } })) {
+    const { start, end } = error.range();
+    const inside = regions.some((r) => start.index >= r.start && end.index <= r.close + 1);
+    if (!inside) return null;
+  }
+  return root;
+}
+
+/**
+ * Whether what a macro wraps parses as Rust items with nothing around it.
+ *
+ * The guard on blanking: a body that only makes sense to the macro reading it
+ * leaves the parser recovering, and recovery rewrites the tree well past the
+ * macro's own text. Asking the body alone keeps the answer the same wherever
+ * the invocation stands.
+ *
+ * A tree-sitter ERROR node is the whole of the test. Recovery still produces
+ * nodes under it, which is why the wrong edges were drawn in the first place —
+ * they looked like ordinary declarations sitting at file level.
+ */
+function rustBodyIsItemsOnItsOwn(body: string): boolean {
+  if (body.trim() === "") return false;
+  try {
+    const root = parse("rust" as unknown as Lang, body).root();
+    return root.findAll({ rule: { kind: "ERROR" } }).length === 0;
+  } catch {
+    // A body the grammar cannot be run on is one we have no evidence about.
+    return false;
+  }
 }
 
 /**
@@ -852,12 +1036,20 @@ const RUST_MACRO_UNWRAP_PASSES = 2;
 /**
  * Extract import statements from source code using ast-grep.
  * Returns raw module specifiers for each language's import syntax.
+ *
+ * `unwrapped` is internal, and only the Rust macro pass passes it: the tree it
+ * had to build to accept the source it rewrote, so the same text is not parsed
+ * twice, and the regions it blanked, which the next pass needs to tell its own
+ * damage from the last pass's leftovers. Nothing else should pass it — it
+ * describes one particular `source` and would be read as if it described this
+ * one.
  */
 export function extractImports(
   source: string,
   lang: Lang | string,
   ext: string,
   unwrapPassesLeft: number = RUST_MACRO_UNWRAP_PASSES,
+  unwrapped?: UnwrappedSource,
 ): ImportInfo[] {
   const imports: ImportInfo[] = [];
   const langKey = String(lang);
@@ -933,7 +1125,7 @@ export function extractImports(
 
   // ── AST-based extraction for languages with grammar support ───────────
   try {
-    const sgNode = parse(lang, source).root();
+    const sgNode = (unwrapped?.root as SgNode | undefined) ?? parse(lang, source).root();
 
     switch (langKey) {
       case "python": {
@@ -1194,9 +1386,16 @@ export function extractImports(
           const inlined = rustSourceWithMacroBodiesInlined(
             source,
             sgNode as unknown as SgNodeLike,
+            unwrapped?.regions ?? [],
           );
           if (inlined !== null) {
-            const withBodies = extractImports(inlined, lang, ext, unwrapPassesLeft - 1);
+            const withBodies = extractImports(
+              inlined.source,
+              lang,
+              ext,
+              unwrapPassesLeft - 1,
+              inlined,
+            );
             imports.push(...importsNotAlreadyFound(withBodies, imports));
           }
         }

--- a/src/services/graph-imports.ts
+++ b/src/services/graph-imports.ts
@@ -301,17 +301,41 @@ function stripRustComments(text: string): string {
  * what lets that position be reconstructed; it is empty for the overwhelming
  * majority of declarations, which sit at the top of a file.
  */
-function rustInlineModules(node: SgNodeLike): string[] {
+function rustInlineModules(node: SgNodeLike): InlinePosition {
   const chain: string[] = [];
+  let innermost: SgNodeLike | null = null;
   let current = node.parent();
   while (current) {
     if (current.kind() === "mod_item") {
+      innermost ??= current;
+      // An inline `mod` may carry a `#[path]` of its own, and then it is that
+      // path — not the module's name — that names the directory its children
+      // live in.
+      const declared = rustPathAttribute(current);
       const name = current.field("name")?.text();
-      if (name) chain.unshift(stripRawIdent(name));
+      if (declared) chain.unshift(declared.replace(/\/+$/, ""));
+      else if (name) chain.unshift(stripRawIdent(name));
     }
     current = current.parent();
   }
-  return chain;
+
+  // What the innermost block declares by hand: a path whose head names one of
+  // these is a path into the block, not out to another crate.
+  const declares = new Set<string>();
+  const body = innermost?.field("body");
+  if (body) {
+    for (const child of body.findAll({ rule: { kind: "mod_item" } })) {
+      const name = child.field("name")?.text();
+      if (name) declares.add(stripRawIdent(name));
+    }
+  }
+  return { chain, declares };
+}
+
+/** Where a declaration sits inside inline `mod` blocks, and what they declare. */
+interface InlinePosition {
+  chain: string[];
+  declares: Set<string>;
 }
 
 /** The subset of the ast-grep node API this module reads. */
@@ -321,6 +345,7 @@ interface SgNodeLike {
   parent(): SgNodeLike | null;
   prev(): SgNodeLike | null;
   field(name: string): SgNodeLike | null;
+  findAll(matcher: { rule: { kind: string } }): SgNodeLike[];
 }
 
 /**
@@ -340,11 +365,12 @@ interface SgNodeLike {
  * inside `mod tests`, `use some_crate::Thing;` is how a test reaches another
  * crate of the project, and rebasing it would lose that edge.
  */
-function rustPathFromInline(path: string, inline: string[]): string | null {
-  if (inline.length === 0) return path;
+function rustPathFromInline(path: string, inline: InlinePosition): string | null {
+  const levels = inline.chain;
+  if (levels.length === 0) return path;
   const segments = path.split("::").filter(Boolean);
   if (segments.length === 0) return null;
-  if (segments[0] === "crate") return path;
+  if (segments[0] === "crate" || path.startsWith("::")) return path;
 
   let climbed = 0;
   let rest = segments;
@@ -355,13 +381,18 @@ function rustPathFromInline(path: string, inline: string[]): string | null {
       climbed++;
       rest = rest.slice(1);
     }
-    if (climbed === 0) return path;
+    // A bare head is rebased only when the block itself declares a module by
+    // that name — `mod tests { mod fixtures; use fixtures::build; }` is a path
+    // into the block. Otherwise it is left alone, because the commoner shape
+    // by far is `mod tests { use some_crate::Thing; }`, and rebasing that
+    // would lose the edge to the other crate.
+    if (climbed === 0) return inline.declares.has(segments[0]) ? `self::${levels.join("::")}::${path}` : path;
   }
 
   // Each `super` first consumes an inline level; only what is left of the
   // climb reaches the file system.
-  const remainingClimb = Math.max(0, climbed - inline.length);
-  const prefix = inline.slice(0, Math.max(0, inline.length - climbed));
+  const remainingClimb = Math.max(0, climbed - levels.length);
+  const prefix = levels.slice(0, Math.max(0, levels.length - climbed));
   if (remainingClimb > 0) {
     return [...Array(remainingClimb).fill("super"), ...rest].join("::");
   }
@@ -629,16 +660,17 @@ export function extractImports(source: string, lang: Lang | string, ext: string)
           const declaredPath = rustPathAttribute(typed);
           if (declaredPath) {
             const spec =
-              inline.length === 0
+              inline.chain.length === 0
                 ? declaredPath
-                : `self/${inline.join("/")}/${declaredPath}`;
+                : `self/${inline.chain.join("/")}/${declaredPath}`;
             imports.push({ moduleSpecifier: spec, isDynamic: false });
             continue;
           }
           const name = stripRawIdent(match[1]);
           // Declared inside `mod outer { … }`, the file sits under `outer/`,
           // not beside the declaring file.
-          const spec = inline.length === 0 ? name : ["self", ...inline, name].join("::");
+          const spec =
+            inline.chain.length === 0 ? name : ["self", ...inline.chain, name].join("::");
           imports.push({ moduleSpecifier: spec, isDynamic: false });
         }
         // extern crate serde;  /  #[macro_use] extern crate log as logging;

--- a/src/services/graph-imports.ts
+++ b/src/services/graph-imports.ts
@@ -597,15 +597,26 @@ export function extractImports(source: string, lang: Lang | string, ext: string)
             .match(/^(?:pub\s*(?:\([^)]*\)\s*)?)?mod\s+((?:r#)?\w+)\s*;/);
           if (!match) continue;
           const typed = node as unknown as SgNodeLike;
+          const inline = rustInlineModules(typed);
           // `#[path = "…"]` moves the file away from every convention, and only
           // the attribute says where. It travels as a path with its extension,
           // which no module path ever has, and the resolver reads it as one.
+          //
+          // The two forms count from different places, which rustc settles and
+          // no reading of the path can: a declared module resolves it against
+          // the directory the declaring file sits in, while one inside an
+          // inline block resolves it against that file's own module directory
+          // plus a directory per inline level. The `self/` head marks the
+          // second form for the resolver.
           const declaredPath = rustPathAttribute(typed);
           if (declaredPath) {
-            imports.push({ moduleSpecifier: declaredPath, isDynamic: false });
+            const spec =
+              inline.length === 0
+                ? declaredPath
+                : `self/${inline.join("/")}/${declaredPath}`;
+            imports.push({ moduleSpecifier: spec, isDynamic: false });
             continue;
           }
-          const inline = rustInlineModules(typed);
           const name = stripRawIdent(match[1]);
           // Declared inside `mod outer { … }`, the file sits under `outer/`,
           // not beside the declaring file.

--- a/src/services/graph-imports.ts
+++ b/src/services/graph-imports.ts
@@ -812,7 +812,7 @@ function importKey(imp: ImportInfo): string {
     imp.isModuleDeclaration ?? "",
     imp.declaredName ?? "",
     imp.fromInlineBlock ?? "",
-  ].join(" ");
+  ].join("\0");
 }
 
 /**

--- a/src/services/graph-imports.ts
+++ b/src/services/graph-imports.ts
@@ -221,6 +221,80 @@ function extractJsTsImportsFromNode(sgNode: ReturnType<ReturnType<typeof parse>[
   return imports;
 }
 
+/** Split a `use` group body on its top-level commas, ignoring nested groups. */
+function splitRustUseList(inner: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+    else if (ch === "," && depth === 0) {
+      parts.push(inner.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(inner.slice(start));
+  return parts.map((part) => part.trim()).filter(Boolean);
+}
+
+/**
+ * One leaf of a `use` tree as a module path: the alias is dropped, and so are
+ * trailing `self` and `*`, which name the module the path already reached
+ * rather than something under it.
+ */
+function rustUseLeafPath(leaf: string): string {
+  const segments = leaf
+    .replace(/\s+as\s+(?:\w+)\s*$/, "")
+    .split("::")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  while (segments.length > 0 && ["self", "*"].includes(segments[segments.length - 1])) {
+    segments.pop();
+  }
+  return segments.join("::");
+}
+
+/**
+ * Flatten one `use` tree into the module paths it names, one per leaf:
+ *
+ *   crate::config::Config     → ["crate::config::Config"]
+ *   crate::{a::Thing, b}      → ["crate::a::Thing", "crate::b"]
+ *   crate::a::{self, b as c}  → ["crate::a", "crate::a::b"]
+ *   crate::a::*               → ["crate::a"]
+ *
+ * A braced group is not a module path and never resolved to one; recording the
+ * leaves instead is what lets `use crate::{parser, printer}` draw an edge to
+ * each of the two files rather than to their parent module — or, in a flat
+ * crate with no parent module file, to nothing at all.
+ */
+export function expandRustUseTree(tree: string): string[] {
+  const trimmed = tree.trim();
+  if (!trimmed) return [];
+
+  const open = trimmed.indexOf("{");
+  if (open === -1) {
+    const leaf = rustUseLeafPath(trimmed);
+    return leaf ? [leaf] : [];
+  }
+  const close = trimmed.lastIndexOf("}");
+  if (close < open) return [];
+
+  const prefix = trimmed.slice(0, open).replace(/::\s*$/, "").trim();
+  const paths: string[] = [];
+  for (const part of splitRustUseList(trimmed.slice(open + 1, close))) {
+    for (const expanded of expandRustUseTree(part)) {
+      paths.push(prefix ? `${prefix}::${expanded}` : expanded);
+    }
+    // `self` and `*` expand to nothing, so the group's own prefix is what the
+    // leaf named: `use crate::a::{self, b}` imports `crate::a` as well as
+    // `crate::a::b`.
+    if ((part === "self" || part === "*") && prefix) paths.push(prefix);
+  }
+  return paths;
+}
+
 /**
  * Extract import statements from source code using ast-grep.
  * Returns raw module specifiers for each language's import syntax.
@@ -374,19 +448,26 @@ export function extractImports(source: string, lang: Lang | string, ext: string)
       }
 
       case "rust": {
-        // use std::collections::HashMap;
+        // use std::collections::HashMap;  /  pub use crate::config::Config;
+        //
+        // A `use_declaration` node carries its visibility modifier, so the
+        // optional `pub` / `pub(crate)` / `pub(in path)` prefix has to be
+        // consumed here: without it every re-export in the tree was dropped
+        // before reaching the resolver, and re-exports are how a Rust crate
+        // publishes its own modules.
         for (const node of sgNode.findAll({ rule: { kind: "use_declaration" } })) {
           const text = node.text();
-          const match = text.match(/^use\s+(.+);?\s*$/);
-          if (match) {
-            imports.push({ moduleSpecifier: match[1].trim().replace(/;$/, ""), isDynamic: false });
+          const match = text.match(/^(?:pub\s*(?:\([^)]*\)\s*)?)?use\s+([\s\S]+?)\s*;?\s*$/);
+          if (!match) continue;
+          for (const spec of expandRustUseTree(match[1])) {
+            imports.push({ moduleSpecifier: spec, isDynamic: false });
           }
         }
-        // mod foo;
+        // mod foo;  /  pub mod foo;  /  pub(crate) mod foo;
         for (const node of sgNode.findAll({ rule: { kind: "mod_item" } })) {
           const text = node.text();
           if (text.includes("{")) continue; // inline mod definition, not an import
-          const match = text.match(/^mod\s+(\w+)\s*;/);
+          const match = text.match(/^(?:pub\s*(?:\([^)]*\)\s*)?)?mod\s+(\w+)\s*;/);
           if (match) {
             imports.push({ moduleSpecifier: match[1], isDynamic: false });
           }

--- a/src/services/graph-imports.ts
+++ b/src/services/graph-imports.ts
@@ -1006,6 +1006,39 @@ export function extractImports(
         break;
       }
 
+      // ── What counts as a Rust declaration, and what does not ─────────────
+      //
+      // Rust can put a module declaration where a reader does not look, and
+      // each way it does is a candidate for this block. **One test decides
+      // every one of them, so this never becomes a list of libraries we happen
+      // to know:**
+      //
+      //     Does the language guarantee it, or does it require knowing a
+      //     library?
+      //
+      // In, because the language guarantees them:
+      //   - a `mod`/`use` written in a macro body — expansion happens before
+      //     name resolution, so what is written there is a declaration. This is
+      //     a fact about the language, not about any particular macro.
+      //   - `#[path]`, and `#[cfg_attr(…, path = …)]`, which the Reference
+      //     documents as the same relocation.
+      //   - `include!("x.rs")` with a literal path, also in the Reference.
+      //
+      // Out, and not for lack of effort:
+      //   - `automod::dir!("tests/x")` and anything like it. Reading it means
+      //     teaching this file one third-party macro *and its expansion rules*
+      //     — where the path counts from, whether the read recurses, which
+      //     names are excluded. It is 92 files on clap and 163 across a
+      //     245-crate sample, and **the size of the number is not what decides**:
+      //     the moment it can, the criterion stops being "what the source says".
+      //     `tests/unit/graph-discovery.test.ts` holds a test that pins this
+      //     refusal, so moving the boundary cannot happen quietly.
+      //   - `include!(concat!(env!("OUT_DIR"), …))` — that file does not exist
+      //     until `build.rs` has run, so no reading of the source can find it.
+      //
+      // A case that passes the test is worth adding however few files it
+      // reaches; one that fails it is refused however many. Whoever adds the
+      // next one: answer the question above first, in the commit message.
       case "rust": {
         // use std::collections::HashMap;  /  pub use crate::config::Config;
         //
@@ -1124,6 +1157,33 @@ export function extractImports(
           if (name && name !== "self") {
             imports.push({ moduleSpecifier: stripRawIdent(name), isDynamic: false });
           }
+        }
+
+        // `include!("gen.rs")` pastes a file's text where it stands. It brings
+        // no name into scope, so it declares no module and carries no
+        // `declaredName` — but the file is a source rustc opens, and cargo
+        // lists it in the dep-info like any other. The Reference resolves the
+        // path against the directory of the file that writes it, which is
+        // already what a `.rs` specifier means to the resolver, inline module
+        // or not: unlike a `#[path]`, an `include!` inside `mod inner { … }`
+        // still counts from the file.
+        //
+        // A literal path only. `include!(concat!(env!("OUT_DIR"), "/x.rs"))`
+        // names a file that does not exist until `build.rs` has run, which no
+        // reading of the source can find — 94 of them across a 1,256-crate
+        // registry cache, against 122 literal ones standing in code.
+        //
+        // Reading the AST rather than the text is also what keeps the
+        // illustrative ones out: an `include!` written inside a doc comment is
+        // part of that comment's node and never a `macro_invocation`, and there
+        // are 9 of those in the same cache.
+        for (const node of sgNode.findAll({ rule: { kind: "macro_invocation" } })) {
+          const invocation = node.text();
+          // Brackets are interchangeable on an invocation, and cargo accepts
+          // all three spellings.
+          const literal = invocation.match(/^\s*include\s*!\s*[([{]\s*"([^"]+\.rs)"\s*[)\]}]/);
+          if (!literal) continue;
+          imports.push({ moduleSpecifier: literal[1], isDynamic: false });
         }
 
         // What a macro invocation wraps is read last, on a source with its head

--- a/src/services/graph-imports.ts
+++ b/src/services/graph-imports.ts
@@ -10,6 +10,14 @@ export interface ImportInfo {
   moduleSpecifier: string; // The raw import string
   isDynamic: boolean;
   isCssImport?: boolean;   // True when extracted from a CSS/style context
+  /**
+   * True when the specifier comes from a declaration that brings a file into
+   * the module tree — a Rust `mod foo;` — rather than from a path that merely
+   * names something. Rust needs the difference: a module has to be declared
+   * before an unanchored path can reach it, and the declaration is the only
+   * evidence of that in the file.
+   */
+  isModuleDeclaration?: boolean;
 }
 
 /**
@@ -663,7 +671,7 @@ export function extractImports(source: string, lang: Lang | string, ext: string)
               inline.chain.length === 0
                 ? declaredPath
                 : `self/${inline.chain.join("/")}/${declaredPath}`;
-            imports.push({ moduleSpecifier: spec, isDynamic: false });
+            imports.push({ moduleSpecifier: spec, isDynamic: false, isModuleDeclaration: true });
             continue;
           }
           const name = stripRawIdent(match[1]);
@@ -671,7 +679,7 @@ export function extractImports(source: string, lang: Lang | string, ext: string)
           // not beside the declaring file.
           const spec =
             inline.chain.length === 0 ? name : ["self", ...inline.chain, name].join("::");
-          imports.push({ moduleSpecifier: spec, isDynamic: false });
+          imports.push({ moduleSpecifier: spec, isDynamic: false, isModuleDeclaration: true });
         }
         // extern crate serde;  /  #[macro_use] extern crate log as logging;
         //

--- a/src/services/graph-imports.ts
+++ b/src/services/graph-imports.ts
@@ -256,7 +256,13 @@ function stripRawIdent(segment: string): string {
  * rather than something under it.
  */
 function rustUseLeafPath(leaf: string): string {
-  const segments = leaf
+  const trimmed = leaf.trim();
+  // A leading `::` says the head names a crate, never a module in scope. The
+  // marker is kept because the resolver now prefers a local module, and
+  // dropping it turned `use ::config::Item;` into an edge at a local
+  // `config.rs` that the source explicitly said not to look at.
+  const global = trimmed.startsWith("::");
+  const segments = trimmed
     .replace(/\s+as\s+(?:r#)?\w+\s*$/, "")
     .split("::")
     .map((segment) => stripRawIdent(segment.trim()))
@@ -264,7 +270,13 @@ function rustUseLeafPath(leaf: string): string {
   while (segments.length > 0 && ["self", "*"].includes(segments[segments.length - 1])) {
     segments.pop();
   }
-  return segments.join("::");
+  if (segments.length === 0) return "";
+  return global ? `::${segments.join("::")}` : segments.join("::");
+}
+
+/** A group leaf with its alias removed, which is what says whether it is `self`. */
+function rustLeafHead(part: string): string {
+  return part.replace(/\s+as\s+(?:r#)?\w+\s*$/, "").trim();
 }
 
 /**
@@ -369,7 +381,11 @@ function rustPathFromInline(path: string, inline: string[]): string | null {
  */
 function rustPathAttribute(node: SgNodeLike): string | null {
   let previous = node.prev();
-  while (previous?.kind() === "attribute_item") {
+  // Comments count as siblings too, and one written between the attribute and
+  // the `mod` it belongs to would otherwise end the walk before the attribute
+  // is seen — a comment above a relocated module is exactly where someone
+  // explains why it was relocated.
+  while (previous && (previous.kind() === "attribute_item" || previous.kind().includes("comment"))) {
     const match = previous.text().match(/^#\[\s*path\s*=\s*"([^"]+)"\s*\]$/);
     if (match) return match[1];
     previous = previous.prev();
@@ -410,8 +426,10 @@ export function expandRustUseTree(tree: string): string[] {
     }
     // `self` and `*` expand to nothing, so the group's own prefix is what the
     // leaf named: `use crate::a::{self, b}` imports `crate::a` as well as
-    // `crate::a::b`.
-    if ((part === "self" || part === "*") && prefix) paths.push(prefix);
+    // `crate::a::b`. The alias has to come off first — `{self as cfg}` is the
+    // same leaf, and comparing the raw text dropped the whole import.
+    const head = rustLeafHead(part);
+    if ((head === "self" || head === "*") && prefix) paths.push(prefix);
   }
   return paths;
 }

--- a/src/services/graph-imports.ts
+++ b/src/services/graph-imports.ts
@@ -18,6 +18,16 @@ export interface ImportInfo {
    * evidence of that in the file.
    */
   isModuleDeclaration?: boolean;
+  /**
+   * The name a module declaration puts in the declaring file's own scope.
+   * Absent when the declaration is written inside an inline `mod` block,
+   * where the name belongs to the block rather than to the file.
+   *
+   * It is not the specifier: `#[path = "custom.rs"] mod foo;` travels as the
+   * path it declares, while the name it brings into scope is `foo`, and it is
+   * `foo` an unanchored `use foo::Item;` in that file may reach.
+   */
+  declaredName?: string;
 }
 
 /**
@@ -666,20 +676,38 @@ export function extractImports(source: string, lang: Lang | string, ext: string)
           // plus a directory per inline level. The `self/` head marks the
           // second form for the resolver.
           const declaredPath = rustPathAttribute(typed);
+          const name = stripRawIdent(match[1]);
+          // The name a declaration brings into scope, which is the module's
+          // name and never its file's: `#[path = "custom.rs"] mod foo;` puts
+          // `foo` in scope, and `use foo::Item;` beside it compiles — checked
+          // on cargo 1.70.0 and 1.98.0. It is carried separately because the
+          // specifier cannot hold it: there it is a path, or an anchored
+          // `self::…` chain. Declared inside an inline block, the name belongs
+          // to that block and not to the file, so nothing is reported.
+          const declaredName = inline.chain.length === 0 ? name : undefined;
           if (declaredPath) {
             const spec =
               inline.chain.length === 0
                 ? declaredPath
                 : `self/${inline.chain.join("/")}/${declaredPath}`;
-            imports.push({ moduleSpecifier: spec, isDynamic: false, isModuleDeclaration: true });
+            imports.push({
+              moduleSpecifier: spec,
+              isDynamic: false,
+              isModuleDeclaration: true,
+              declaredName,
+            });
             continue;
           }
-          const name = stripRawIdent(match[1]);
           // Declared inside `mod outer { … }`, the file sits under `outer/`,
           // not beside the declaring file.
           const spec =
             inline.chain.length === 0 ? name : ["self", ...inline.chain, name].join("::");
-          imports.push({ moduleSpecifier: spec, isDynamic: false, isModuleDeclaration: true });
+          imports.push({
+            moduleSpecifier: spec,
+            isDynamic: false,
+            isModuleDeclaration: true,
+            declaredName,
+          });
         }
         // extern crate serde;  /  #[macro_use] extern crate log as logging;
         //

--- a/src/services/graph-imports.ts
+++ b/src/services/graph-imports.ts
@@ -28,6 +28,18 @@ export interface ImportInfo {
    * `foo` an unanchored `use foo::Item;` in that file may reach.
    */
   declaredName?: string;
+  /**
+   * True when the path was written inside an inline `mod { … }` block and its
+   * head is not a module that block declares. Such a head cannot reach a module
+   * the *file* declares: rustc asks for an anchor first. Checked on cargo
+   * 1.98.0 — `pub mod corelib;` at file level with `use corelib::marker;`
+   * inside `pub mod block { … }` is E0432, "a similar path exists: use
+   * crate::corelib::marker" (`super::` where the block sits deeper).
+   *
+   * It is the mirror of the case already handled the other way round, where a
+   * declaration written inside a block does not count at file level.
+   */
+  fromInlineBlock?: boolean;
 }
 
 /**
@@ -328,8 +340,9 @@ function rustInlineModules(node: SgNodeLike): InlinePosition {
       innermost ??= current;
       // An inline `mod` may carry a `#[path]` of its own, and then it is that
       // path — not the module's name — that names the directory its children
-      // live in.
-      const declared = rustPathAttribute(current);
+      // live in. Where several are named, only one directory can be walked
+      // from: the nearest is taken, the reading a single `#[path]` already got.
+      const declared = rustPathAttributes(current).paths[0] ?? null;
       const name = current.field("name")?.text();
       if (declared) chain.unshift(declared.replace(/\/+$/, ""));
       else if (name) chain.unshift(stripRawIdent(name));
@@ -339,21 +352,112 @@ function rustInlineModules(node: SgNodeLike): InlinePosition {
 
   // What the innermost block declares by hand: a path whose head names one of
   // these is a path into the block, not out to another crate.
+  //
+  // Direct children only. `findAll` walks the whole subtree, so a module
+  // declared two blocks down counted as this block's own: with
+  // `mod nested { pub mod corelib { … } }` inside `outer`, a `use
+  // corelib::marker;` written in `outer` was rebased into the block and drew an
+  // edge to a file rustc never reaches — `error[E0432]: unresolved import
+  // corelib` on rustc 1.98.0, edition 2021. A name declared in a nested block
+  // is in that block's scope, not in this one's, which is the same rule that
+  // keeps a block's declaration out of the file's scope.
   const declares = new Set<string>();
+  let importsEverything = false;
   const body = innermost?.field("body");
   if (body) {
-    for (const child of body.findAll({ rule: { kind: "mod_item" } })) {
-      const name = child.field("name")?.text();
-      if (name) declares.add(stripRawIdent(name));
+    for (const child of body.children()) {
+      if (child.kind() === "mod_item") {
+        const name = child.field("name")?.text();
+        if (name) declares.add(stripRawIdent(name));
+        continue;
+      }
+      // A glob rooted inside the crate puts names in the block that nothing
+      // here can enumerate: `use super::*;` brings in every module the file
+      // declares, and then a bare head inside the block does reach one —
+      // verified on rustc 1.98.0, edition 2021, where the same line is E0432
+      // with the glob removed. Where one appears, the block's scope is not
+      // knowable from the block alone, so nothing is asserted about it.
+      //
+      // The whole path has to be read, not just the trailing `*`. A glob over a
+      // dependency (`use std::collections::*;`) brings in nothing of this
+      // crate, and one over a submodule (`use crate::prelude::*;`) brings in
+      // only what that module re-exports — neither puts the file's own modules
+      // in the block, and treating them as if they did switched the guard off
+      // for any block that happened to contain one. Only the anchor itself
+      // does: `use super::*;` at the first level is the file's own scope, in
+      // whichever of its spellings it is written.
+      if (child.kind() === "use_declaration") {
+        const text = stripRustComments(child.text()).replace(/\s+/g, "");
+        const tree = text.replace(/^(?:pub(?:\([^)]*\))?)?use/, "").replace(/;$/, "");
+        if (namesAnchorGlob(tree, chain.length)) importsEverything = true;
+      }
     }
   }
-  return { chain, declares };
+  return { chain, declares, importsEverything };
+}
+
+/**
+ * True when a `use` tree names the glob that reaches out of `depth` inline
+ * blocks and into the file's own scope: `super::*` from one level down,
+ * `super::super::*` from two, and so on. Any spelling, flat or braced.
+ *
+ * The anchor is what puts the file's own modules into a block's scope, so
+ * finding it is what switches the scope guard off. Reading only the flat
+ * spelling missed the braced ones: `use {super::*};` is a group with no prefix
+ * carrying the anchor inside, `use super::{*};` is the same import written the
+ * other way round, and both compile where the bare head that follows is E0432
+ * without them — checked on cargo 1.98.0, edition 2021, with
+ * `use corelib::sub::Marker;` inside `pub mod block { … }`. The cost of missing
+ * one is a real edge left undrawn.
+ *
+ * **The count matters, and the other anchors are not anchors here.** `self::*`
+ * is the block's own scope, `crate::*` is the crate root, and `super::*` from
+ * two levels down only reaches the block in between. None of them puts the
+ * file's declarations in scope: `use crate::{*};` beside `use sibling::Marker;`
+ * inside `mod inner` in a non-root file is E0432 on cargo 1.98.0, "a similar
+ * path exists: super::sibling::Marker", and reading it as an anchor drew that
+ * rejected import as an edge.
+ *
+ * A group is walked rather than matched: the anchor may sit at any depth
+ * (`use {super::{*}};`), and rebuilding each leaf against its prefix is what
+ * the recursion does.
+ */
+function namesAnchorGlob(tree: string, depth: number): boolean {
+  const trimmed = tree.trim();
+  if (!trimmed) return false;
+
+  const open = trimmed.indexOf("{");
+  if (open === -1) {
+    const flat = trimmed.replace(/\s+/g, "");
+    if (!flat.endsWith("::*")) return false;
+    const segments = flat.slice(0, -3).split("::");
+    return segments.length === depth && segments.every((segment) => segment === "super");
+  }
+
+  const close = trimmed.lastIndexOf("}");
+  if (close < open) return false;
+
+  // A leading `::` marks a crate outside this one, whose glob brings in nothing
+  // the file declares. Only a prefix that is itself an anchor can lead to one.
+  const prefix = trimmed.slice(0, open).replace(/::\s*$/, "").trim();
+  if (prefix.startsWith("::")) return false;
+  for (const part of splitRustUseList(trimmed.slice(open + 1, close))) {
+    if (namesAnchorGlob(prefix ? `${prefix}::${part.trim()}` : part, depth)) return true;
+  }
+  return false;
 }
 
 /** Where a declaration sits inside inline `mod` blocks, and what they declare. */
 interface InlinePosition {
   chain: string[];
   declares: Set<string>;
+  /**
+   * True when the innermost block carries a glob `use`, which puts names in its
+   * scope that cannot be enumerated from the block. A bare head inside such a
+   * block may legitimately reach a module the file declares, so nothing is
+   * asserted about its scope.
+   */
+  importsEverything?: boolean;
 }
 
 /** The subset of the ast-grep node API this module reads. */
@@ -364,6 +468,8 @@ interface SgNodeLike {
   prev(): SgNodeLike | null;
   field(name: string): SgNodeLike | null;
   findAll(matcher: { rule: { kind: string } }): SgNodeLike[];
+  children(): SgNodeLike[];
+  range(): { start: { index: number }; end: { index: number } };
 }
 
 /**
@@ -419,27 +525,118 @@ function rustPathFromInline(path: string, inline: InlinePosition): string | null
 }
 
 /**
- * The file a `#[path = "…"]` attribute points at, relative to the directory
- * the declaring file sits in — never to the directory that file's submodules
- * live in. Both `src/a/b.rs` and `src/a/mod.rs` resolve `#[path = "moved.rs"]`
- * to `src/a/moved.rs`.
+ * The values of the `path = "…"` arguments an attribute writes at its own
+ * level, ignoring anything that only *looks* like one from inside a string.
+ *
+ * Scanning the raw text was enough until a doc string named a path:
+ * `#[cfg_attr(docsrs, doc = r#"override with path = "custom.rs""#)] mod plain;`
+ * compiles by convention against `src/plain.rs` on cargo 1.98.0, and reading
+ * the doc's words as a relocation lost that edge without a trace. Strings are
+ * skipped whole — plain, escaped and raw with any number of hashes — and only
+ * what is left is read.
+ */
+function pathValuesOutsideStrings(text: string): string[] {
+  const values: string[] = [];
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+
+    // A raw string opens with `r`, any number of `#`, and a quote; it ends at
+    // the quote followed by the same number of hashes, and nothing inside it
+    // escapes.
+    if (ch === "r") {
+      const raw = /^r(#*)"/.exec(text.slice(i));
+      if (raw) {
+        const closer = `"${raw[1]}`;
+        const end = text.indexOf(closer, i + raw[0].length);
+        i = end === -1 ? text.length : end + closer.length;
+        continue;
+      }
+    }
+
+    if (ch === '"') {
+      // Read the string, and keep it when it is the value of a `path` written
+      // outside any other string — which is what the walk has established by
+      // arriving here.
+      let j = i + 1;
+      let value = "";
+      while (j < text.length && text[j] !== '"') {
+        if (text[j] === "\\") {
+          value += text[j + 1] ?? "";
+          j += 2;
+          continue;
+        }
+        value += text[j];
+        j += 1;
+      }
+      if (/\bpath\s*=\s*$/.test(text.slice(0, i))) values.push(value);
+      i = j + 1;
+      continue;
+    }
+
+    i += 1;
+  }
+  return values;
+}
+
+/**
+ * Every file the `#[path = "…"]` attributes above a `mod` point at, relative to
+ * the directory the declaring file sits in — never to the directory that file's
+ * submodules live in. Both `src/a/b.rs` and `src/a/mod.rs` resolve
+ * `#[path = "moved.rs"]` to `src/a/moved.rs`.
  *
  * Attributes are siblings preceding the `mod` in the tree, and several may
  * stack (`#[cfg(test)]` above `#[path = …]`), so the walk goes back through
- * all of them.
+ * all of them. Nearest first, which is the order a single declaration is read
+ * in when only one path is named.
+ *
+ * **A `#[cfg_attr(…, path = "…")]` names one too**, and reading only the bare
+ * form did real damage in both directions at once. It is the Rust Reference's
+ * own example and the standard platform-abstraction idiom — 12 occurrences in 8
+ * crates of a 141-crate registry sample, among them `libc`, `rustix`, `serde`
+ * and `tempfile`. On `errno` the module `sys` is relocated to `unix.rs` or
+ * `windows.rs` and `src/sys.rs` is never read; unread, the graph drew an edge
+ * to a file rustc ignores and missed the one holding the whole crate body.
+ * Reproduced on cargo 1.98.0 with a `compile_error!` in `src/sys.rs`: the
+ * package builds, and the dep-info lists `src/unix.rs` and no `src/sys.rs`.
+ *
+ * Every named path is returned, and each draws its own edge. That is the
+ * reading the rest of the model already takes: the graph is independent of
+ * which features and target are selected, so a module that is `unix.rs` here
+ * and `windows.rs` there depends on both as far as the tree is concerned.
+ *
+ * `conditional` says whether every path found came from a `cfg_attr`. When it
+ * did, **the convention is still one of the answers**: with the condition
+ * false the attribute is not applied at all and the module is the file its name
+ * implies. `#[cfg_attr(any(), path = "ghost.rs")] mod platform;` compiles
+ * against `src/platform.rs` on cargo 1.98.0, and reading only the named path
+ * lost that edge while drawing one into a file rustc never opens.
  */
-function rustPathAttribute(node: SgNodeLike): string | null {
+function rustPathAttributes(node: SgNodeLike): { paths: string[]; conditional: boolean } {
+  const paths: string[] = [];
+  let conditional = true;
   let previous = node.prev();
   // Comments count as siblings too, and one written between the attribute and
   // the `mod` it belongs to would otherwise end the walk before the attribute
   // is seen — a comment above a relocated module is exactly where someone
   // explains why it was relocated.
   while (previous && (previous.kind() === "attribute_item" || previous.kind().includes("comment"))) {
-    const match = previous.text().match(/^#\[\s*path\s*=\s*"([^"]+)"\s*\]$/);
-    if (match) return match[1];
+    const text = previous.text();
+    const bare = text.match(/^#\[\s*path\s*=\s*"([^"]+)"\s*\]$/);
+    if (bare) {
+      paths.push(bare[1]);
+      // A bare `#[path]` always applies, so the convention never comes back.
+      conditional = false;
+    } else if (/^#\[\s*cfg_attr\s*\(/.test(text)) {
+      // The condition is not read: what it selects depends on the target and
+      // the features, neither of which this graph fixes. Only `path` is picked
+      // out of the attributes the `cfg_attr` would apply — a `#[cfg_attr(unix,
+      // doc = "…")]` names none and contributes nothing.
+      paths.push(...pathValuesOutsideStrings(text));
+    }
     previous = previous.prev();
   }
-  return null;
+  return { paths, conditional: paths.length > 0 && conditional };
 }
 
 /**
@@ -467,11 +664,23 @@ export function expandRustUseTree(tree: string): string[] {
   const close = trimmed.lastIndexOf("}");
   if (close < open) return [];
 
-  const prefix = trimmed.slice(0, open).replace(/::\s*$/, "").trim();
+  // A group written `::{a::b, c::d}` carries the external marker in its prefix
+  // and nowhere else: stripping the trailing `::` leaves the empty string, and
+  // an empty prefix is indistinguishable from a group with no prefix at all
+  // (`use {a, b};`). Read that way, `use ::{log::info};` reached the local
+  // module `log` again — the very capture the leading `::` exists to prevent,
+  // and the same bug the single-path spelling had. `::corelib::{marker}` was
+  // never affected, because there the marker survives inside a non-empty
+  // prefix. Checked on rustc 1.98.0: in edition 2018 the braced global form
+  // resolves to the dependency and `use log::info;` beside `pub mod log;`
+  // is E0432, so the two spellings must not resolve to the same file.
+  const rawPrefix = trimmed.slice(0, open).trim();
+  const global = rawPrefix === "::";
+  const prefix = rawPrefix.replace(/::\s*$/, "").trim();
   const paths: string[] = [];
   for (const part of splitRustUseList(trimmed.slice(open + 1, close))) {
     for (const expanded of expandRustUseTree(part)) {
-      paths.push(prefix ? `${prefix}::${expanded}` : expanded);
+      paths.push(prefix ? `${prefix}::${expanded}` : global ? `::${expanded}` : expanded);
     }
     // `self` and `*` expand to nothing, so the group's own prefix is what the
     // leaf named: `use crate::a::{self, b}` imports `crate::a` as well as
@@ -484,10 +693,172 @@ export function expandRustUseTree(tree: string): string[] {
 }
 
 /**
+ * The Rust source with the head and the braces of every `name! { … }` erased,
+ * so what the invocation wraps is read as the items it is.
+ *
+ * tree-sitter keeps a macro's body as an unparsed token tree, so nothing inside
+ * one is a node and `findAll` walks straight past it. Expansion happens before
+ * name resolution, though, and a `mod x;` written in there is a declaration like
+ * any other: **256 of tokio's 535 `mod` declarations (48%) were invisible**, and
+ * 566 of 3,286 across a 141-crate registry sample, plus 348 `use` in tokio
+ * alone. 59 of the 287 files rustc reads for tokio's lib had no incoming edge,
+ * every one of them declared inside a macro body.
+ *
+ *     cfg_io_util! {          // tokio/src/io/util/mod.rs
+ *         mod async_buf_read_ext;
+ *         …36 declarations the graph did not see
+ *     }
+ *
+ * The rewrite keeps every other character where it was, so what the body sits
+ * inside is unchanged: a macro invoked inside `mod inner { … }` leaves its
+ * declarations inside that block, and the inline-block machinery reads them
+ * from there without knowing a macro was ever involved. **A macro body is not a
+ * module level** — it opens no scope of its own — and blanking the braces
+ * rather than the whole invocation is what says so.
+ *
+ * Only `{}` is unwrapped. A `()` or `[]` invocation carries an expression, not
+ * items, and unwrapping it would feed the parser a fragment that is not one.
+ *
+ * **The limit that stays**: what a macro does with the tokens it is handed is
+ * unknowable from the source. One that expands them declares the modules it
+ * names; one that discards them declares nothing, and both are written the same
+ * way. Reading the body is the answer that is right for the shapes that occur —
+ * `cfg_if!` and the `cfg_*!` family, which is what the 295 invocations carrying
+ * a `mod` in a 245-crate sample are made of — and wrong for a macro that throws
+ * its argument away. Restricting to item positions closes the case that
+ * actually occurs, `quote!`; a discarding macro in item position is left as a
+ * known cost.
+ *
+ * And only where an item may stand. A macro body holds items when the
+ * invocation itself is an item — that is the whole of the rule, and reading it
+ * off the tree keeps the graph from having to know any library by name. Without
+ * it, a proc-macro crate writing
+ *
+ *     quote! {
+ *         mod generated;
+ *     }
+ *     .into()
+ *
+ * had `src/generated.rs` drawn as its dependency, though that module belongs to
+ * whoever invokes the macro and rustc never reads the file here: verified on
+ * cargo 1.98.0 with a `compile_error!` in it, where the crate builds clean and
+ * the dep-info lists `src/lib.rs` alone.
+ *
+ * Returns null when there was nothing to unwrap, which is the common case.
+ */
+function rustSourceWithMacroBodiesInlined(source: string, root: SgNodeLike): string | null {
+  const chars = source.split("");
+  const blank = (at: number): void => {
+    // Newlines stay: a line comment must keep ending where it ended, or what
+    // follows it on the next line is swallowed.
+    if (chars[at] !== "\n" && chars[at] !== "\r") chars[at] = " ";
+  };
+
+  let changed = false;
+  for (const node of root.findAll({ rule: { kind: "macro_invocation" } })) {
+    if (!standsWhereAnItemMay(node)) continue;
+    const text = node.text();
+    const open = text.indexOf("{");
+    if (open === -1) continue;
+    // The last brace has to close the invocation itself. Where it does not, the
+    // delimiter is `(` or `[` and the `{` found above is inside the arguments.
+    const trimmed = text.trimEnd();
+    if (!trimmed.endsWith("}")) continue;
+    const close = text.lastIndexOf("}");
+    if (close <= open) continue;
+
+    const start = node.range().start.index;
+    for (let i = 0; i <= open; i++) blank(start + i);
+    blank(start + close);
+    changed = true;
+  }
+  return changed ? chars.join("") : null;
+}
+
+/**
+ * Whether a node sits where a Rust *item* is written: the file itself, or the
+ * body of a `mod`, `impl` or `trait`.
+ *
+ * A macro invocation anywhere else is an expression, and what it wraps is a
+ * value being built rather than items being declared. That is what keeps a
+ * proc-macro's `quote!` from being read as this crate's own declarations: the
+ * module it names belongs to whoever invokes the macro, and rustc never opens
+ * the file here — verified on cargo 1.98.0 with a `compile_error!` in it, where
+ * the crate builds clean and its dep-info lists `src/lib.rs` alone.
+ *
+ * **A block is not on the list**, though an item may legally be written in one.
+ * The tail expression of a block — a `quote! { … }` returned without a
+ * semicolon, the idiom of every `fn … -> TokenStream` — has `block` for its
+ * parent too, and nothing in the tree tells the two apart. Measured across
+ * ripgrep, tokio and clap, admitting blocks adds not one edge, so the whole of
+ * what it buys is that false one.
+ *
+ * An `impl` body does count, even though no `mod` may be written in one:
+ * tokio's `cfg_unstable! { fn … { use crate::runtime::UnhandledPanic; } }` is
+ * written there, and the `use` inside the function it wraps is a real
+ * dependency.
+ */
+function standsWhereAnItemMay(node: SgNodeLike): boolean {
+  const kind = node.parent()?.kind();
+  return kind === "source_file" || kind === "declaration_list";
+}
+
+/** A key that tells two extracted imports apart, for the multiset below. */
+function importKey(imp: ImportInfo): string {
+  return [
+    imp.moduleSpecifier,
+    imp.isDynamic,
+    imp.isCssImport ?? "",
+    imp.isModuleDeclaration ?? "",
+    imp.declaredName ?? "",
+    imp.fromInlineBlock ?? "",
+  ].join(" ");
+}
+
+/**
+ * The imports of `found` that `already` does not hold, counting repeats.
+ *
+ * The second pass over a macro-unwrapped source re-reads the whole file, so
+ * everything the first pass found comes back with it. Subtracting as a multiset
+ * adds exactly what the macro bodies were hiding and leaves the existing edges —
+ * including their repeats, which consumers count — untouched.
+ */
+function importsNotAlreadyFound(found: ImportInfo[], already: ImportInfo[]): ImportInfo[] {
+  const remaining = new Map<string, number>();
+  for (const imp of already) {
+    const key = importKey(imp);
+    remaining.set(key, (remaining.get(key) ?? 0) + 1);
+  }
+  const fresh: ImportInfo[] = [];
+  for (const imp of found) {
+    const key = importKey(imp);
+    const left = remaining.get(key) ?? 0;
+    if (left > 0) remaining.set(key, left - 1);
+    else fresh.push(imp);
+  }
+  return fresh;
+}
+
+/**
+ * How many times a Rust source is re-read after unwrapping macro bodies.
+ *
+ * One pass covers what is written in a file; a second catches a macro that only
+ * became visible when the one around it was unwrapped. The bound is what keeps
+ * a pathological file from being re-parsed without end — it is not a limit
+ * anything real has been seen to reach.
+ */
+const RUST_MACRO_UNWRAP_PASSES = 2;
+
+/**
  * Extract import statements from source code using ast-grep.
  * Returns raw module specifiers for each language's import syntax.
  */
-export function extractImports(source: string, lang: Lang | string, ext: string): ImportInfo[] {
+export function extractImports(
+  source: string,
+  lang: Lang | string,
+  ext: string,
+  unwrapPassesLeft: number = RUST_MACRO_UNWRAP_PASSES,
+): ImportInfo[] {
   const imports: ImportInfo[] = [];
   const langKey = String(lang);
 
@@ -650,7 +1021,25 @@ export function extractImports(source: string, lang: Lang | string, ext: string)
           const inline = rustInlineModules(node as unknown as SgNodeLike);
           for (const spec of expandRustUseTree(match[1])) {
             const fromInline = rustPathFromInline(spec, inline);
-            if (fromInline) imports.push({ moduleSpecifier: fromInline, isDynamic: false });
+            if (!fromInline) continue;
+            // A bare head inside a block, left alone by the rebase above, is
+            // either another crate or nothing — never a module the file
+            // declares. Marking it here is what keeps the resolver from
+            // answering it with the file's own declarations.
+            const head = fromInline.replace(/^::/, "").split("::")[0];
+            const bareInsideBlock =
+              inline.chain.length > 0 &&
+              !inline.importsEverything &&
+              !fromInline.startsWith("::") &&
+              !fromInline.startsWith("self::") &&
+              !fromInline.startsWith("super::") &&
+              !fromInline.startsWith("crate::") &&
+              !inline.declares.has(head);
+            imports.push({
+              moduleSpecifier: fromInline,
+              isDynamic: false,
+              ...(bareInsideBlock ? { fromInlineBlock: true } : {}),
+            });
           }
         }
         // mod foo;  /  pub mod foo;  /  pub(crate) mod foo;  /  mod r#async;
@@ -675,7 +1064,7 @@ export function extractImports(source: string, lang: Lang | string, ext: string)
           // inline block resolves it against that file's own module directory
           // plus a directory per inline level. The `self/` head marks the
           // second form for the resolver.
-          const declaredPath = rustPathAttribute(typed);
+          const { paths: declaredPaths, conditional } = rustPathAttributes(typed);
           const name = stripRawIdent(match[1]);
           // The name a declaration brings into scope, which is the module's
           // name and never its file's: `#[path = "custom.rs"] mod foo;` puts
@@ -685,18 +1074,31 @@ export function extractImports(source: string, lang: Lang | string, ext: string)
           // `self::…` chain. Declared inside an inline block, the name belongs
           // to that block and not to the file, so nothing is reported.
           const declaredName = inline.chain.length === 0 ? name : undefined;
-          if (declaredPath) {
-            const spec =
-              inline.chain.length === 0
-                ? declaredPath
-                : `self/${inline.chain.join("/")}/${declaredPath}`;
-            imports.push({
-              moduleSpecifier: spec,
-              isDynamic: false,
-              isModuleDeclaration: true,
-              declaredName,
-            });
-            continue;
+          if (declaredPaths.length > 0) {
+            // The name the declaration brings into scope is carried by exactly
+            // one of the specifiers, because the map it feeds holds one file
+            // per name. An unconditional `#[path]` takes it — that file is the
+            // module, full stop. Where every path is conditional the convention
+            // takes it instead: the map also answers this file's own
+            // declaration, and pointing it at a conditional path made
+            // `mod platform;` resolve to `ghost.rs` and lose `platform.rs`.
+            const nameGoesToConvention = conditional;
+            for (const [index, declaredPath] of declaredPaths.entries()) {
+              const spec =
+                inline.chain.length === 0
+                  ? declaredPath
+                  : `self/${inline.chain.join("/")}/${declaredPath}`;
+              imports.push({
+                moduleSpecifier: spec,
+                isDynamic: false,
+                isModuleDeclaration: true,
+                declaredName: index === 0 && !nameGoesToConvention ? declaredName : undefined,
+              });
+            }
+            // Every path came from a `cfg_attr`, so the condition may be false
+            // and leave the module where its name puts it. That file is one of
+            // the answers too, and it falls through to the convention below.
+            if (!conditional) continue;
           }
           // Declared inside `mod outer { … }`, the file sits under `outer/`,
           // not beside the declaring file.
@@ -706,7 +1108,9 @@ export function extractImports(source: string, lang: Lang | string, ext: string)
             moduleSpecifier: spec,
             isDynamic: false,
             isModuleDeclaration: true,
-            declaredName,
+            // Claimed above by an unconditional `#[path]`, which is the module
+            // whatever its name says; a conditional one leaves it here.
+            declaredName: declaredPaths.length > 0 && !conditional ? undefined : declaredName,
           });
         }
         // extern crate serde;  /  #[macro_use] extern crate log as logging;
@@ -719,6 +1123,21 @@ export function extractImports(source: string, lang: Lang | string, ext: string)
           const name = node.field("name")?.text();
           if (name && name !== "self") {
             imports.push({ moduleSpecifier: stripRawIdent(name), isDynamic: false });
+          }
+        }
+
+        // What a macro invocation wraps is read last, on a source with its head
+        // and braces blanked out, and only what the pass above could not see is
+        // kept. See `rustSourceWithMacroBodiesInlined` for why a body has to be
+        // read at all, and why it is not a module level.
+        if (unwrapPassesLeft > 0) {
+          const inlined = rustSourceWithMacroBodiesInlined(
+            source,
+            sgNode as unknown as SgNodeLike,
+          );
+          if (inlined !== null) {
+            const withBodies = extractImports(inlined, lang, ext, unwrapPassesLeft - 1);
+            imports.push(...importsNotAlreadyFound(withBodies, imports));
           }
         }
         break;

--- a/src/services/graph-imports.ts
+++ b/src/services/graph-imports.ts
@@ -761,10 +761,12 @@ export function expandRustUseTree(tree: string): string[] {
  * `mod after;` lost the edge it should have had.
  *
  * So the rewritten source is parsed before it is used, and it is kept only when
- * every ERROR node sits inside a macro that was unwrapped. Where one does not,
- * the pass is redone with the bodies that parse as items on their own — the
- * rest stay the token trees they were. `recoveryStaysInside` carries why the
- * test is drawn there and not around the ERROR itself.
+ * every ERROR node sits inside a macro this pass unwrapped, or is one the pass
+ * before already accepted. Where one does not, the pass is redone with the
+ * bodies that parse as items on their own — the rest stay the token trees they
+ * were. `recoveryStaysInside` carries why the test is drawn there and not
+ * around the ERROR itself, and why what an earlier pass hands on is its ERRORs
+ * rather than its regions.
  *
  * The admission rule still decides what a body means: an `if #[cfg(…)]` is not
  * something the language guarantees, it is what one library spells its
@@ -779,7 +781,7 @@ export function expandRustUseTree(tree: string): string[] {
 function rustSourceWithMacroBodiesInlined(
   source: string,
   root: SgNodeLike,
-  carried: MacroRegion[],
+  forgiven: Span[],
 ): UnwrappedSource | null {
   const regions: MacroRegion[] = [];
   for (const node of root.findAll({ rule: { kind: "macro_invocation" } })) {
@@ -803,7 +805,11 @@ function rustSourceWithMacroBodiesInlined(
   }
   if (regions.length === 0) return null;
 
-  const attempts: MacroRegion[][] = [regions];
+  // An ERROR the source has before anything is blanked, outside every macro
+  // about to be unwrapped and not one an earlier pass already accepted, will
+  // reject every attempt below — the check is answered on the tree in hand,
+  // before three parses that cannot pass.
+  if (!recoveryStaysInside(root, regions, forgiven)) return null;
 
   // Recovery reached past a macro's own text, so the tree around it can no
   // longer be trusted — but the macro that let it out is one of the few written
@@ -819,26 +825,52 @@ function rustSourceWithMacroBodiesInlined(
   // libc's `freebsd/mod.rs` parses as one ERROR from line 1 once its fifteen
   // `cfg_if!`s are blanked — and no reading of that tree would be worth
   // trusting.
-  const dirty = (r: MacroRegion): boolean =>
-    !rustBodyIsItemsOnItsOwn(source.slice(r.open + 1, r.close));
-  const outsideBlocks = regions.filter((r) => !(r.insideBlock && dirty(r)));
-  if (outsideBlocks.length < regions.length) attempts.push(outsideBlocks);
-  const clean = regions.filter((r) => !dirty(r));
-  if (clean.length < outsideBlocks.length) attempts.push(clean);
+  //
+  // Each body is parsed on its own at most once, and only once the first
+  // attempt has been refused: the common outcome is that it is not, and a
+  // tokio file with a dozen `cfg_*!` bodies would otherwise pay a dozen
+  // parses for nothing.
+  const parsedAlone = new Map<MacroRegion, boolean>();
+  const dirty = (r: MacroRegion): boolean => {
+    let answer = parsedAlone.get(r);
+    if (answer === undefined) {
+      answer = !rustBodyIsItemsOnItsOwn(source.slice(r.open + 1, r.close));
+      parsedAlone.set(r, answer);
+    }
+    return answer;
+  };
+  const narrower: (() => MacroRegion[])[] = [
+    () => regions.filter((r) => !(r.insideBlock && dirty(r))),
+    () => regions.filter((r) => !dirty(r)),
+  ];
 
-  for (const attempt of attempts) {
-    if (attempt.length === 0) continue;
+  let attempt = regions;
+  for (;;) {
     const rewritten = rustSourceWithRegionsBlanked(source, attempt);
-    // Every macro unwrapped so far counts, not only this pass's own: the second
-    // pass reads what the first one rewrote, so a `cfg_if!` kept there has its
-    // ERROR standing in this pass's input. Blanking preserves every index —
-    // characters become spaces, none are removed — so the regions carried from
-    // the earlier pass still say where its text is.
-    const unwrapped = carried.concat(attempt);
-    const kept = recoveryStaysInside(rewritten, unwrapped);
-    if (kept) return { source: rewritten, root: kept, regions: unwrapped };
+    let tree: SgNodeLike;
+    try {
+      tree = parse("rust" as unknown as Lang, rewritten).root() as unknown as SgNodeLike;
+    } catch {
+      return null;
+    }
+    const errors = recoveryStaysInside(tree, attempt, forgiven);
+    if (errors) return { source: rewritten, root: tree, errors };
+
+    // Retry with fewer bodies, but only when the next rule actually drops one.
+    let next: MacroRegion[] | undefined;
+    while (next === undefined && narrower.length > 0) {
+      const candidate = narrower.shift()?.();
+      if (candidate !== undefined && candidate.length < attempt.length) next = candidate;
+    }
+    if (next === undefined || next.length === 0) return null;
+    attempt = next;
   }
-  return null;
+}
+
+/** A half-open range of character indexes in a source. */
+interface Span {
+  start: number;
+  end: number;
 }
 
 interface UnwrappedSource {
@@ -846,8 +878,12 @@ interface UnwrappedSource {
   source: string;
   /** Its tree, already built by the check that accepted it. */
   root: SgNodeLike;
-  /** Every macro region blanked in it, this pass's and the earlier ones'. */
-  regions: MacroRegion[];
+  /**
+   * Every ERROR node that tree holds — each inside a macro unwrapped in this
+   * pass or an earlier one, or the check would not have accepted it. The next
+   * pass forgives exactly these, and nothing else.
+   */
+  errors: Span[];
 }
 
 interface MacroRegion {
@@ -901,39 +937,53 @@ function rustSourceWithRegionsBlanked(source: string, regions: MacroRegion[]): s
  * to close the 18 would pay for the fix with the case that works: `js-sys`,
  * `backtrace`, `ahash` and `aes` each lose real module edges.
  *
- * `regions` is every macro unwrapped so far, the earlier passes' included, and
- * nothing else earns an exemption. Tolerating the ERROR nodes a source already
- * had is the obvious-looking shortcut and it opens the defect back up: a file
- * carrying an unresolved merge marker inside `mod inner { … }` has an ERROR at
- * the same index the recovery produces, so the damaged pass was accepted and
- * `mod after;` was drawn at file level again. Measured on the live version
- * before this was tightened.
+ * An ERROR earns its exemption one of two ways, and nothing else does. Either it
+ * sits inside a macro *this* pass unwrapped, or it is — start and end — one the
+ * earlier pass already accepted, which still stands in this pass's input since
+ * blanking turns characters into spaces and removes none. The second pass reads
+ * what the first rewrote, so a file-level `cfg_if!` kept there has its ERROR on
+ * the attribute in this pass's text, and that one is forgiven.
+ *
+ * Two shortcuts look equivalent and both reopen the defect. Tolerating the
+ * ERROR nodes a source already had: a file carrying an unresolved merge marker
+ * inside `mod inner { … }` has an ERROR at the same index the recovery produces,
+ * so the damaged pass was accepted and `mod after;` was drawn at file level
+ * again — measured on the live version before this was tightened. Tolerating
+ * anything inside a macro an earlier pass unwrapped: a clean body such as
+ * `outer! { mod k { cfg_if! { … } mod z; } }` is accepted whole on the first
+ * pass, and on the second the `cfg_if!` closes `mod k` early — the orphan `}`
+ * that should reject the pass lies inside `outer!`'s region, and `mod z;` was
+ * drawn at file level exactly as in the case this guard was written for. Found
+ * by review, and the reason the exemption is a list of ERRORs, not of regions.
  *
  * A source that does not parse cleanly for reasons of its own therefore gets no
  * unwrapping at all, which is the conservative side to fall on: 1,771 of 34,655
  * `.rs` files in a registry cache are in that state, and not one of them carries
  * a declaration inside a macro body.
  *
- * Returns the tree when the source is usable, so the caller reads its imports
- * off it instead of parsing the same text again, which is what keeps the check
- * affordable. What it still costs, measured on tokio with nine runs a side
- * alternating between the two: 2,013 ms before this change, 2,123 ms after,
- * against 1,304 ms on `main` — so the guard is 5% of the graph build, on top of
- * the 54% the rest of the Rust work already costs.
+ * Returns the ERROR nodes of an accepted tree, which is what the next pass is
+ * handed, and null where one lies outside. The tree is the one the caller
+ * already built and goes on to read its imports off, so the check adds no
+ * parse of its own. What it still costs, measured on tokio with nine runs a
+ * side alternating between the two: 2,013 ms before this change, 2,123 ms
+ * after, against 1,304 ms on `main` — 5% of the graph build, on top of the 54%
+ * the rest of the Rust work already costs.
  */
-function recoveryStaysInside(rewritten: string, regions: MacroRegion[]): SgNodeLike | null {
-  let root: SgNodeLike;
-  try {
-    root = parse("rust" as unknown as Lang, rewritten).root() as unknown as SgNodeLike;
-  } catch {
-    return null;
-  }
+function recoveryStaysInside(
+  root: SgNodeLike,
+  regions: MacroRegion[],
+  forgiven: Span[],
+): Span[] | null {
+  const errors: Span[] = [];
   for (const error of root.findAll({ rule: { kind: "ERROR" } })) {
-    const { start, end } = error.range();
-    const inside = regions.some((r) => start.index >= r.start && end.index <= r.close + 1);
-    if (!inside) return null;
+    const start = error.range().start.index;
+    const end = error.range().end.index;
+    const inside = regions.some((r) => start >= r.start && end <= r.close + 1);
+    const inherited = forgiven.some((f) => f.start === start && f.end === end);
+    if (!inside && !inherited) return null;
+    errors.push({ start, end });
   }
-  return root;
+  return errors;
 }
 
 /**
@@ -987,7 +1037,19 @@ function standsWhereAnItemMay(node: SgNodeLike): boolean {
   return kind === "source_file" || kind === "declaration_list";
 }
 
-/** A key that tells two extracted imports apart, for the multiset below. */
+/**
+ * A key that tells two extracted imports apart, for the merge below.
+ *
+ * `fromInlineBlock` is left out on purpose: it is not part of what an import
+ * *is* but of how far the pass that read it could see. `mod tests { cfg_test! {
+ * use super::*; } use outer::Thing; }` reads `outer::Thing` as a bare head in a
+ * block on the first pass, because the glob that brings the file's own
+ * declarations into scope is still hidden in the token tree; the second pass
+ * sees the glob and reads the same line as a path the block may answer. Keyed
+ * on the flag, both readings were kept, and the first one — resolved with no
+ * declarations in scope — could reach a workspace crate named `outer` that
+ * rustc would refuse with E0432. Found by review.
+ */
 function importKey(imp: ImportInfo): string {
   return [
     imp.moduleSpecifier,
@@ -995,41 +1057,53 @@ function importKey(imp: ImportInfo): string {
     imp.isCssImport ?? "",
     imp.isModuleDeclaration ?? "",
     imp.declaredName ?? "",
-    imp.fromInlineBlock ?? "",
   ].join("\0");
 }
 
 /**
- * The imports of `found` that `already` does not hold, counting repeats.
+ * `already` with the second pass's reading folded in, counting repeats.
  *
  * The second pass over a macro-unwrapped source re-reads the whole file, so
- * everything the first pass found comes back with it. Subtracting as a multiset
- * adds exactly what the macro bodies were hiding and leaves the existing edges —
- * including their repeats, which consumers count — untouched.
+ * everything the first pass found comes back with it. Each import the second
+ * pass re-reads replaces the first pass's copy of it — the later reading saw
+ * more of the file, and its scope flag is the right one — and what only the
+ * macro bodies held is appended. An import the second pass did not come back
+ * with stays: an `include! { "x.rs" }` written with braces is blanked like any
+ * body, and only the first pass reads the file it names. Repeats survive on
+ * both sides, since consumers count them.
  */
-function importsNotAlreadyFound(found: ImportInfo[], already: ImportInfo[]): ImportInfo[] {
-  const remaining = new Map<string, number>();
-  for (const imp of already) {
+function withMacroPassMerged(already: ImportInfo[], found: ImportInfo[]): ImportInfo[] {
+  const merged = already.slice();
+  const unclaimed = new Map<string, number[]>();
+  already.forEach((imp, at) => {
     const key = importKey(imp);
-    remaining.set(key, (remaining.get(key) ?? 0) + 1);
-  }
-  const fresh: ImportInfo[] = [];
+    const slots = unclaimed.get(key);
+    if (slots) slots.push(at);
+    else unclaimed.set(key, [at]);
+  });
   for (const imp of found) {
-    const key = importKey(imp);
-    const left = remaining.get(key) ?? 0;
-    if (left > 0) remaining.set(key, left - 1);
-    else fresh.push(imp);
+    const at = unclaimed.get(importKey(imp))?.shift();
+    if (at === undefined) merged.push(imp);
+    else merged[at] = imp;
   }
-  return fresh;
+  return merged;
 }
 
 /**
  * How many times a Rust source is re-read after unwrapping macro bodies.
  *
  * One pass covers what is written in a file; a second catches a macro that only
- * became visible when the one around it was unwrapped. The bound is what keeps
- * a pathological file from being re-parsed without end — it is not a limit
- * anything real has been seen to reach.
+ * became visible when the one around it was unwrapped — provided it stands
+ * where an item may. A macro written inside a `cfg_if!` arm does not: after
+ * blanking, the arm is the block of a recovered `if`, and `standsWhereAnItemMay`
+ * turns a block down for the reason it gives. So `cfg_if! { if #[cfg(unix)] {
+ * cfg_io_util! { mod deep; } } }` reads nothing under `cfg_io_util!`, and a
+ * nested `cfg_if!` in an arm — a shape libc writes — reads only its own text.
+ * That is the limit of reading a body in place; reading each body on its own
+ * with the invocation's scope would lift it.
+ *
+ * The bound is what keeps a pathological file from being re-parsed without end
+ * — it is not a limit anything real has been seen to reach.
  */
 const RUST_MACRO_UNWRAP_PASSES = 2;
 
@@ -1379,14 +1453,14 @@ export function extractImports(
         }
 
         // What a macro invocation wraps is read last, on a source with its head
-        // and braces blanked out, and only what the pass above could not see is
-        // kept. See `rustSourceWithMacroBodiesInlined` for why a body has to be
-        // read at all, and why it is not a module level.
+        // and braces blanked out, and folded into what the pass above found. See
+        // `rustSourceWithMacroBodiesInlined` for why a body has to be read at
+        // all, and why it is not a module level.
         if (unwrapPassesLeft > 0) {
           const inlined = rustSourceWithMacroBodiesInlined(
             source,
             sgNode as unknown as SgNodeLike,
-            unwrapped?.regions ?? [],
+            unwrapped?.errors ?? [],
           );
           if (inlined !== null) {
             const withBodies = extractImports(
@@ -1396,7 +1470,7 @@ export function extractImports(
               unwrapPassesLeft - 1,
               inlined,
             );
-            imports.push(...importsNotAlreadyFound(withBodies, imports));
+            imports.splice(0, imports.length, ...withMacroPassMerged(imports, withBodies));
           }
         }
         break;

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1759,7 +1759,7 @@ export function resolveRustImport(
   // 1.98.0.
   const declaredFile = ((): string | null => {
     const spec = declaredMods?.get(head);
-    if (!spec || !spec.endsWith(".rs")) return null;
+    if (!spec?.endsWith(".rs")) return null;
     const fromInline = spec.startsWith("self/");
     const base = fromInline ? ownModuleDir : path.dirname(relSourceFile);
     const declared = toForwardSlash(

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1190,6 +1190,20 @@ export interface RustCrate {
    * library target, neither of which anything can import by name.
    */
   name: string | null;
+  /**
+   * `[package] name` with dashes turned into underscores, which is the name a
+   * dependency on this crate is declared under — while `name` above is what
+   * the code writes, and the two differ wherever `[lib] name` is set. Null for
+   * a manifest that declares no package.
+   */
+  packageName: string | null;
+  /**
+   * Set when the manifest could not be parsed. The crate still contributes its
+   * convention targets, but nothing is known about what it declares, and a
+   * check that reads "declares nothing" off an unread manifest would cost the
+   * package every cross-crate edge — one unreadable `Cargo.toml` must not.
+   */
+  manifestUnread?: true;
   /** Project-relative path of the library root module, when the crate has one. */
   libRoot: string | null;
   /**
@@ -1694,7 +1708,15 @@ export function buildRustCrateMap(fileSet: Set<string>, projectPath: string): Ru
       if (gitDeps.has(alias)) continue;
       if (patchedLocally.has(aliases[alias] ?? alias)) externalDeps.delete(alias);
     }
-    const crateEntry: RustCrate = { dir, name, libRoot, roots: [...roots].sort(), edition };
+    const crateEntry: RustCrate = {
+      dir,
+      name,
+      packageName: packageName?.replace(/-/g, "_") ?? null,
+      libRoot,
+      roots: [...roots].sort(),
+      edition,
+    };
+    if (manifest === null) crateEntry.manifestUnread = true;
     if (Object.keys(aliases).length > 0) {
       crateEntry.aliases = aliases;
     }
@@ -1820,6 +1842,13 @@ function resolveRustModulePath(
 }
 
 /**
+ * The crates rustc provides without any manifest declaring them: `std` and
+ * its two pieces, the proc-macro bridge, and the test harness. A path that
+ * names one reaches no file of this project, in any edition.
+ */
+const RUST_BUILTIN_CRATES = new Set(["std", "core", "alloc", "proc_macro", "test"]);
+
+/**
  * Resolve one Rust module path to the project file it names.
  *
  * `relSourceFile` is the importing file, project-relative and forward-slashed.
@@ -1904,23 +1933,49 @@ export function resolveRustImport(
     // across every crate of the project, so `use helper::Thing` drew an edge
     // into a sibling `helper` the manifest never named (review finding). The
     // one name a package reaches without declaring it is its own library,
-    // which its binaries, tests and examples import by that name. `aliases`
-    // holds every declared dependency under the name the code writes, renamed
-    // or not, so its keys are the fence. A file outside every manifest has
-    // no package to ask, and is left as it was.
-    if (
-      importingCrate &&
-      name !== importingCrate.name &&
-      !Object.hasOwn(importingCrate.aliases ?? {}, name)
-    ) {
-      return null;
+    // which its binaries, tests and examples import by that name.
+    //
+    // A dependency is declared under its package name (or an alias of it), but
+    // the code writes its *library* name, and the two differ wherever the
+    // dependency sets `[lib] name` — `rust-crypto` is imported as `crypto`. So
+    // the fence admits a name in two ways: it is a key of `aliases`, which
+    // holds every declared dependency under the name the code writes for it;
+    // or it is the library name of a project crate declared under its own
+    // package name — not renamed, since `tools = { package = "helper" }` puts
+    // the crate in scope as `tools` and nothing else. A manifest that could not be read
+    // declares nothing that can be known, and is not fenced at all — the
+    // alternative costs that package every cross-crate edge. A file outside
+    // every manifest has no package to ask, and is left as it was.
+    if (importingCrate && !importingCrate.manifestUnread && name !== importingCrate.name) {
+      const declared = Object.entries(importingCrate.aliases ?? {});
+      // Renamed, the alias is what cargo hands rustc as the crate's name.
+      const renamed = declared.some(([alias, target]) => alias !== target && alias === name);
+      // Declared under its own package name, the crate's name to rustc is its
+      // library name — cargo passes `--extern otherlib=…` for a dependency
+      // written `other = { path = "../other" }` whose `[lib] name` is
+      // `otherlib`, and `use other::Thing` is E0432 there. Where the project
+      // holds no crate of that package name, the dependency comes from outside
+      // and the package name is all that is known of it.
+      const plain = new Set(declared.filter(([alias, target]) => alias === target).map(([alias]) => alias));
+      const libraryOfPlain = crates.some(
+        (crate) => crate.name === name && crate.packageName !== null && plain.has(crate.packageName),
+      );
+      const plainFromOutside =
+        plain.has(name) && !crates.some((crate) => crate.packageName === name && crate.libRoot);
+      if (!renamed && !libraryOfPlain && !plainFromOutside) return null;
     }
     // `dep = { package = "real-name" }` renames a dependency for the crate
     // that declares it, and the code then writes the alias. The alias appears
     // in no `[package] name`, so without this the path resolved to nothing —
     // or worse, to a local module that happened to carry the alias.
     const declared = importingCrate?.aliases?.[name] ?? name;
-    const candidates = crates.filter((crate) => crate.name === declared && crate.libRoot);
+    // What the alias resolves to is a package name, and what the code wrote
+    // may be a library name; a crate answers to either. `dep = { path = "…",
+    // package = "other" }` where `other` sets `[lib] name = "otherlib"` reached
+    // nothing when only the library name was compared.
+    const candidates = crates.filter(
+      (crate) => (crate.name === declared || crate.packageName === declared) && crate.libRoot,
+    );
     if (candidates.length === 0) return null;
     return (
       candidates.sort((a, b) => {
@@ -1994,20 +2049,37 @@ export function resolveRustImport(
     // carried `#[path = "local.rs"] mod foo;` was answered with that local
     // file, while rustc reaches the root's `foo` — a review finding left open
     // from an earlier round. So the file's declaration map is not consulted
-    // at all here. The root module is tried first, and a crate the package
-    // declares second: in 2015 `extern crate foo;` at the root puts the crate
-    // there too, and a root that declares both is E0260, so only one exists.
-    // Without a target root there is nothing to count from, and the path is
-    // left unresolved rather than guessed.
-    if (globalMarker && edition2015) {
+    // at all here.
+    //
+    // Three things a name at the root can be, tried in this order. A module
+    // of the root, found by walking from the root's directory — with no file
+    // to fall back on, since a walk that lands on the root whenever nothing
+    // matches would answer every other case with the root too (found by
+    // review: it made the two branches below unreachable). A crate the package
+    // declares, which `extern crate foo;` at the root puts there — a root
+    // declaring both a module and a crate of one name is E0260, so only one
+    // exists; a registry crate is such a crate and resolves to nothing. And
+    // otherwise an item the root defines or re-exports — `use ::BrotliResult;`
+    // — which is the root file itself, unless the name is one of the crates
+    // rustc provides without any manifest: those are not items of this crate.
+    //
+    // A 2015 file outside every target has no root to count from, and is left
+    // unresolved rather than guessed.
+    if (globalMarker && importingCrate?.edition === "2015") {
       if (!own) return null;
-      const atRoot = resolveRustModulePath(own.moduleDir, segments, own.root, fileSet);
+      const atRoot = resolveRustModulePath(own.moduleDir, segments, null, fileSet);
       if (atRoot) return atRoot;
       const crate = crateNamed(head);
-      if (!crate?.libRoot) return null;
-      return segments.length === 1
-        ? crate.libRoot
-        : resolveRustModulePath(rustModuleDir(crate.libRoot, true), segments.slice(1), crate.libRoot, fileSet);
+      if (crate?.libRoot) {
+        return segments.length === 1
+          ? crate.libRoot
+          : resolveRustModulePath(rustModuleDir(crate.libRoot, true), segments.slice(1), crate.libRoot, fileSet);
+      }
+      const declaresIt =
+        importingCrate.externalDeps?.includes(head) ||
+        Object.hasOwn(importingCrate.aliases ?? {}, head) ||
+        RUST_BUILTIN_CRATES.has(head);
+      return declaresIt ? null : own.root;
     }
 
     // A bare specifier is a `mod foo;` declaration (see extractImports), which

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1186,9 +1186,8 @@ export interface RustCrate {
   /**
    * The name other crates import it by — `[package] name` with dashes turned
    * into underscores, which is the translation Cargo itself performs. Null for
-   * a manifest that declares no package (a `[workspace]`-only root), no
-   * library target, or an explicit `[workspace.exclude]` member, none of which
-   * anything can import by name.
+   * a manifest that declares no package (a `[workspace]`-only root) or no
+   * library target, neither of which anything can import by name.
    */
   name: string | null;
   /** Project-relative path of the library root module, when the crate has one. */
@@ -1363,27 +1362,9 @@ export function buildRustCrateMap(fileSet: Set<string>, projectPath: string): Ru
     const under = (relative: string): string => (dir === "." ? relative : `${dir}/${relative}`);
 
     const enclosingWs = findEnclosingWorkspace(dir);
-    let isExcludedByWorkspace = false;
     const wsDeps = new Map<string, string>();
 
     if (enclosingWs) {
-      const relToWs =
-        enclosingWs.dir === "."
-          ? dir
-          : dir.startsWith(`${enclosingWs.dir}/`)
-            ? dir.slice(enclosingWs.dir.length + 1)
-            : null;
-
-      if (relToWs !== null && relToWs !== "") {
-        const excludePatterns = patternList(enclosingWs.table.exclude);
-        if (excludePatterns && excludePatterns.length > 0) {
-          const excludeRes = excludePatterns.map((p) => globToRegex(p.replace(/\/+$/, ""), ".*"));
-          if (excludeRes.some((re) => re.test(relToWs))) {
-            isExcludedByWorkspace = true;
-          }
-        }
-      }
-
       const wsDepsTable = asTable(enclosingWs.table.dependencies);
       if (wsDepsTable) {
         for (const [depKey, depVal] of Object.entries(wsDepsTable)) {
@@ -1419,15 +1400,16 @@ export function buildRustCrateMap(fileSet: Set<string>, projectPath: string): Ru
 
     // `[lib] name` overrides the package name for the importable target; both
     // spellings reach the same file, so both are recorded by the caller's map.
-    // An explicitly excluded workspace member cannot be imported by name.
+    //
+    // `[workspace] exclude` does NOT take a package out of the importable set,
+    // however much it looks like it should: it only keeps the member out of
+    // the default set of workspace-wide commands. A member of the workspace
+    // can still depend on an excluded package by path, and does — checked by
+    // building exactly that and watching `cargo check` accept it. Reading
+    // `exclude` as "not importable" lost a real edge.
     const declaredName = typeof lib?.name === "string" ? lib.name : null;
     const packageName = typeof pkg?.name === "string" ? pkg.name : null;
-    const name =
-      isExcludedByWorkspace
-        ? null
-        : libRoot
-          ? ((declaredName ?? packageName)?.replace(/-/g, "_") ?? null)
-          : null;
+    const name = libRoot ? ((declaredName ?? packageName)?.replace(/-/g, "_") ?? null) : null;
 
     const roots = new Set<string>();
     if (libRoot) roots.add(libRoot);

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1704,7 +1704,12 @@ export function resolveRustImport(
   // `use ::config::Item;` says the head names a crate and not a module in
   // scope — it is how a file that also has a local `config` reaches the other
   // one. Since a local module otherwise wins, the marker has to survive.
-  const global = specifier.startsWith("::");
+  //
+  // What it means, though, is an edition rule: `::` is the extern prelude from
+  // 2018 on, and the crate root in 2015, where it says nothing a bare head does
+  // not already say. Checked on 1.98.0 with one crate carrying `pub mod log;`
+  // and `use ::log::LocalMarker;`: it compiles in 2015 and is E0432 in 2018.
+  const globalMarker = specifier.startsWith("::");
 
   const segments = specifier
     .split("::")
@@ -1772,6 +1777,12 @@ export function resolveRustImport(
   // names a module of the crate rather than one in this file's scope — and no
   // declaration in this file is required, or expected.
   const rootRelative = importingCrate?.edition === "2015" && own !== null;
+
+  // And so the leading `::` marks an external crate only where the extern
+  // prelude exists. In 2015 it is the same crate root an unanchored path counts
+  // from, and letting the marker through sent the path looking for a workspace
+  // crate of that name — or, finding none, to nothing at all.
+  const global = globalMarker && !rootRelative;
 
   const target = ((): string | null => {
     // A bare specifier is a `mod foo;` declaration (see extractImports), which

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1658,6 +1658,7 @@ export function resolveRustImport(
   relSourceFile: string,
   fileSet: Set<string>,
   crates: RustCrate[],
+  declaredMods?: Set<string>,
 ): string | null {
   const own = rustRootForFile(crates, relSourceFile);
   const isRoot = own?.root === relSourceFile;
@@ -1756,7 +1757,15 @@ export function resolveRustImport(
       // item declared right there — in `foo.rs` beside `foo/`, or in
       // `foo/mod.rs`. Without this the whole `foo.rs`-plus-`foo/` layout, which
       // is the one rustc recommends, lost every `super::` edge out of a child.
-      const parent = rustModuleFile(moduleDir, fileSet);
+      //
+      // The crate root is that module for the top of the tree, and it is named
+      // by neither convention: `src` holds no `src.rs` and no `src/mod.rs`, so
+      // `super::Item` written in `src/foo.rs` — the commonest `super::` there
+      // is — resolved to nothing until the root was checked by name.
+      const parent =
+        own && moduleDir === own.moduleDir
+          ? own.root
+          : rustModuleFile(moduleDir, fileSet);
       return resolveRustModulePath(
         moduleDir,
         rest,
@@ -1782,9 +1791,23 @@ export function resolveRustImport(
     // `src/registry.rs`, and rustc rejects that same line from 2018 on. A
     // crate with no manifest keeps the 2018 reading, which is what a bare
     // tree of `.rs` files most likely is.
+    //
+    // The head must name a module the file actually declares. Matching a
+    // sibling `.rs` file by name alone is a filesystem answer to a question
+    // about scope: it let a third-party head capture the import whenever a
+    // file of that name happened to exist, and in `tests/` — where each file
+    // is its own integration-test crate and none can import another — it drew
+    // an edge Rust cannot express at all. rustc agrees the declaration is the
+    // gate: with `mod log;` present, `use log::item;` reaches the module and
+    // not the dependency. `declaredMods` left undefined keeps the older,
+    // looser reading, so every existing caller behaves as before.
     const unanchoredFrom =
       importingCrate?.edition === "2015" && own ? own.moduleDir : ownModuleDir;
-    const local = global ? null : resolveRustModulePath(unanchoredFrom, segments, null, fileSet);
+    const declaredHere = declaredMods === undefined || declaredMods.has(head);
+    const local =
+      global || !declaredHere
+        ? null
+        : resolveRustModulePath(unanchoredFrom, segments, null, fileSet);
     if (local) return local;
 
     const crate = crateNamed(head);
@@ -1833,6 +1856,7 @@ export function resolveImport(
   elixirModuleMap?: Map<string, string[]>,
   phpFqcnMap?: Map<string, string[]>,
   rustCrates?: RustCrate[],
+  rustDeclaredMods?: Set<string>,
 ): string | null {
   // Skip obvious external/stdlib modules. Go is excluded from this
   // pre-check because its external classifier in `isExternalModule`
@@ -2148,6 +2172,7 @@ export function resolveImport(
         toForwardSlash(path.relative(projectPath, sourceFile)),
         fileSet,
         rustCrates ?? [],
+        rustDeclaredMods,
       );
     }
 

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1911,10 +1911,19 @@ export function resolveRustImport(
 
   // The package whose manifest governs this file, which is what says under
   // which names its dependencies are imported: the same crate answers to
-  // different names in two members of one workspace.
+  // different names in two members of one workspace. The innermost manifest
+  // containing the file wins, so depth is what ranks them — and the root's
+  // `"."` names no directory at all, it is the empty prefix. Measured by its
+  // length it is one character, which ties with every member directory of one
+  // character and, the sort being stable and manifests walked shallowest
+  // first, wins the tie: every file of `a/` was then governed by the root's
+  // manifest. A `[workspace]`-only root declares no dependency and no edition,
+  // so `a/`'s crates went unreachable and its 2018-or-later files were read as
+  // 2015 (review finding).
+  const depthOf = (crate: RustCrate): number => (crate.dir === "." ? 0 : crate.dir.length);
   const importingCrate = crates
     .filter((crate) => crate.dir === "." || relSourceFile.startsWith(`${crate.dir}/`))
-    .sort((a, b) => b.dir.length - a.dir.length)[0];
+    .sort((a, b) => depthOf(b) - depthOf(a))[0];
 
   // A crate this project declares, preferring one whose directory contains the
   // importing file — two manifests can carry the same package name, and a
@@ -2187,13 +2196,14 @@ export function resolveRustImport(
     // not the dependency. `declaredMods` left undefined keeps the older,
     // looser reading, so every existing caller behaves as before.
     //
-    // The gate is a 2018 rule and only a 2018 rule. In edition 2015 the path
-    // is absolute from the crate root, so it names a module of the crate and
-    // not one in the file's scope: `use registry::write;` in `src/client.rs`
-    // compiles with `mod registry;` written in `lib.rs` and nothing at all in
-    // `client.rs` — checked on cargo 1.70.0 and 1.98.0. Gating that on a
-    // declaration in the importing file would drop the edge on every 2015
-    // crate, which is every crate whose manifest omits the key.
+    // The gate is on in every edition. An earlier round wrote here that it was
+    // a 2018 rule only, on the ground that `use registry::write;` in
+    // `src/client.rs` compiles with `mod registry;` written in `lib.rs` — true
+    // of rustc, and the edge is indeed one this resolver does not draw. What
+    // the decision recorded above `edition2015` says is that acting on it costs
+    // more than it buys: see that comment for the four ways it drew edges rustc
+    // rejects. This paragraph is what that decision replaced (review finding:
+    // it contradicted the code and the other comment both).
     // A head the declaration moved is answered from where it moved it, and its
     // own children from the directory that file sits in — `src/inner.rs` for a
     // module filed at `src/custom.rs`, which is what E0583 asks for.

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1983,10 +1983,33 @@ export function resolveRustImport(
   // the marker names an external crate only where the extern prelude exists. In
   // 2015 it is the same crate root an unanchored path counts from, and letting
   // it through sent the path looking for a workspace crate of that name — or,
-  // finding none, to nothing at all.
+  // finding none, to nothing at all. That case is answered first below, from
+  // the root and nowhere else.
   const global = globalMarker && !edition2015;
 
   const target = ((): string | null => {
+    // In edition 2015 the leading `::` is the crate root, and the crate root
+    // only: the same one `crate::` names, never this file's scope. Read
+    // through the file's own declarations, `use ::foo::Item` in a child that
+    // carried `#[path = "local.rs"] mod foo;` was answered with that local
+    // file, while rustc reaches the root's `foo` — a review finding left open
+    // from an earlier round. So the file's declaration map is not consulted
+    // at all here. The root module is tried first, and a crate the package
+    // declares second: in 2015 `extern crate foo;` at the root puts the crate
+    // there too, and a root that declares both is E0260, so only one exists.
+    // Without a target root there is nothing to count from, and the path is
+    // left unresolved rather than guessed.
+    if (globalMarker && edition2015) {
+      if (!own) return null;
+      const atRoot = resolveRustModulePath(own.moduleDir, segments, own.root, fileSet);
+      if (atRoot) return atRoot;
+      const crate = crateNamed(head);
+      if (!crate?.libRoot) return null;
+      return segments.length === 1
+        ? crate.libRoot
+        : resolveRustModulePath(rustModuleDir(crate.libRoot, true), segments.slice(1), crate.libRoot, fileSet);
+    }
+
     // A bare specifier is a `mod foo;` declaration (see extractImports), which
     // names a file in the declaring file's own module directory. `use foo;` —
     // a whole crate, no path — and `extern crate foo;` arrive in the same

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1115,6 +1115,396 @@ export function pythonRootsForFile(
 }
 
 /**
+ * Discover every `Cargo.toml` under `projectPath`, project-relative and
+ * forward-slash-normalized.
+ *
+ * `Cargo.toml` is not a graphable file (no AST grammar, not an extra
+ * extension), so it is never in the set returned by `getGraphableFiles` — this
+ * walk is independent of that set, exactly like {@link findGoModFiles} (the
+ * fileSet-scan trap from issue #82 applies here identically). The same ignore
+ * filter `getGraphableFiles` uses is applied, with the same trailing-slash
+ * convention for directories.
+ *
+ * `target/` is additionally skipped unconditionally. It is where Cargo unpacks
+ * every dependency it builds, each carrying its own `Cargo.toml`, and a vendored
+ * crate registered from there would claim a name the workspace also declares.
+ * DEFAULT_IGNORE_PATTERNS lists it, but a `.socraticodeignore` negation can
+ * re-include it, and `CARGO_TARGET_DIR` can put it under any other name — which
+ * is why the manifests found there are also the ones nothing else would catch.
+ */
+function findCargoManifests(projectPath: string): string[] {
+  const ig = createIgnoreFilter(projectPath);
+  const results: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const relPath = toForwardSlash(path.relative(projectPath, path.join(dir, entry.name)));
+      if (shouldIgnore(ig, entry.isDirectory() ? `${relPath}/` : relPath)) continue;
+      if (entry.isDirectory()) {
+        if (entry.name === "target") continue;
+        walk(path.join(dir, entry.name));
+      } else if (entry.name === "Cargo.toml") {
+        // Mirrors findGoModFiles: readdirSync Dirents do not follow symlinks,
+        // so a symlinked manifest reports isFile()===false and would be missed.
+        let isFile = entry.isFile();
+        if (!isFile && entry.isSymbolicLink()) {
+          try {
+            isFile = statSync(path.join(dir, entry.name)).isFile();
+          } catch {
+            continue;
+          }
+        }
+        if (isFile) results.push(relPath);
+      }
+    }
+  };
+  walk(projectPath);
+  // Sorted so a name declared by two manifests resolves to the same crate on
+  // every machine.
+  return results.sort();
+}
+
+/** One crate found in the tree: what it is called, and where its modules start. */
+export interface RustCrate {
+  /** Project-relative directory holding its `Cargo.toml`; `"."` at the root. */
+  dir: string;
+  /**
+   * The name other crates import it by — `[package] name` with dashes turned
+   * into underscores, which is the translation Cargo itself performs. Null for
+   * a manifest that declares no package (a `[workspace]`-only root) or no
+   * library target, neither of which anything can import by name.
+   */
+  name: string | null;
+  /** Project-relative path of the library root module, when the crate has one. */
+  libRoot: string | null;
+  /**
+   * Project-relative paths of every root module the manifest implies: the
+   * library, plus each binary, integration test, example and benchmark, plus
+   * the build script. Each is the top of its own module tree, which is what
+   * `crate::` is relative to.
+   */
+  roots: string[];
+}
+
+/** A parsed `Cargo.toml` as this reader consumes it. */
+type CargoTable = Record<string, TomlValue | undefined>;
+
+function asTable(value: TomlValue | undefined): CargoTable | null {
+  // isTable admits a TOML date, which carries none of the keys read below and
+  // so reaches the same "declares nothing" path as any other non-table.
+  return isTable(value) ? value : null;
+}
+
+/** A declared target's `path`, when the entry carries one. */
+function declaredTargetPath(entry: TomlValue | undefined): string | null {
+  const table = asTable(entry);
+  const declared = table?.path;
+  return typeof declared === "string" ? declared : null;
+}
+
+/**
+ * Build the crate map for a Rust project, one entry per `Cargo.toml`.
+ *
+ * Rust names its own code three ways, and only one of them says anything about
+ * the filesystem. `mod foo;` names a sibling file, which the resolver already
+ * followed. `crate::`, `super::` and `self::` name a position in the module
+ * tree, whose root is a target's root module — `src/lib.rs`, `src/main.rs`, or
+ * whatever `[[bin]] path` declares. `some_crate::` names a whole other crate,
+ * which is only in this project if a manifest here declares it, under a name
+ * whose dashes Cargo turns into underscores (`sailor-core` is imported as
+ * `sailor_core`). None of the three resolved before this map existed: every
+ * specifier containing `::` returned null, so a Rust project's file graph came
+ * out as its bare `mod` declarations and nothing else.
+ *
+ * Targets are read from the manifest where declared and taken by convention
+ * otherwise, matching Cargo's own autodiscovery: `src/lib.rs`, `src/main.rs`,
+ * `src/bin/<name>.rs`, `src/bin/<name>/main.rs`, `tests/`, `examples/`,
+ * `benches/` and
+ * `build.rs`. A convention path is recorded only when the file is actually in
+ * `fileSet`, so a root that does not exist never shadows one that does.
+ *
+ * The manifest is parsed with the same TOML reader the Python side uses rather
+ * than scanned, so a `path` key belonging to a dependency is a different key
+ * rather than nearby text. A manifest that cannot be parsed contributes its
+ * convention targets and no name: one unreadable `Cargo.toml` must not cost the
+ * whole project its Rust edges.
+ *
+ * Call this once per graph build and pass the result to resolveImport.
+ */
+export function buildRustCrateMap(fileSet: Set<string>, projectPath: string): RustCrate[] {
+  const root = path.resolve(projectPath);
+  const relManifests = findCargoManifests(root);
+  if (relManifests.length === 0) return [];
+
+  const rustFiles = [...fileSet].filter((f) => f.endsWith(".rs")).sort();
+  const crates: RustCrate[] = [];
+
+  for (const relManifest of relManifests) {
+    const dir = toForwardSlash(path.dirname(relManifest)); // "." at the root
+    const under = (relative: string): string => (dir === "." ? relative : `${dir}/${relative}`);
+
+    let manifest: CargoTable | null = null;
+    try {
+      manifest = asTable(parseToml(readFileSync(path.join(root, relManifest), "utf8")));
+    } catch {
+      // Unreadable or malformed manifest: its convention targets still count.
+    }
+
+    const pkg = asTable(manifest?.package);
+    const lib = asTable(manifest?.lib);
+    const declaredLib = declaredTargetPath(manifest?.lib);
+    const conventionLib = under("src/lib.rs");
+    const libRoot =
+      declaredLib && fileSet.has(under(declaredLib))
+        ? under(declaredLib)
+        : fileSet.has(conventionLib)
+          ? conventionLib
+          : null;
+
+    // `[lib] name` overrides the package name for the importable target; both
+    // spellings reach the same file, so both are recorded by the caller's map.
+    const declaredName = typeof lib?.name === "string" ? lib.name : null;
+    const packageName = typeof pkg?.name === "string" ? pkg.name : null;
+    const name = libRoot ? ((declaredName ?? packageName)?.replace(/-/g, "_") ?? null) : null;
+
+    const roots = new Set<string>();
+    if (libRoot) roots.add(libRoot);
+
+    // Explicitly declared targets. An array-of-tables key holds one table per
+    // target; a manifest that spells it as a single table is malformed for
+    // Cargo, and declaredTargetPath reads it as one entry rather than failing.
+    for (const key of ["bin", "test", "example", "bench"]) {
+      const declared = manifest?.[key];
+      for (const entry of Array.isArray(declared) ? declared : [declared]) {
+        const targetPath = declaredTargetPath(entry);
+        if (targetPath && fileSet.has(under(targetPath))) roots.add(under(targetPath));
+      }
+    }
+    const buildScript = typeof pkg?.build === "string" ? pkg.build : "build.rs";
+    if (fileSet.has(under(buildScript))) roots.add(under(buildScript));
+
+    // Convention targets, as Cargo autodiscovers them.
+    if (fileSet.has(under("src/main.rs"))) roots.add(under("src/main.rs"));
+    for (const dirName of ["src/bin", "tests", "examples", "benches"]) {
+      const prefix = `${under(dirName)}/`;
+      for (const file of rustFiles) {
+        if (!file.startsWith(prefix)) continue;
+        const rest = file.slice(prefix.length);
+        // `<dir>/name.rs` is a target; `<dir>/name/main.rs` is a target whose
+        // own modules live beside it. Anything deeper is a module of one of
+        // those, not a target of its own.
+        if (!rest.includes("/")) roots.add(file);
+        else if (rest.split("/").length === 2 && rest.endsWith("/main.rs")) roots.add(file);
+      }
+    }
+
+    crates.push({ dir, name, libRoot, roots: [...roots].sort() });
+  }
+
+  return crates;
+}
+
+/**
+ * The directory a Rust file's submodules live in.
+ *
+ * A crate root (`src/lib.rs`, `src/main.rs`, `src/bin/tool.rs`) and a `mod.rs`
+ * both own the directory they sit in — `mod foo;` in either names `foo.rs`
+ * beside them. Every other file owns the directory named after it: `mod bar;`
+ * inside `src/foo.rs` names `src/foo/bar.rs`, never `src/bar.rs`.
+ *
+ * `lib.rs` and `main.rs` own their directory by convention as well as by being
+ * roots, so a tree with no `Cargo.toml` — where no root is known — still reads
+ * them the way Cargo would.
+ */
+function rustModuleDir(relFile: string, isCrateRoot: boolean): string {
+  const dir = toForwardSlash(path.dirname(relFile));
+  if (isCrateRoot || ["mod.rs", "lib.rs", "main.rs"].includes(path.basename(relFile))) return dir;
+  const stem = path.basename(relFile, ".rs");
+  return dir === "." ? stem : `${dir}/${stem}`;
+}
+
+/** Join a module directory and a path below it, with `"."` meaning the root. */
+function underModuleDir(moduleDir: string, relative: string): string {
+  return moduleDir === "." ? relative : `${moduleDir}/${relative}`;
+}
+
+/**
+ * The crate root module governing one file, and the directory that root's
+ * module tree starts from.
+ *
+ * A file can sit under several roots — `src/bin/tool.rs` is a root of its own
+ * while also sitting under `src/lib.rs`'s directory — so the deepest module
+ * directory wins, and a file that IS a root is its own. Null when no manifest
+ * covers the file, which is what keeps `crate::` unresolved rather than
+ * guessed in a tree with no `Cargo.toml`.
+ */
+function rustRootForFile(
+  crates: RustCrate[],
+  relFile: string,
+): { root: string; moduleDir: string } | null {
+  let best: { root: string; moduleDir: string } | null = null;
+  for (const crate of crates) {
+    for (const root of crate.roots) {
+      if (root === relFile) return { root, moduleDir: rustModuleDir(root, true) };
+      const moduleDir = rustModuleDir(root, true);
+      const covers = moduleDir === "." || relFile.startsWith(`${moduleDir}/`);
+      if (covers && (best === null || moduleDir.length > best.moduleDir.length)) {
+        best = { root, moduleDir };
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * The file holding the module that owns `moduleDir`, in either of the two
+ * layouts Rust allows for a module with children: `foo.rs` beside `foo/`, or
+ * `foo/mod.rs` inside it.
+ */
+function rustModuleFile(moduleDir: string, fileSet: Set<string>): string | null {
+  if (moduleDir === ".") return null;
+  for (const candidate of [`${moduleDir}.rs`, `${moduleDir}/mod.rs`]) {
+    if (fileSet.has(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Walk a module path down from a module directory to the file that holds it.
+ *
+ * The trailing segments of a Rust path name items, not modules — `crate::db::
+ * Connection` ends at a type — and nothing in the path says where the modules
+ * stop. So the longest prefix that names a file wins, and a path that names
+ * only items in the root resolves to the root module itself.
+ */
+function resolveRustModulePath(
+  moduleDir: string,
+  segments: string[],
+  rootFile: string | null,
+  fileSet: Set<string>,
+): string | null {
+  for (let k = segments.length; k >= 1; k--) {
+    const base = underModuleDir(moduleDir, segments.slice(0, k).join("/"));
+    if (fileSet.has(`${base}.rs`)) return `${base}.rs`;
+    if (fileSet.has(`${base}/mod.rs`)) return `${base}/mod.rs`;
+  }
+  return rootFile && fileSet.has(rootFile) ? rootFile : null;
+}
+
+/**
+ * Resolve one Rust module path to the project file it names.
+ *
+ * `relSourceFile` is the importing file, project-relative and forward-slashed.
+ * `crates` comes from {@link buildRustCrateMap}; an empty list leaves
+ * `crate::` and cross-crate paths unresolved, which is what a tree carrying no
+ * `Cargo.toml` should produce.
+ *
+ * `super::` and `self::` are answered from the file's own position rather than
+ * from its crate root, so they resolve in a manifest-less tree too. Climbing
+ * stops at the crate root's directory when a root is known: a path cannot leave
+ * its crate through `super`, and without the guard `super::super::x` at the top
+ * of a workspace member would reach into a sibling's files.
+ */
+export function resolveRustImport(
+  specifier: string,
+  relSourceFile: string,
+  fileSet: Set<string>,
+  crates: RustCrate[],
+): string | null {
+  const segments = specifier
+    .split("::")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  if (segments.length === 0) return null;
+
+  const own = rustRootForFile(crates, relSourceFile);
+  const isRoot = own?.root === relSourceFile;
+  const ownModuleDir = rustModuleDir(relSourceFile, isRoot);
+
+  // A crate this project declares, preferring one whose directory contains the
+  // importing file — two manifests can carry the same package name, and a
+  // workspace member's own name must not resolve into an unrelated checkout.
+  const crateNamed = (name: string): RustCrate | null => {
+    const candidates = crates.filter((crate) => crate.name === name && crate.libRoot);
+    if (candidates.length === 0) return null;
+    return (
+      candidates.sort((a, b) => {
+        const aCovers = a.dir === "." || relSourceFile.startsWith(`${a.dir}/`);
+        const bCovers = b.dir === "." || relSourceFile.startsWith(`${b.dir}/`);
+        if (aCovers !== bCovers) return aCovers ? -1 : 1;
+        return b.dir.length - a.dir.length || a.dir.localeCompare(b.dir);
+      })[0] ?? null
+    );
+  };
+
+  const head = segments[0];
+
+  // A bare specifier is a `mod foo;` declaration (see extractImports), which
+  // names a file in the declaring file's own module directory. `use foo;` —
+  // a whole crate, no path — arrives in the same shape, so the local module
+  // is tried first and the crate name second: only one of the two exists in
+  // any tree that compiles.
+  if (segments.length === 1 && !["crate", "self", "super"].includes(head)) {
+    const local = resolveRustModulePath(ownModuleDir, [head], null, fileSet);
+    if (local) return local;
+    return crateNamed(head)?.libRoot ?? null;
+  }
+
+  if (head === "crate") {
+    if (!own) return null;
+    return resolveRustModulePath(own.moduleDir, segments.slice(1), own.root, fileSet);
+  }
+
+  if (head === "self" || head === "super") {
+    let moduleDir = ownModuleDir;
+    let rest = segments;
+    while (rest.length > 0 && (rest[0] === "self" || rest[0] === "super")) {
+      if (rest[0] === "super") {
+        // The crate root's own directory is the top: `super` from a module
+        // directly under it would leave the crate.
+        if (own && moduleDir === own.moduleDir) return null;
+        moduleDir = toForwardSlash(path.dirname(moduleDir));
+      }
+      rest = rest.slice(1);
+    }
+    // What the climb landed on is a module too, and `super::Item` names an
+    // item declared right there — in `foo.rs` beside `foo/`, or in
+    // `foo/mod.rs`. Without this the whole `foo.rs`-plus-`foo/` layout, which
+    // is the one rustc recommends, lost every `super::` edge out of a child.
+    const parent = rustModuleFile(moduleDir, fileSet);
+    const resolved = resolveRustModulePath(
+      moduleDir,
+      rest,
+      parent === relSourceFile ? null : parent,
+      fileSet,
+    );
+    return resolved === relSourceFile ? null : resolved;
+  }
+
+  const crate = crateNamed(head);
+  if (crate?.libRoot) {
+    return resolveRustModulePath(
+      rustModuleDir(crate.libRoot, true),
+      segments.slice(1),
+      crate.libRoot,
+      fileSet,
+    );
+  }
+
+  // A uniform path: since Rust 2018 a `use` may start at a module in scope
+  // without saying `self::`, and `pub use inner::Thing;` beside `mod inner;`
+  // is how a crate republishes its own modules. Reached only once the head is
+  // known not to name a crate here, so a third-party path still resolves to
+  // nothing unless the tree really holds a module by that name.
+  return resolveRustModulePath(ownModuleDir, segments, null, fileSet);
+}
+
+/**
  * Resolve a module specifier to a relative file path within the project.
  * Returns null if the module is external (e.g., npm package, stdlib).
  *
@@ -1140,6 +1530,7 @@ export function resolveImport(
   pythonImportRoots?: string[],
   elixirModuleMap?: Map<string, string[]>,
   phpFqcnMap?: Map<string, string[]>,
+  rustCrates?: RustCrate[],
 ): string | null {
   // Skip obvious external/stdlib modules. Go is excluded from this
   // pre-check because its external classifier in `isExternalModule`
@@ -1445,18 +1836,17 @@ export function resolveImport(
     }
 
     case "rust": {
-      // mod foo → foo.rs or foo/mod.rs
-      if (!moduleSpecifier.includes("::")) {
-        const candidates = [
-          path.join(sourceDir, `${moduleSpecifier}.rs`),
-          path.join(sourceDir, moduleSpecifier, "mod.rs"),
-        ];
-        for (const candidate of candidates) {
-          const rel = toForwardSlash(path.relative(projectPath, candidate));
-          if (fileSet.has(rel)) return rel;
-        }
-      }
-      return null;
+      // `mod foo;`, `crate::`, `super::`, `self::` and cross-crate paths all
+      // resolve against the crate map. Before it, everything carrying `::`
+      // returned null and a Rust graph held only bare `mod` declarations. An
+      // empty map still resolves `mod`, `super` and `self` from the file's own
+      // position.
+      return resolveRustImport(
+        moduleSpecifier,
+        toForwardSlash(path.relative(projectPath, sourceFile)),
+        fileSet,
+        rustCrates ?? [],
+      );
     }
 
     case "csharp": {

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1898,6 +1898,23 @@ export function resolveRustImport(
     // verified on cargo 1.98.0, where a `compile_error!` in it does not stop
     // the build because rustc never reads the file.
     if (importingCrate?.externalDeps?.includes(name)) return null;
+    // Only what the importing package declares is in its extern prelude. A
+    // sibling of the workspace it does not depend on is not reachable, and
+    // rustc refuses the path with E0432 — yet the raw name used to be searched
+    // across every crate of the project, so `use helper::Thing` drew an edge
+    // into a sibling `helper` the manifest never named (review finding). The
+    // one name a package reaches without declaring it is its own library,
+    // which its binaries, tests and examples import by that name. `aliases`
+    // holds every declared dependency under the name the code writes, renamed
+    // or not, so its keys are the fence. A file outside every manifest has
+    // no package to ask, and is left as it was.
+    if (
+      importingCrate &&
+      name !== importingCrate.name &&
+      !Object.hasOwn(importingCrate.aliases ?? {}, name)
+    ) {
+      return null;
+    }
     // `dep = { package = "real-name" }` renames a dependency for the crate
     // that declares it, and the code then writes the alias. The alias appears
     // in no `[package] name`, so without this the path resolved to nothing —

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1008,19 +1008,6 @@ function declaredWorkspaceMembers(
   // Split on the wildcards first and quote only the literal spans between
   // them, so every other regex metacharacter matches itself. `**` always
   // spans separators; what a lone `*` spans is `singleStar`, and the two
-  // sides of the declaration do not agree on it. Naming both spellings in the
-  // type rejects a fragment that is neither — a `".+"` or a `"[^/]"` that
-  // would quietly change what every pattern matches. It does not stop the two
-  // being transposed, since each is valid at either call site; the tests that
-  // assert each side separately are what pin that.
-  const toRe = (pattern: string, singleStar: "[^/]*" | ".*"): RegExp => {
-    const quote = (literal: string) => literal.replace(/[.+^${}()|[\]\\?*]/g, "\\$&");
-    const body = pattern
-      .split("**")
-      .map((span) => span.split("*").map(quote).join(singleStar))
-      .join(".*");
-    return new RegExp(`^${body}$`);
-  };
   const prefix = manifestDir === "." ? "" : `${manifestDir}/`;
   const relativeToManifest = (dir: string): string | null => {
     if (!prefix) return dir;
@@ -1041,9 +1028,9 @@ function declaredWorkspaceMembers(
   // A narrow `*` on the include side registers fewer roots than uv, which
   // costs at most an edge. A narrow `*` on the exclude side fails to exclude,
   // which admits a package the manifest named and draws an edge uv would not.
-  const included = memberPatterns.map((p) => toRe(p.replace(/\/+$/, ""), "[^/]*"));
+  const included = memberPatterns.map((p) => globToRegex(p.replace(/\/+$/, ""), "[^/]*"));
   if (included.length === 0) return [];
-  const excluded = excludePatterns.map((p) => toRe(p.replace(/\/+$/, ""), ".*"));
+  const excluded = excludePatterns.map((p) => globToRegex(p.replace(/\/+$/, ""), ".*"));
 
   return allManifestDirs.filter((dir) => {
     if (dir === manifestDir) return false;
@@ -1051,6 +1038,19 @@ function declaredWorkspaceMembers(
     if (rel === null) return false;
     return included.some((re) => re.test(rel)) && !excluded.some((re) => re.test(rel));
   });
+}
+
+/**
+ * Compile a glob pattern into a regular expression.
+ * `**` spans separators; `singleStar` controls what a lone `*` spans.
+ */
+function globToRegex(pattern: string, singleStar: "[^/]*" | ".*"): RegExp {
+  const quote = (literal: string) => literal.replace(/[.+^${}()|[\]\\?*]/g, "\\$&");
+  const body = pattern
+    .split("**")
+    .map((span) => span.split("*").map(quote).join(singleStar))
+    .join(".*");
+  return new RegExp(`^${body}$`);
 }
 
 /**
@@ -1125,12 +1125,11 @@ export function pythonRootsForFile(
  * filter `getGraphableFiles` uses is applied, with the same trailing-slash
  * convention for directories.
  *
- * `target/` is additionally skipped unconditionally. It is where Cargo unpacks
- * every dependency it builds, each carrying its own `Cargo.toml`, and a vendored
- * crate registered from there would claim a name the workspace also declares.
- * DEFAULT_IGNORE_PATTERNS lists it, but a `.socraticodeignore` negation can
- * re-include it, and `CARGO_TARGET_DIR` can put it under any other name — which
- * is why the manifests found there are also the ones nothing else would catch.
+ * `target/` is skipped unconditionally by directory name. Additionally, any
+ * directory carrying `CACHEDIR.TAG` (created by Cargo per the Cache Directory
+ * Tagging Standard) or `.cargo-ok` is skipped unconditionally: this defends
+ * against custom `CARGO_TARGET_DIR` directory names where Cargo unpacks
+ * dependencies and build artifacts during compilation.
  */
 function findCargoManifests(projectPath: string): string[] {
   const ig = createIgnoreFilter(projectPath);
@@ -1140,6 +1139,17 @@ function findCargoManifests(projectPath: string): string[] {
     try {
       entries = readdirSync(dir, { withFileTypes: true });
     } catch {
+      return;
+    }
+    // A Cargo target / build directory contains CACHEDIR.TAG at its root,
+    // created by Cargo during build (per the Cache Directory Tagging Standard).
+    // Skipping any directory carrying this tag or .cargo-ok prevents unpacked
+    // dependencies and vendored build artifacts under non-default CARGO_TARGET_DIR
+    // names from registering as project crates.
+    if (
+      dir !== projectPath &&
+      entries.some((e) => e.name === "CACHEDIR.TAG" || e.name === ".cargo-ok")
+    ) {
       return;
     }
     for (const entry of entries) {
@@ -1176,8 +1186,9 @@ export interface RustCrate {
   /**
    * The name other crates import it by — `[package] name` with dashes turned
    * into underscores, which is the translation Cargo itself performs. Null for
-   * a manifest that declares no package (a `[workspace]`-only root) or no
-   * library target, neither of which anything can import by name.
+   * a manifest that declares no package (a `[workspace]`-only root), no
+   * library target, or an explicit `[workspace.exclude]` member, none of which
+   * anything can import by name.
    */
   name: string | null;
   /** Project-relative path of the library root module, when the crate has one. */
@@ -1189,6 +1200,22 @@ export interface RustCrate {
    * `crate::` is relative to.
    */
   roots: string[];
+  /**
+   * The Rust edition the manifest declares, defaulting to `"2015"` when the
+   * key is absent, as Cargo does. It decides both target autodiscovery and
+   * where an unanchored path in a `use` starts counting from.
+   */
+  edition: string;
+  /**
+   * Map from local dependency name / alias (with dashes turned to underscores)
+   * to the target crate's package name (with dashes turned to underscores).
+   *
+   * Covers:
+   *   [dependencies]
+   *   my_alias = { package = "actual-package-name", ... }
+   * as well as `[workspace.dependencies]` referenced via `workspace = true`.
+   */
+  aliases?: Record<string, string>;
 }
 
 /** A parsed `Cargo.toml` as this reader consumes it. */
@@ -1208,6 +1235,59 @@ function declaredTargetPath(entry: TomlValue | undefined): string | null {
 }
 
 /**
+ * Extract dependency aliases declared in a `Cargo.toml` table (e.g. `[dependencies]`,
+ * `[dev-dependencies]`, `[build-dependencies]`, `[target.*.dependencies]`).
+ *
+ * Normalizes dashes to underscores for both the local alias name and the target
+ * crate package name. If `dep.workspace = true`, resolves against workspace
+ * dependencies declared in the enclosing workspace manifest.
+ */
+function extractCargoAliases(
+  manifest: CargoTable | null,
+  wsDeps: Map<string, string>,
+): Record<string, string> {
+  if (!manifest) return {};
+  const aliases: Record<string, string> = {};
+
+  const processDepTable = (tableValue: TomlValue | undefined): void => {
+    const table = asTable(tableValue);
+    if (!table) return;
+    for (const [depKey, depVal] of Object.entries(table)) {
+      const alias = depKey.replace(/-/g, "_");
+      if (isTable(depVal)) {
+        if (typeof depVal.package === "string") {
+          aliases[alias] = depVal.package.replace(/-/g, "_");
+        } else if (depVal.workspace === true) {
+          const wsTarget = wsDeps.get(alias) ?? wsDeps.get(depKey.replace(/_/g, "-"));
+          aliases[alias] = wsTarget ?? alias;
+        } else {
+          aliases[alias] = alias;
+        }
+      } else if (typeof depVal === "string") {
+        aliases[alias] = alias;
+      }
+    }
+  };
+
+  processDepTable(manifest.dependencies);
+  processDepTable(manifest["dev-dependencies"]);
+  processDepTable(manifest["build-dependencies"]);
+
+  const targetSection = asTable(manifest.target);
+  if (targetSection) {
+    for (const targetVal of Object.values(targetSection)) {
+      const targetTable = asTable(targetVal);
+      if (!targetTable) continue;
+      processDepTable(targetTable.dependencies);
+      processDepTable(targetTable["dev-dependencies"]);
+      processDepTable(targetTable["build-dependencies"]);
+    }
+  }
+
+  return aliases;
+}
+
+/**
  * Build the crate map for a Rust project, one entry per `Cargo.toml`.
  *
  * Rust names its own code three ways, and only one of them says anything about
@@ -1222,11 +1302,15 @@ function declaredTargetPath(entry: TomlValue | undefined): string | null {
  * out as its bare `mod` declarations and nothing else.
  *
  * Targets are read from the manifest where declared and taken by convention
- * otherwise, matching Cargo's own autodiscovery: `src/lib.rs`, `src/main.rs`,
- * `src/bin/<name>.rs`, `src/bin/<name>/main.rs`, `tests/`, `examples/`,
- * `benches/` and
- * `build.rs`. A convention path is recorded only when the file is actually in
- * `fileSet`, so a root that does not exist never shadows one that does.
+ * otherwise, matching Cargo's own autodiscovery rules per edition:
+ *   - `autobins`, `autotests`, `autoexamples`, `autobenches`, `autolib` flags
+ *     turn off autodiscovery for their respective directories when set to `false`.
+ *   - In edition 2015, autodiscovery is turned off by default for a target type
+ *     when at least one target of that type is manually declared. In edition
+ *     2018+, autodiscovery remains enabled unless explicitly set to `false`.
+ *   - `[package] build = false` disables the build script target (`build.rs`).
+ *   - `[workspace] exclude` patterns exclude matching directories from being
+ *     registered as importable workspace members (`name = null`).
  *
  * The manifest is parsed with the same TOML reader the Python side uses rather
  * than scanned, so a `path` key belonging to a dependency is a different key
@@ -1242,35 +1326,108 @@ export function buildRustCrateMap(fileSet: Set<string>, projectPath: string): Ru
   if (relManifests.length === 0) return [];
 
   const rustFiles = [...fileSet].filter((f) => f.endsWith(".rs")).sort();
-  const crates: RustCrate[] = [];
+  const parsedManifests: Array<{ relManifest: string; dir: string; manifest: CargoTable | null }> = [];
 
   for (const relManifest of relManifests) {
     const dir = toForwardSlash(path.dirname(relManifest)); // "." at the root
-    const under = (relative: string): string => (dir === "." ? relative : `${dir}/${relative}`);
-
     let manifest: CargoTable | null = null;
     try {
-      manifest = asTable(parseToml(readFileSync(path.join(root, relManifest), "utf8")));
+      manifest = asTable(parseToml(readFileSync(path.join(root, relManifest), "utf8").replace(/^\uFEFF/, "")));
     } catch {
       // Unreadable or malformed manifest: its convention targets still count.
+    }
+    parsedManifests.push({ relManifest, dir, manifest });
+  }
+
+  // Collect all workspace tables to resolve `[workspace] exclude` and `[workspace.dependencies]`.
+  const workspaceManifests = parsedManifests
+    .filter((m) => m.manifest?.workspace !== undefined && isTable(m.manifest.workspace))
+    .map((m) => ({ dir: m.dir, table: m.manifest?.workspace as CargoTable }));
+
+  const findEnclosingWorkspace = (
+    dir: string,
+  ): { dir: string; table: CargoTable } | null => {
+    let best: { dir: string; table: CargoTable } | null = null;
+    for (const ws of workspaceManifests) {
+      const isAncestor = ws.dir === "." || dir === ws.dir || dir.startsWith(`${ws.dir}/`);
+      if (isAncestor && (best === null || ws.dir.length > best.dir.length)) {
+        best = ws;
+      }
+    }
+    return best;
+  };
+
+  const crates: RustCrate[] = [];
+
+  for (const { dir, manifest } of parsedManifests) {
+    const under = (relative: string): string => (dir === "." ? relative : `${dir}/${relative}`);
+
+    const enclosingWs = findEnclosingWorkspace(dir);
+    let isExcludedByWorkspace = false;
+    const wsDeps = new Map<string, string>();
+
+    if (enclosingWs) {
+      const relToWs =
+        enclosingWs.dir === "."
+          ? dir
+          : dir.startsWith(`${enclosingWs.dir}/`)
+            ? dir.slice(enclosingWs.dir.length + 1)
+            : null;
+
+      if (relToWs !== null && relToWs !== "") {
+        const excludePatterns = patternList(enclosingWs.table.exclude);
+        if (excludePatterns && excludePatterns.length > 0) {
+          const excludeRes = excludePatterns.map((p) => globToRegex(p.replace(/\/+$/, ""), ".*"));
+          if (excludeRes.some((re) => re.test(relToWs))) {
+            isExcludedByWorkspace = true;
+          }
+        }
+      }
+
+      const wsDepsTable = asTable(enclosingWs.table.dependencies);
+      if (wsDepsTable) {
+        for (const [depKey, depVal] of Object.entries(wsDepsTable)) {
+          const normKey = depKey.replace(/-/g, "_");
+          if (isTable(depVal) && typeof depVal.package === "string") {
+            wsDeps.set(normKey, depVal.package.replace(/-/g, "_"));
+          } else {
+            wsDeps.set(normKey, normKey);
+          }
+        }
+      }
     }
 
     const pkg = asTable(manifest?.package);
     const lib = asTable(manifest?.lib);
+    // A manifest with no `edition` key is a 2015 manifest — Cargo warns about
+    // it and carries on. Reading only the explicit spelling left every such
+    // package on 2018 rules, and a `[[bin]]` declared beside an undeclared
+    // file in `src/bin/` then handed the file a crate root Cargo never gives
+    // it. Old manifests are exactly the ones that omit the key.
+    const edition = typeof pkg?.edition === "string" ? pkg.edition : "2015";
+    const is2015 = edition === "2015";
+
     const declaredLib = declaredTargetPath(manifest?.lib);
+    const autolib = typeof pkg?.autolib === "boolean" ? pkg.autolib : true;
     const conventionLib = under("src/lib.rs");
     const libRoot =
       declaredLib && fileSet.has(under(declaredLib))
         ? under(declaredLib)
-        : fileSet.has(conventionLib)
+        : (manifest?.lib !== undefined || autolib) && fileSet.has(conventionLib)
           ? conventionLib
           : null;
 
     // `[lib] name` overrides the package name for the importable target; both
     // spellings reach the same file, so both are recorded by the caller's map.
+    // An explicitly excluded workspace member cannot be imported by name.
     const declaredName = typeof lib?.name === "string" ? lib.name : null;
     const packageName = typeof pkg?.name === "string" ? pkg.name : null;
-    const name = libRoot ? ((declaredName ?? packageName)?.replace(/-/g, "_") ?? null) : null;
+    const name =
+      isExcludedByWorkspace
+        ? null
+        : libRoot
+          ? ((declaredName ?? packageName)?.replace(/-/g, "_") ?? null)
+          : null;
 
     const roots = new Set<string>();
     if (libRoot) roots.add(libRoot);
@@ -1282,16 +1439,48 @@ export function buildRustCrateMap(fileSet: Set<string>, projectPath: string): Ru
       const declared = manifest?.[key];
       for (const entry of Array.isArray(declared) ? declared : [declared]) {
         const targetPath = declaredTargetPath(entry);
-        if (targetPath && fileSet.has(under(targetPath))) roots.add(under(targetPath));
+        const targetEntryTable = asTable(entry);
+        if (targetPath && fileSet.has(under(targetPath))) {
+          roots.add(under(targetPath));
+        } else if (!targetPath && typeof targetEntryTable?.name === "string") {
+          const targetName = targetEntryTable.name;
+          if (key === "bin") {
+            const candidates = [`src/bin/${targetName}.rs`, `src/bin/${targetName}/main.rs`];
+            if (targetName === (packageName ?? name)) candidates.push("src/main.rs");
+            for (const cand of candidates) {
+              if (fileSet.has(under(cand))) roots.add(under(cand));
+            }
+          } else if (key === "test") {
+            for (const cand of [`tests/${targetName}.rs`, `tests/${targetName}/main.rs`]) {
+              if (fileSet.has(under(cand))) roots.add(under(cand));
+            }
+          } else if (key === "example") {
+            for (const cand of [`examples/${targetName}.rs`, `examples/${targetName}/main.rs`]) {
+              if (fileSet.has(under(cand))) roots.add(under(cand));
+            }
+          } else if (key === "bench") {
+            for (const cand of [`benches/${targetName}.rs`, `benches/${targetName}/main.rs`]) {
+              if (fileSet.has(under(cand))) roots.add(under(cand));
+            }
+          }
+        }
       }
     }
-    const buildScript = typeof pkg?.build === "string" ? pkg.build : "build.rs";
-    if (fileSet.has(under(buildScript))) roots.add(under(buildScript));
 
-    // Convention targets, as Cargo autodiscovers them.
-    if (fileSet.has(under("src/main.rs"))) roots.add(under("src/main.rs"));
-    for (const dirName of ["src/bin", "tests", "examples", "benches"]) {
-      const prefix = `${under(dirName)}/`;
+    // Build script target: `build = false` in [package] explicitly disables it.
+    if (pkg?.build !== false) {
+      const buildScript = typeof pkg?.build === "string" ? pkg.build : "build.rs";
+      if (fileSet.has(under(buildScript))) roots.add(under(buildScript));
+    }
+
+    // Convention targets, as Cargo autodiscovers them according to edition and flags.
+    const autoBins =
+      typeof pkg?.autobins === "boolean"
+        ? pkg.autobins
+        : !(is2015 && manifest?.bin !== undefined);
+    if (autoBins) {
+      if (fileSet.has(under("src/main.rs"))) roots.add(under("src/main.rs"));
+      const prefix = `${under("src/bin")}/`;
       for (const file of rustFiles) {
         if (!file.startsWith(prefix)) continue;
         const rest = file.slice(prefix.length);
@@ -1303,7 +1492,55 @@ export function buildRustCrateMap(fileSet: Set<string>, projectPath: string): Ru
       }
     }
 
-    crates.push({ dir, name, libRoot, roots: [...roots].sort() });
+    const autoTests =
+      typeof pkg?.autotests === "boolean"
+        ? pkg.autotests
+        : !(is2015 && manifest?.test !== undefined);
+    if (autoTests) {
+      const prefix = `${under("tests")}/`;
+      for (const file of rustFiles) {
+        if (!file.startsWith(prefix)) continue;
+        const rest = file.slice(prefix.length);
+        if (!rest.includes("/")) roots.add(file);
+        else if (rest.split("/").length === 2 && rest.endsWith("/main.rs")) roots.add(file);
+      }
+    }
+
+    const autoExamples =
+      typeof pkg?.autoexamples === "boolean"
+        ? pkg.autoexamples
+        : !(is2015 && manifest?.example !== undefined);
+    if (autoExamples) {
+      const prefix = `${under("examples")}/`;
+      for (const file of rustFiles) {
+        if (!file.startsWith(prefix)) continue;
+        const rest = file.slice(prefix.length);
+        if (!rest.includes("/")) roots.add(file);
+        else if (rest.split("/").length === 2 && rest.endsWith("/main.rs")) roots.add(file);
+      }
+    }
+
+    const autoBenches =
+      typeof pkg?.autobenches === "boolean"
+        ? pkg.autobenches
+        : !(is2015 && manifest?.bench !== undefined);
+    if (autoBenches) {
+      const prefix = `${under("benches")}/`;
+      for (const file of rustFiles) {
+        if (!file.startsWith(prefix)) continue;
+        const rest = file.slice(prefix.length);
+        if (!rest.includes("/")) roots.add(file);
+        else if (rest.split("/").length === 2 && rest.endsWith("/main.rs")) roots.add(file);
+      }
+    }
+
+    const aliases = extractCargoAliases(manifest, wsDeps);
+    const crateEntry: RustCrate = { dir, name, libRoot, roots: [...roots].sort(), edition };
+    if (Object.keys(aliases).length > 0) {
+      crateEntry.aliases = aliases;
+    }
+
+    crates.push(crateEntry);
   }
 
   return crates;
@@ -1347,19 +1584,43 @@ function rustRootForFile(
   crates: RustCrate[],
   relFile: string,
 ): { root: string; moduleDir: string } | null {
+  // The answer depends only on the file and the crate map, and every import in
+  // a file asks it again — around twenty times per file, once per `use`. On a
+  // workspace of a hundred crates that repetition measured two seconds of the
+  // build. The cache is keyed on the crate map itself, so it lives exactly as
+  // long as the build that produced it and never outlives a stale map.
+  let perFile = rustRootCache.get(crates);
+  if (!perFile) {
+    perFile = new Map();
+    rustRootCache.set(crates, perFile);
+  }
+  const cached = perFile.get(relFile);
+  if (cached !== undefined) return cached;
+
   let best: { root: string; moduleDir: string } | null = null;
   for (const crate of crates) {
     for (const root of crate.roots) {
-      if (root === relFile) return { root, moduleDir: rustModuleDir(root, true) };
       const moduleDir = rustModuleDir(root, true);
+      if (root === relFile) {
+        best = { root, moduleDir };
+        break;
+      }
       const covers = moduleDir === "." || relFile.startsWith(`${moduleDir}/`);
       if (covers && (best === null || moduleDir.length > best.moduleDir.length)) {
         best = { root, moduleDir };
       }
     }
+    if (best?.root === relFile) break;
   }
+  perFile.set(relFile, best);
   return best;
 }
+
+/** Per-build memo for {@link rustRootForFile}; see the note in that function. */
+const rustRootCache = new WeakMap<
+  RustCrate[],
+  Map<string, { root: string; moduleDir: string } | null>
+>();
 
 /**
  * The file holding the module that owns `moduleDir`, in either of the two
@@ -1416,6 +1677,17 @@ export function resolveRustImport(
   fileSet: Set<string>,
   crates: RustCrate[],
 ): string | null {
+  // A `#[path = "…"]` attribute arrives as the path it declares, extension and
+  // all, which no module path ever carries. It is relative to the directory
+  // the declaring file sits in — never to the directory that file's submodules
+  // live in, so `src/a/b.rs` and `src/a/mod.rs` both reach `src/a/moved.rs`.
+  if (specifier.endsWith(".rs")) {
+    const declared = toForwardSlash(
+      path.normalize(path.join(path.dirname(relSourceFile), specifier)),
+    );
+    return fileSet.has(declared) ? declared : null;
+  }
+
   const segments = specifier
     .split("::")
     .map((segment) => segment.trim())
@@ -1426,11 +1698,23 @@ export function resolveRustImport(
   const isRoot = own?.root === relSourceFile;
   const ownModuleDir = rustModuleDir(relSourceFile, isRoot);
 
+  // The package whose manifest governs this file, which is what says under
+  // which names its dependencies are imported: the same crate answers to
+  // different names in two members of one workspace.
+  const importingCrate = crates
+    .filter((crate) => crate.dir === "." || relSourceFile.startsWith(`${crate.dir}/`))
+    .sort((a, b) => b.dir.length - a.dir.length)[0];
+
   // A crate this project declares, preferring one whose directory contains the
   // importing file — two manifests can carry the same package name, and a
   // workspace member's own name must not resolve into an unrelated checkout.
   const crateNamed = (name: string): RustCrate | null => {
-    const candidates = crates.filter((crate) => crate.name === name && crate.libRoot);
+    // `dep = { package = "real-name" }` renames a dependency for the crate
+    // that declares it, and the code then writes the alias. The alias appears
+    // in no `[package] name`, so without this the path resolved to nothing —
+    // or worse, to a local module that happened to carry the alias.
+    const declared = importingCrate?.aliases?.[name] ?? name;
+    const candidates = crates.filter((crate) => crate.name === declared && crate.libRoot);
     if (candidates.length === 0) return null;
     return (
       candidates.sort((a, b) => {
@@ -1444,64 +1728,87 @@ export function resolveRustImport(
 
   const head = segments[0];
 
-  // A bare specifier is a `mod foo;` declaration (see extractImports), which
-  // names a file in the declaring file's own module directory. `use foo;` —
-  // a whole crate, no path — arrives in the same shape, so the local module
-  // is tried first and the crate name second: only one of the two exists in
-  // any tree that compiles.
-  if (segments.length === 1 && !["crate", "self", "super"].includes(head)) {
-    const local = resolveRustModulePath(ownModuleDir, [head], null, fileSet);
-    if (local) return local;
-    return crateNamed(head)?.libRoot ?? null;
-  }
-
-  if (head === "crate") {
-    if (!own) return null;
-    return resolveRustModulePath(own.moduleDir, segments.slice(1), own.root, fileSet);
-  }
-
-  if (head === "self" || head === "super") {
-    let moduleDir = ownModuleDir;
-    let rest = segments;
-    while (rest.length > 0 && (rest[0] === "self" || rest[0] === "super")) {
-      if (rest[0] === "super") {
-        // The crate root's own directory is the top: `super` from a module
-        // directly under it would leave the crate.
-        if (own && moduleDir === own.moduleDir) return null;
-        moduleDir = toForwardSlash(path.dirname(moduleDir));
-      }
-      rest = rest.slice(1);
+  const target = ((): string | null => {
+    // A bare specifier is a `mod foo;` declaration (see extractImports), which
+    // names a file in the declaring file's own module directory. `use foo;` —
+    // a whole crate, no path — and `extern crate foo;` arrive in the same
+    // shape, so the local module is tried first and the crate name second:
+    // only one of the two exists in any tree that compiles.
+    if (segments.length === 1 && !["crate", "self", "super"].includes(head)) {
+      const local = resolveRustModulePath(ownModuleDir, [head], null, fileSet);
+      if (local) return local;
+      return crateNamed(head)?.libRoot ?? null;
     }
-    // What the climb landed on is a module too, and `super::Item` names an
-    // item declared right there — in `foo.rs` beside `foo/`, or in
-    // `foo/mod.rs`. Without this the whole `foo.rs`-plus-`foo/` layout, which
-    // is the one rustc recommends, lost every `super::` edge out of a child.
-    const parent = rustModuleFile(moduleDir, fileSet);
-    const resolved = resolveRustModulePath(
-      moduleDir,
-      rest,
-      parent === relSourceFile ? null : parent,
-      fileSet,
-    );
-    return resolved === relSourceFile ? null : resolved;
-  }
 
-  const crate = crateNamed(head);
-  if (crate?.libRoot) {
-    return resolveRustModulePath(
-      rustModuleDir(crate.libRoot, true),
-      segments.slice(1),
-      crate.libRoot,
-      fileSet,
-    );
-  }
+    if (head === "crate") {
+      if (!own) return null;
+      return resolveRustModulePath(own.moduleDir, segments.slice(1), own.root, fileSet);
+    }
 
-  // A uniform path: since Rust 2018 a `use` may start at a module in scope
-  // without saying `self::`, and `pub use inner::Thing;` beside `mod inner;`
-  // is how a crate republishes its own modules. Reached only once the head is
-  // known not to name a crate here, so a third-party path still resolves to
-  // nothing unless the tree really holds a module by that name.
-  return resolveRustModulePath(ownModuleDir, segments, null, fileSet);
+    if (head === "self" || head === "super") {
+      let moduleDir = ownModuleDir;
+      let rest = segments;
+      while (rest.length > 0 && (rest[0] === "self" || rest[0] === "super")) {
+        if (rest[0] === "super") {
+          // The crate root's own directory is the top: `super` from a module
+          // directly under it would leave the crate.
+          if (own && moduleDir === own.moduleDir) return null;
+          moduleDir = toForwardSlash(path.dirname(moduleDir));
+        }
+        rest = rest.slice(1);
+      }
+      // What the climb landed on is a module too, and `super::Item` names an
+      // item declared right there — in `foo.rs` beside `foo/`, or in
+      // `foo/mod.rs`. Without this the whole `foo.rs`-plus-`foo/` layout, which
+      // is the one rustc recommends, lost every `super::` edge out of a child.
+      const parent = rustModuleFile(moduleDir, fileSet);
+      return resolveRustModulePath(
+        moduleDir,
+        rest,
+        parent === relSourceFile ? null : parent,
+        fileSet,
+      );
+    }
+
+    // A uniform path: since Rust 2018 a `use` may start at a module in scope
+    // without saying `self::`, and `pub use inner::Thing;` beside `mod inner;`
+    // is how a crate republishes its own modules.
+    //
+    // This is tried before the crate names because that is the order rustc
+    // resolves in: a module in scope wins, and the extern prelude is consulted
+    // last. Reading the crate names first drew an edge into an unrelated
+    // sibling crate whenever a local module happened to carry its name —
+    // `config`, `log` and `utils` are both common module names and published
+    // crate names — and did so without the importing package declaring any
+    // dependency on it.
+    //
+    // In edition 2015 an unanchored path is absolute from the crate root
+    // instead: `use registry::write;` in `src/client.rs` names
+    // `src/registry.rs`, and rustc rejects that same line from 2018 on. A
+    // crate with no manifest keeps the 2018 reading, which is what a bare
+    // tree of `.rs` files most likely is.
+    const unanchoredFrom =
+      importingCrate?.edition === "2015" && own ? own.moduleDir : ownModuleDir;
+    const local = resolveRustModulePath(unanchoredFrom, segments, null, fileSet);
+    if (local) return local;
+
+    const crate = crateNamed(head);
+    if (crate?.libRoot) {
+      return resolveRustModulePath(
+        rustModuleDir(crate.libRoot, true),
+        segments.slice(1),
+        crate.libRoot,
+        fileSet,
+      );
+    }
+    return null;
+  })();
+
+  // A file never imports itself. `use crate::db::Connection;` written inside
+  // `#[cfg(test)] mod tests` in `db.rs` names that very file, and so does a
+  // `super::` path that climbs back to its own module: recorded as an edge,
+  // each becomes a node depending on itself.
+  return target === relSourceFile ? null : target;
 }
 
 /**

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1748,6 +1748,11 @@ export function resolveRustImport(
   // existing caller behaves as before.
   const declaredHere = declaredMods === undefined || declaredMods.has(head);
 
+  // In edition 2015 an unanchored path is absolute from the crate root, so it
+  // names a module of the crate rather than one in this file's scope — and no
+  // declaration in this file is required, or expected.
+  const rootRelative = importingCrate?.edition === "2015" && own !== null;
+
   const target = ((): string | null => {
     // A bare specifier is a `mod foo;` declaration (see extractImports), which
     // names a file in the declaring file's own module directory. `use foo;` —
@@ -1762,10 +1767,15 @@ export function resolveRustImport(
     // cargo 1.70.0 and 1.98.0 that line reaches the dependency with the file
     // sitting right there.
     if (segments.length === 1 && !["crate", "self", "super"].includes(head)) {
+      // A declaration always counts from the declaring file. A bare `use foo;`
+      // counts from the crate root in 2015, and in 2018 needs the declaration.
+      const from = declaredHere
+        ? ownModuleDir
+        : rootRelative
+          ? own.moduleDir
+          : null;
       const local =
-        global || !declaredHere
-          ? null
-          : resolveRustModulePath(ownModuleDir, [head], null, fileSet);
+        global || from === null ? null : resolveRustModulePath(from, [head], null, fileSet);
       if (local) return local;
       return crateNamed(head)?.libRoot ?? null;
     }
@@ -1835,10 +1845,17 @@ export function resolveRustImport(
     // gate: with `mod log;` present, `use log::item;` reaches the module and
     // not the dependency. `declaredMods` left undefined keeps the older,
     // looser reading, so every existing caller behaves as before.
-    const unanchoredFrom =
-      importingCrate?.edition === "2015" && own ? own.moduleDir : ownModuleDir;
+    //
+    // The gate is a 2018 rule and only a 2018 rule. In edition 2015 the path
+    // is absolute from the crate root, so it names a module of the crate and
+    // not one in the file's scope: `use registry::write;` in `src/client.rs`
+    // compiles with `mod registry;` written in `lib.rs` and nothing at all in
+    // `client.rs` — checked on cargo 1.70.0 and 1.98.0. Gating that on a
+    // declaration in the importing file would drop the edge on every 2015
+    // crate, which is every crate whose manifest omits the key.
+    const unanchoredFrom = rootRelative ? own.moduleDir : ownModuleDir;
     const local =
-      global || !declaredHere
+      global || (!rootRelative && !declaredHere)
         ? null
         : resolveRustModulePath(unanchoredFrom, segments, null, fileSet);
     if (local) return local;

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1677,13 +1677,25 @@ export function resolveRustImport(
   fileSet: Set<string>,
   crates: RustCrate[],
 ): string | null {
+  const own = rustRootForFile(crates, relSourceFile);
+  const isRoot = own?.root === relSourceFile;
+  const ownModuleDir = rustModuleDir(relSourceFile, isRoot);
+
   // A `#[path = "…"]` attribute arrives as the path it declares, extension and
-  // all, which no module path ever carries. It is relative to the directory
-  // the declaring file sits in — never to the directory that file's submodules
-  // live in, so `src/a/b.rs` and `src/a/mod.rs` both reach `src/a/moved.rs`.
+  // all, which no module path ever carries.
+  //
+  // On a declared module it is relative to the directory the declaring file
+  // sits in — never to the directory that file's submodules live in, so
+  // `src/a/b.rs` and `src/a/mod.rs` both reach `src/a/moved.rs`. Written
+  // inside an inline `mod`, it counts from the file's own module directory
+  // instead, one directory deeper per inline level; extractImports marks that
+  // form with a `self/` head, since nothing in the path itself tells them
+  // apart.
   if (specifier.endsWith(".rs")) {
+    const fromInline = specifier.startsWith("self/");
+    const base = fromInline ? ownModuleDir : path.dirname(relSourceFile);
     const declared = toForwardSlash(
-      path.normalize(path.join(path.dirname(relSourceFile), specifier)),
+      path.normalize(path.join(base, fromInline ? specifier.slice("self/".length) : specifier)),
     );
     return fileSet.has(declared) ? declared : null;
   }
@@ -1693,10 +1705,6 @@ export function resolveRustImport(
     .map((segment) => segment.trim())
     .filter(Boolean);
   if (segments.length === 0) return null;
-
-  const own = rustRootForFile(crates, relSourceFile);
-  const isRoot = own?.root === relSourceFile;
-  const ownModuleDir = rustModuleDir(relSourceFile, isRoot);
 
   // The package whose manifest governs this file, which is what says under
   // which names its dependencies are imported: the same crate answers to

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1741,14 +1741,31 @@ export function resolveRustImport(
 
   const head = segments[0];
 
+  // Whether the head names a module this very file declares. It gates both
+  // shapes an unanchored path takes — a head on its own and a head with
+  // segments below it — because scope is what decides them, not length.
+  // Left undefined by a caller, it keeps the older, looser reading, so every
+  // existing caller behaves as before.
+  const declaredHere = declaredMods === undefined || declaredMods.has(head);
+
   const target = ((): string | null => {
     // A bare specifier is a `mod foo;` declaration (see extractImports), which
     // names a file in the declaring file's own module directory. `use foo;` —
     // a whole crate, no path — and `extern crate foo;` arrive in the same
     // shape, so the local module is tried first and the crate name second:
     // only one of the two exists in any tree that compiles.
+    //
+    // Which of the two it is, the declaration decides: `mod foo;` puts `foo`
+    // among the names this file declares, `use foo;` does not. Without that
+    // gate an orphan `src/serde.rs` — a file no `mod` names, left by a
+    // refactor — captured `use serde;` and drew an edge rustc does not: on
+    // cargo 1.70.0 and 1.98.0 that line reaches the dependency with the file
+    // sitting right there.
     if (segments.length === 1 && !["crate", "self", "super"].includes(head)) {
-      const local = global ? null : resolveRustModulePath(ownModuleDir, [head], null, fileSet);
+      const local =
+        global || !declaredHere
+          ? null
+          : resolveRustModulePath(ownModuleDir, [head], null, fileSet);
       if (local) return local;
       return crateNamed(head)?.libRoot ?? null;
     }
@@ -1820,7 +1837,6 @@ export function resolveRustImport(
     // looser reading, so every existing caller behaves as before.
     const unanchoredFrom =
       importingCrate?.edition === "2015" && own ? own.moduleDir : ownModuleDir;
-    const declaredHere = declaredMods === undefined || declaredMods.has(head);
     const local =
       global || !declaredHere
         ? null

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1385,7 +1385,24 @@ export function buildRustCrateMap(fileSet: Set<string>, projectPath: string): Ru
     // package on 2018 rules, and a `[[bin]]` declared beside an undeclared
     // file in `src/bin/` then handed the file a crate root Cargo never gives
     // it. Old manifests are exactly the ones that omit the key.
-    const edition = typeof pkg?.edition === "string" ? pkg.edition : "2015";
+    //
+    // `edition.workspace = true` is not a missing key: the member inherits
+    // `[workspace.package] edition`, and `pkg.edition` is the table
+    // `{ workspace: true }` rather than a string. Read as a plain key only,
+    // every member of every workspace that centralises its edition — the
+    // recommended layout — fell back to 2015, which turns off autodiscovery
+    // next to a declared `[[bin]]` and reads unanchored `use` paths from the
+    // crate root instead of the module directory. Verified with cargo 1.70,
+    // 1.85 and 1.98: the member compiles `async fn`, and `cargo metadata`
+    // reports edition 2021 for it; with the key omitted entirely, the same
+    // member reports 2015 and rejects `async fn` — inheritance happens only
+    // when the member asks for it.
+    const wsPackage = enclosingWs ? asTable(enclosingWs.table.package) : null;
+    const inheritsEdition = isTable(pkg?.edition) && pkg.edition.workspace === true;
+    const inheritedEdition =
+      inheritsEdition && typeof wsPackage?.edition === "string" ? wsPackage.edition : null;
+    const edition =
+      typeof pkg?.edition === "string" ? pkg.edition : (inheritedEdition ?? "2015");
     const is2015 = edition === "2015";
 
     const declaredLib = declaredTargetPath(manifest?.lib);

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1700,6 +1700,11 @@ export function resolveRustImport(
     return fileSet.has(declared) ? declared : null;
   }
 
+  // `use ::config::Item;` says the head names a crate and not a module in
+  // scope — it is how a file that also has a local `config` reaches the other
+  // one. Since a local module otherwise wins, the marker has to survive.
+  const global = specifier.startsWith("::");
+
   const segments = specifier
     .split("::")
     .map((segment) => segment.trim())
@@ -1743,7 +1748,7 @@ export function resolveRustImport(
     // shape, so the local module is tried first and the crate name second:
     // only one of the two exists in any tree that compiles.
     if (segments.length === 1 && !["crate", "self", "super"].includes(head)) {
-      const local = resolveRustModulePath(ownModuleDir, [head], null, fileSet);
+      const local = global ? null : resolveRustModulePath(ownModuleDir, [head], null, fileSet);
       if (local) return local;
       return crateNamed(head)?.libRoot ?? null;
     }
@@ -1797,7 +1802,7 @@ export function resolveRustImport(
     // tree of `.rs` files most likely is.
     const unanchoredFrom =
       importingCrate?.edition === "2015" && own ? own.moduleDir : ownModuleDir;
-    const local = resolveRustModulePath(unanchoredFrom, segments, null, fileSet);
+    const local = global ? null : resolveRustModulePath(unanchoredFrom, segments, null, fileSet);
     if (local) return local;
 
     const crate = crateNamed(head);

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1675,7 +1675,8 @@ export function resolveRustImport(
   relSourceFile: string,
   fileSet: Set<string>,
   crates: RustCrate[],
-  declaredMods?: Set<string>,
+  declaredMods?: Map<string, string>,
+  isDeclaration?: boolean,
 ): string | null {
   const own = rustRootForFile(crates, relSourceFile);
   const isRoot = own?.root === relSourceFile;
@@ -1748,6 +1749,25 @@ export function resolveRustImport(
   // existing caller behaves as before.
   const declaredHere = declaredMods === undefined || declaredMods.has(head);
 
+  // Where the declaration put that module's file, when it moved it. A
+  // `#[path = "custom.rs"] mod foo;` names `foo` and files it under
+  // `custom.rs`, and the name alone reaches neither: `src/foo.rs` does not
+  // exist, so the path fell through to the crate of that name and drew an edge
+  // into an unrelated library. What rustc does with the children is the other
+  // half — they sit BESIDE the file the attribute names, `src/inner.rs` and
+  // not `src/custom/inner.rs`, which E0583 states outright on 1.70.0 and
+  // 1.98.0.
+  const declaredFile = ((): string | null => {
+    const spec = declaredMods?.get(head);
+    if (!spec || !spec.endsWith(".rs")) return null;
+    const fromInline = spec.startsWith("self/");
+    const base = fromInline ? ownModuleDir : path.dirname(relSourceFile);
+    const declared = toForwardSlash(
+      path.normalize(path.join(base, fromInline ? spec.slice("self/".length) : spec)),
+    );
+    return fileSet.has(declared) ? declared : null;
+  })();
+
   // In edition 2015 an unanchored path is absolute from the crate root, so it
   // names a module of the crate rather than one in this file's scope — and no
   // declaration in this file is required, or expected.
@@ -1767,16 +1787,32 @@ export function resolveRustImport(
     // cargo 1.70.0 and 1.98.0 that line reaches the dependency with the file
     // sitting right there.
     if (segments.length === 1 && !["crate", "self", "super"].includes(head)) {
-      // A declaration always counts from the declaring file. A bare `use foo;`
-      // counts from the crate root in 2015, and in 2018 needs the declaration.
-      const from = declaredHere
-        ? ownModuleDir
-        : rootRelative
-          ? own.moduleDir
-          : null;
+      if (global) return crateNamed(head)?.libRoot ?? null;
+      // A declaration is answered by the declaration: from the declaring
+      // file's own module directory, or from wherever `#[path]` filed it. It
+      // is never a crate, so it never falls through to one.
+      if (isDeclaration) {
+        return declaredFile ?? resolveRustModulePath(ownModuleDir, [head], null, fileSet);
+      }
+      // A `use foo;` in edition 2015 counts from the crate root even when this
+      // very file declares `foo` — checked on 1.70.0 and 1.98.0, where
+      // `use foo::Nested;` beside `mod foo;` is E0432 while `use foo::AtRoot;`
+      // reaches the root's module. Telling the two apart takes knowing which
+      // of them wrote the specifier, which is why the caller now says so — and
+      // a caller that says nothing keeps the older reading, where a bare head
+      // is tried from the file's own directory whatever the edition.
       const local =
-        global || from === null ? null : resolveRustModulePath(from, [head], null, fileSet);
+        rootRelative && isDeclaration === false
+          ? resolveRustModulePath(own.moduleDir, [head], null, fileSet)
+          : declaredHere
+            ? (declaredFile ?? resolveRustModulePath(ownModuleDir, [head], null, fileSet))
+            : null;
       if (local) return local;
+      // A name this file declares as a module is not a crate, whatever the
+      // manifest carries: rustc reads the module. Falling through drew an edge
+      // into a same-named library whenever the module's own file was somewhere
+      // the name alone could not reach — which is every `#[path]`.
+      if (declaredMods?.has(head)) return null;
       return crateNamed(head)?.libRoot ?? null;
     }
 
@@ -1853,12 +1889,29 @@ export function resolveRustImport(
     // `client.rs` — checked on cargo 1.70.0 and 1.98.0. Gating that on a
     // declaration in the importing file would drop the edge on every 2015
     // crate, which is every crate whose manifest omits the key.
+    // A head the declaration moved is answered from where it moved it, and its
+    // own children from the directory that file sits in — `src/inner.rs` for a
+    // module filed at `src/custom.rs`, which is what E0583 asks for.
+    if (!global && declaredFile) {
+      const below = resolveRustModulePath(
+        toForwardSlash(path.dirname(declaredFile)),
+        segments.slice(1),
+        declaredFile,
+        fileSet,
+      );
+      if (below) return below;
+    }
+
     const unanchoredFrom = rootRelative ? own.moduleDir : ownModuleDir;
     const local =
       global || (!rootRelative && !declaredHere)
         ? null
         : resolveRustModulePath(unanchoredFrom, segments, null, fileSet);
     if (local) return local;
+
+    // A name this file declares as a module is not a crate; see the same guard
+    // on the single-segment branch.
+    if (!global && declaredMods?.has(head)) return null;
 
     const crate = crateNamed(head);
     if (crate?.libRoot) {
@@ -1906,7 +1959,8 @@ export function resolveImport(
   elixirModuleMap?: Map<string, string[]>,
   phpFqcnMap?: Map<string, string[]>,
   rustCrates?: RustCrate[],
-  rustDeclaredMods?: Set<string>,
+  rustDeclaredMods?: Map<string, string>,
+  rustIsDeclaration?: boolean,
 ): string | null {
   // Skip obvious external/stdlib modules. Go is excluded from this
   // pre-check because its external classifier in `isExternalModule`
@@ -2223,6 +2277,7 @@ export function resolveImport(
         fileSet,
         rustCrates ?? [],
         rustDeclaredMods,
+        rustIsDeclaration,
       );
     }
 

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -1215,6 +1215,17 @@ export interface RustCrate {
    * as well as `[workspace.dependencies]` referenced via `workspace = true`.
    */
   aliases?: Record<string, string>;
+  /**
+   * The dependency names this manifest fetches from outside the project — a
+   * registry or a git remote — rather than from a directory of its own.
+   *
+   * A dependency with no `path` is a different crate from a project crate that
+   * happens to carry the same name, and cargo compiles against the fetched one.
+   * `log = "0.4"` beside a workspace member also called `log` drew an edge into
+   * that member: verified on cargo 1.98.0 with a `compile_error!` in the local
+   * crate, which builds clean because rustc never reads it.
+   */
+  externalDeps?: string[];
 }
 
 /** A parsed `Cargo.toml` as this reader consumes it. */
@@ -1226,11 +1237,92 @@ function asTable(value: TomlValue | undefined): CargoTable | null {
   return isTable(value) ? value : null;
 }
 
-/** A declared target's `path`, when the entry carries one. */
+/**
+ * A declared target's `path`, when the entry carries one, in the spelling the
+ * file set uses.
+ *
+ * Cargo accepts `path = "./src/api.rs"` and `path = "src/./api.rs"`; the file
+ * set holds neither, so the raw string never matched and the declaration was
+ * silently dropped. What followed was worse than losing the target: a `[lib]`
+ * declared that way erased the crate's name and roots entirely, so every
+ * sibling depending on it lost its edges, and a `[[bin]]` fell through to
+ * convention and rooted the file one directory too deep — `mod part;` in
+ * `src/tools/tool.rs` reached `src/tools/tool/part.rs` instead of
+ * `src/tools/part.rs`. Verified with cargo 1.98.0: `cargo metadata` reports
+ * the target at the normalized path and `cargo build` compiles against the
+ * sibling, with a `compile_error!` in the deeper file proving it is never read.
+ *
+ * Backslashes are folded first: a manifest written on Windows may spell the
+ * separator that way, and the file set is forward-slashed throughout.
+ */
 function declaredTargetPath(entry: TomlValue | undefined): string | null {
   const table = asTable(entry);
   const declared = table?.path;
-  return typeof declared === "string" ? declared : null;
+  if (typeof declared !== "string") return null;
+  const normalized = toForwardSlash(path.posix.normalize(declared.replace(/\\/g, "/")));
+  // `normalize` turns "" into "." and leaves a trailing slash on a directory;
+  // neither names a file, and passing them on would match nothing anyway.
+  //
+  // Returning null hands the target to convention rather than dropping it, and
+  // that is deliberate. Cargo 1.98.0 refuses such a manifest outright — "path
+  // `…/` for lib `x` is a directory, but a source file was expected" — so no
+  // build exists to mirror and the oracle names no right answer. Dropping the
+  // target is the more expensive of the two wrongs: it takes the crate's name
+  // and roots with it, and every edge its dependents draw.
+  return normalized === "." || normalized === "" ? null : normalized.replace(/\/+$/, "");
+}
+
+/**
+ * The **package names** a manifest sends to a local directory through
+ * `[patch.crates-io]` or the deprecated `[replace]`.
+ *
+ * Such a name reads as a registry dependency where it is declared, and cargo
+ * builds it from the path anyway. `[patch]` is keyed by source, `[replace]` by
+ * package spec (`"log:0.4.0"`), and only an entry carrying a `path` moves the
+ * crate inside the project.
+ *
+ * Package names, not the names the importing crate writes: `alias = { package =
+ * "itoa" }` is patched under `itoa` and imported as `alias`, so the caller has
+ * to translate before matching. And only the `crates-io` source: a
+ * `[patch.crates-io]` does not touch a dependency taken from a git remote,
+ * which cargo keeps fetching — verified on 1.98.0, where the dep-info names the
+ * checkout under `CARGO_HOME/git` and never the local directory.
+ *
+ * **The version is not compared**, and that is a known cost: cargo applies a
+ * patch only when the local crate's version satisfies the requirement, so
+ * `itoa = "1.0.18"` patched by a local `9.9.9` builds against the registry
+ * while this reads the patch as active. Matching it takes a semver
+ * implementation this module does not have, and the reading errs toward the
+ * project's own crate — the same direction the resolver took before any of this
+ * existed.
+ */
+function collectPatchedPaths(manifest: CargoTable | null): Set<string> {
+  const patched = new Set<string>();
+  if (!manifest) return patched;
+
+  const readEntries = (tableValue: TomlValue | undefined): void => {
+    const table = asTable(tableValue);
+    if (!table) return;
+    for (const [key, value] of Object.entries(table)) {
+      if (!isTable(value) || typeof value.path !== "string") continue;
+      // A `[replace]` key carries the version after a colon; a `[patch]` one
+      // does not, and splitting is harmless there.
+      patched.add(key.split(":")[0].replace(/-/g, "_"));
+    }
+  };
+
+  const patchSection = asTable(manifest.patch);
+  if (patchSection) {
+    for (const [source, entries] of Object.entries(patchSection)) {
+      // `[patch."https://github.com/…"]` patches that remote, not the registry,
+      // and a dependency taken from anywhere else is untouched by it.
+      if (source !== "crates-io") continue;
+      readEntries(entries);
+    }
+  }
+  readEntries(manifest.replace);
+
+  return patched;
 }
 
 /**
@@ -1244,6 +1336,9 @@ function declaredTargetPath(entry: TomlValue | undefined): string | null {
 function extractCargoAliases(
   manifest: CargoTable | null,
   wsDeps: Map<string, string>,
+  wsLocalDeps?: Set<string>,
+  externalDeps?: Set<string>,
+  gitDeps?: Set<string>,
 ): Record<string, string> {
   if (!manifest) return {};
   const aliases: Record<string, string> = {};
@@ -1254,6 +1349,18 @@ function extractCargoAliases(
     for (const [depKey, depVal] of Object.entries(table)) {
       const alias = depKey.replace(/-/g, "_");
       if (isTable(depVal)) {
+        // A `path` is what makes a dependency the project's own; anything else
+        // — a version, a git remote — is fetched from outside, whatever the
+        // project happens to hold under the same name. A `workspace = true`
+        // entry inherits the answer from where the workspace declares it.
+        const local =
+          typeof depVal.path === "string" ||
+          (depVal.workspace === true && (wsLocalDeps?.has(alias) ?? false));
+        if (!local) externalDeps?.add(alias);
+        // A git dependency is fetched from its remote whatever
+        // `[patch.crates-io]` says, so it must not be handed back to a local
+        // crate by one.
+        if (typeof depVal.git === "string") gitDeps?.add(alias);
         if (typeof depVal.package === "string") {
           aliases[alias] = depVal.package.replace(/-/g, "_");
         } else if (depVal.workspace === true) {
@@ -1263,6 +1370,8 @@ function extractCargoAliases(
           aliases[alias] = alias;
         }
       } else if (typeof depVal === "string") {
+        // `dep = "1.0"` is a version and nothing else: always from a registry.
+        externalDeps?.add(alias);
         aliases[alias] = alias;
       }
     }
@@ -1339,14 +1448,22 @@ export function buildRustCrateMap(fileSet: Set<string>, projectPath: string): Ru
   }
 
   // Collect all workspace tables to resolve `[workspace] exclude` and `[workspace.dependencies]`.
+  //
+  // The whole manifest travels beside the `[workspace]` table: `[patch]` is a
+  // top-level section of the workspace root, not part of that table, and the
+  // members inherit it.
   const workspaceManifests = parsedManifests
     .filter((m) => m.manifest?.workspace !== undefined && isTable(m.manifest.workspace))
-    .map((m) => ({ dir: m.dir, table: m.manifest?.workspace as CargoTable }));
+    .map((m) => ({
+      dir: m.dir,
+      table: m.manifest?.workspace as CargoTable,
+      root: m.manifest as CargoTable,
+    }));
 
   const findEnclosingWorkspace = (
     dir: string,
-  ): { dir: string; table: CargoTable } | null => {
-    let best: { dir: string; table: CargoTable } | null = null;
+  ): { dir: string; table: CargoTable; root: CargoTable } | null => {
+    let best: { dir: string; table: CargoTable; root: CargoTable } | null = null;
     for (const ws of workspaceManifests) {
       const isAncestor = ws.dir === "." || dir === ws.dir || dir.startsWith(`${ws.dir}/`);
       if (isAncestor && (best === null || ws.dir.length > best.dir.length)) {
@@ -1359,16 +1476,38 @@ export function buildRustCrateMap(fileSet: Set<string>, projectPath: string): Ru
   const crates: RustCrate[] = [];
 
   for (const { dir, manifest } of parsedManifests) {
-    const under = (relative: string): string => (dir === "." ? relative : `${dir}/${relative}`);
+    // Normalized after joining, not before: a declared `path = "../bar/src/lib.rs"`
+    // is legal — cargo builds it — and joining it raw produces
+    // `crates/foo/../bar/src/lib.rs`, which the file set never holds, so the
+    // declaration was dropped and with it the crate's name and roots. The
+    // convention paths passed through here are already clean, so this only ever
+    // changes a declared one.
+    // An absolute path is legal too, and cargo builds it: there is nothing to
+    // join, and joining it would produce `crates/foo//Users/…`. Where it points
+    // inside the project it becomes the project-relative spelling the file set
+    // holds; where it points outside, nothing in the tree can match it and it
+    // falls through to null, which is the right answer for a file that is not
+    // part of the project.
+    const under = (relative: string): string => {
+      if (path.posix.isAbsolute(relative) || path.isAbsolute(relative)) {
+        const rel = path.relative(projectPath, relative);
+        return rel && !rel.startsWith("..") ? toForwardSlash(rel) : toForwardSlash(relative);
+      }
+      return toForwardSlash(path.posix.normalize(dir === "." ? relative : `${dir}/${relative}`));
+    };
 
     const enclosingWs = findEnclosingWorkspace(dir);
     const wsDeps = new Map<string, string>();
+    // Which of the workspace's own dependency entries carry a `path`, which is
+    // what a member's `dep = { workspace = true }` inherits along with the name.
+    const wsLocalDeps = new Set<string>();
 
     if (enclosingWs) {
       const wsDepsTable = asTable(enclosingWs.table.dependencies);
       if (wsDepsTable) {
         for (const [depKey, depVal] of Object.entries(wsDepsTable)) {
           const normKey = depKey.replace(/-/g, "_");
+          if (isTable(depVal) && typeof depVal.path === "string") wsLocalDeps.add(normKey);
           if (isTable(depVal) && typeof depVal.package === "string") {
             wsDeps.set(normKey, depVal.package.replace(/-/g, "_"));
           } else {
@@ -1377,6 +1516,18 @@ export function buildRustCrateMap(fileSet: Set<string>, projectPath: string): Ru
         }
       }
     }
+
+    // `[patch]` sends a name that reads as a registry dependency to a directory
+    // instead, and it is how a workspace makes its members depend on each other
+    // by version. tokio does exactly this for all five of its crates: read as
+    // registry names, 473 real edges went with them.
+    //
+    // Only the workspace root's, or the manifest's own when it belongs to no
+    // workspace. Cargo says so out loud where a member writes one — "patch for
+    // the non root package will be ignored, specify patch at the workspace
+    // root" — and honouring it there drew an edge into a crate the build never
+    // touches.
+    const patchedLocally = collectPatchedPaths(enclosingWs ? enclosingWs.root : manifest);
 
     const pkg = asTable(manifest?.package);
     const lib = asTable(manifest?.lib);
@@ -1533,10 +1684,22 @@ export function buildRustCrateMap(fileSet: Set<string>, projectPath: string): Ru
       }
     }
 
-    const aliases = extractCargoAliases(manifest, wsDeps);
+    const externalDeps = new Set<string>();
+    const gitDeps = new Set<string>();
+    const aliases = extractCargoAliases(manifest, wsDeps, wsLocalDeps, externalDeps, gitDeps);
+    // The patch table names packages, the dependency table names whatever this
+    // crate imports them as: `alias = { package = "itoa" }` is patched under
+    // `itoa` and written as `alias`, so the translation has to happen here.
+    for (const alias of [...externalDeps]) {
+      if (gitDeps.has(alias)) continue;
+      if (patchedLocally.has(aliases[alias] ?? alias)) externalDeps.delete(alias);
+    }
     const crateEntry: RustCrate = { dir, name, libRoot, roots: [...roots].sort(), edition };
     if (Object.keys(aliases).length > 0) {
       crateEntry.aliases = aliases;
+    }
+    if (externalDeps.size > 0) {
+      crateEntry.externalDeps = [...externalDeps].sort();
     }
 
     crates.push(crateEntry);
@@ -1728,6 +1891,13 @@ export function resolveRustImport(
   // importing file — two manifests can carry the same package name, and a
   // workspace member's own name must not resolve into an unrelated checkout.
   const crateNamed = (name: string): RustCrate | null => {
+    // A name the manifest fetches from a registry or a git remote is that
+    // crate, not a project crate of the same name: cargo compiles against what
+    // it fetched, and the local one is never in scope. `log = "0.4"` beside a
+    // workspace member also called `log` drew an edge into the member —
+    // verified on cargo 1.98.0, where a `compile_error!` in it does not stop
+    // the build because rustc never reads the file.
+    if (importingCrate?.externalDeps?.includes(name)) return null;
     // `dep = { package = "real-name" }` renames a dependency for the crate
     // that declares it, and the code then writes the alias. The alias appears
     // in no `[package] name`, so without this the path resolved to nothing —
@@ -1773,16 +1943,31 @@ export function resolveRustImport(
     return fileSet.has(declared) ? declared : null;
   })();
 
-  // In edition 2015 an unanchored path is absolute from the crate root, so it
-  // names a module of the crate rather than one in this file's scope — and no
-  // declaration in this file is required, or expected.
-  const rootRelative = importingCrate?.edition === "2015" && own !== null;
+  // In edition 2015 an unanchored path is absolute from the crate root rather
+  // than relative to this file's scope.
+  //
+  // **That reading is deliberately not acted on for resolution.** Acting on it
+  // means answering a path with no declaration behind it, and every attempt to
+  // bound that produced a fresh way to draw an edge rustc rejects: a bare
+  // `use b;` between two integration-test crates, an undeclared sibling file, a
+  // `mod` declared in a nested block, a virtual workspace's root crate claiming
+  // its members' declarations. Each was found by a reviewer running cargo,
+  // after the previous one was closed.
+  //
+  // So the gate stays on for every edition: resolve what a declaration proves,
+  // and leave the rest unresolved. The cost is one real edge — `use foo::AtRoot;`
+  // in `src/deep/mod.rs` with `mod foo;` in `lib.rs` compiles and draws nothing
+  // — which `main` never drew either, so nothing published regresses. Fewer
+  // edges, none of them wrong, and the remainder is documentation rather than
+  // another round.
+  const edition2015 = importingCrate?.edition === "2015" && own !== null;
 
-  // And so the leading `::` marks an external crate only where the extern
-  // prelude exists. In 2015 it is the same crate root an unanchored path counts
-  // from, and letting the marker through sent the path looking for a workspace
-  // crate of that name — or, finding none, to nothing at all.
-  const global = globalMarker && !rootRelative;
+  // The edition still decides the leading `::`, which is a separate question:
+  // the marker names an external crate only where the extern prelude exists. In
+  // 2015 it is the same crate root an unanchored path counts from, and letting
+  // it through sent the path looking for a workspace crate of that name — or,
+  // finding none, to nothing at all.
+  const global = globalMarker && !edition2015;
 
   const target = ((): string | null => {
     // A bare specifier is a `mod foo;` declaration (see extractImports), which
@@ -1812,12 +1997,9 @@ export function resolveRustImport(
       // of them wrote the specifier, which is why the caller now says so — and
       // a caller that says nothing keeps the older reading, where a bare head
       // is tried from the file's own directory whatever the edition.
-      const local =
-        rootRelative && isDeclaration === false
-          ? resolveRustModulePath(own.moduleDir, [head], null, fileSet)
-          : declaredHere
-            ? (declaredFile ?? resolveRustModulePath(ownModuleDir, [head], null, fileSet))
-            : null;
+      const local = declaredHere
+        ? (declaredFile ?? resolveRustModulePath(ownModuleDir, [head], null, fileSet))
+        : null;
       if (local) return local;
       // A name this file declares as a module is not a crate, whatever the
       // manifest carries: rustc reads the module. Falling through drew an edge
@@ -1913,11 +2095,10 @@ export function resolveRustImport(
       if (below) return below;
     }
 
-    const unanchoredFrom = rootRelative ? own.moduleDir : ownModuleDir;
     const local =
-      global || (!rootRelative && !declaredHere)
+      global || !declaredHere
         ? null
-        : resolveRustModulePath(unanchoredFrom, segments, null, fileSet);
+        : resolveRustModulePath(ownModuleDir, segments, null, fileSet);
     if (local) return local;
 
     // A name this file declares as a module is not a crate; see the same guard

--- a/tests/integration/rust-graph-vs-cargo.test.ts
+++ b/tests/integration/rust-graph-vs-cargo.test.ts
@@ -43,7 +43,12 @@ function sourcesRustcRead(root: string): Set<string> {
       if (colon === -1) continue;
       for (const raw of line.slice(colon + 1).trim().split(/\s+/)) {
         if (!raw.endsWith(".rs")) continue;
-        const rel = path.relative(root, path.resolve(root, raw));
+        // Every comparison below this — against graph edges and against
+        // literals like `src/lib.rs` — is written with forward slashes, and so
+        // is the `target/` guard. On Windows `path.relative` answers with the
+        // platform separator, which would fail every lookup and let the build
+        // directory through (review finding).
+        const rel = path.relative(root, path.resolve(root, raw)).split(path.sep).join("/");
         if (!rel || rel.startsWith("..") || rel.startsWith("target/")) continue;
         read.add(rel);
       }

--- a/tests/integration/rust-graph-vs-cargo.test.ts
+++ b/tests/integration/rust-graph-vs-cargo.test.ts
@@ -300,3 +300,97 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info (needs ca
     expect([...new Set(strangers)]).toEqual([]);
   });
 });
+
+// A workspace, for what one package may reach in another. Only what a package
+// declares is in its extern prelude: a sibling the manifest never names is
+// E0432 to rustc, whatever the workspace holds. The import that names the
+// undeclared sibling is written under `#[cfg(any())]`, which rustc strips
+// before it resolves names — so the crate builds, and the sibling carries a
+// `compile_error!` that would end the build if cargo ever compiled it as a
+// dependency. The graph fixes no cfg and reads the line; it must still draw
+// nothing from it.
+describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info, across a workspace (needs cargo on PATH)", () => {
+  let root: string;
+  let read: Set<string>;
+
+  beforeAll(() => {
+    ensureDynamicLanguages();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-cargo-ws-"));
+
+    write(root, "Cargo.toml", ['[workspace]', 'members = ["app", "helper", "util"]', 'resolver = "2"', ""].join("\n"));
+    write(
+      root,
+      "app/Cargo.toml",
+      ['[package]', 'name = "app"', 'version = "0.1.0"', 'edition = "2021"', "", "[dependencies]", 'util = { path = "../util" }', ""].join("\n"),
+    );
+    write(
+      root,
+      "app/src/lib.rs",
+      [
+        "#[cfg(any())]",
+        "use helper::Thing;",
+        "",
+        // Written as a `use`: a path inside an expression is not an import to
+        // the graph, and this fixture is about what a `use` may reach.
+        "use util::value;",
+        "",
+        "pub fn all() -> u32 {",
+        "    value()",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    // Another target of the same package reaches its library by the package's
+    // own name, which no manifest declares.
+    write(root, "app/src/bin/tool.rs", "use app::all;\n\nfn main() {\n    println!(\"{}\", all());\n}\n");
+    write(root, "helper/Cargo.toml", ['[package]', 'name = "helper"', 'version = "0.1.0"', 'edition = "2021"', ""].join("\n"));
+    write(root, "helper/src/lib.rs", 'compile_error!("helper is not a dependency of app and must never be compiled for it");\npub struct Thing;\n');
+    write(root, "util/Cargo.toml", ['[package]', 'name = "util"', 'version = "0.1.0"', 'edition = "2021"', ""].join("\n"));
+    write(root, "util/src/lib.rs", "pub fn value() -> u32 {\n    7\n}\n");
+
+    try {
+      execFileSync("cargo", ["check", "--offline", "--quiet", "-p", "app", "--bins", "--lib"], {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 120_000,
+      });
+    } catch (err) {
+      const details = err instanceof Error && "stderr" in err ? String(err.stderr) : String(err);
+      throw new Error(`the fixture workspace did not compile, so there is no oracle:\n${details}`);
+    }
+
+    read = sourcesRustcRead(root);
+  }, 180_000);
+
+  afterAll(() => {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it("reads a dep-info that names the files rustc opened, and not the sibling", () => {
+    expect(read.has("app/src/lib.rs")).toBe(true);
+    expect(read.has("app/src/bin/tool.rs")).toBe(true);
+    expect(read.has("util/src/lib.rs")).toBe(true);
+    expect(read.has("helper/src/lib.rs")).toBe(false);
+  });
+
+  it("draws no edge into a sibling crate the importing package never declared", async () => {
+    // Review finding: the raw import head used to be searched across every
+    // crate of the workspace, and `use helper::Thing` drew `app -> helper`
+    // though app's manifest names no `helper`.
+    const graph = await buildCodeGraph(root);
+    const intoHelper = graph.edges.filter((e) => String(e.target).startsWith("helper/"));
+    expect(intoHelper.map((e) => `${e.source} -> ${e.target}`)).toEqual([]);
+  });
+
+  it("still reaches a declared dependency, and the package's own library from its binary", async () => {
+    const graph = await buildCodeGraph(root);
+    const pairs = new Set(graph.edges.map((e) => `${e.source} -> ${e.target}`));
+    expect(pairs.has("app/src/lib.rs -> util/src/lib.rs")).toBe(true);
+    expect(pairs.has("app/src/bin/tool.rs -> app/src/lib.rs")).toBe(true);
+  });
+});

--- a/tests/integration/rust-graph-vs-cargo.test.ts
+++ b/tests/integration/rust-graph-vs-cargo.test.ts
@@ -497,3 +497,108 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info, in editi
     expect(pairs.has("src/deep/child.rs -> src/deep/local.rs")).toBe(true);
   });
 });
+
+// A member directory of a single character, under a `[workspace]`-only root.
+// The root's `"."` is the empty prefix, but measured as a string it is one
+// character long and tied with `a/`, and the tie went to the root: every file
+// of `a/` was governed by a manifest that declares no dependency and no
+// edition. Both halves of that show here, and cargo settles both — `a` really
+// does depend on `bb`, and `::bb` really is the crate rather than the local
+// module, since `a/src/bb.rs` defines no `Thing`.
+//
+// `a/sub` is here because ranking by depth decides two orderings, not one:
+// root against member, and shallow member against the one nested inside it. A
+// first cut of this fixture pinned only the first, and answering "0 for the
+// root, 1 for everything else" kept it green while `a` governed `a/sub` — where
+// `use cc::Deep;` is E0432, `cc` being declared by `sub` alone.
+describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info, in a one-letter member (needs cargo on PATH)", () => {
+  let root: string;
+  let read: Set<string>;
+
+  beforeAll(() => {
+    ensureDynamicLanguages();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-cargo-short-"));
+
+    write(root, "Cargo.toml", ["[workspace]", 'members = ["a", "a/sub", "bb", "cc"]', 'resolver = "2"', ""].join("\n"));
+    write(
+      root,
+      "a/Cargo.toml",
+      ["[package]", 'name = "pkg"', 'version = "0.1.0"', 'edition = "2021"', "", "[dependencies]", 'bb = { path = "../bb" }', ""].join("\n"),
+    );
+    write(root, "a/src/lib.rs", ["pub mod bb;", "", "use ::bb::Thing;", "", "pub fn go() -> Thing {", "    Thing", "}", ""].join("\n"));
+    // Declared, so rustc compiles it — and it defines no `Thing`, which is why
+    // the `use` above compiles only when `::bb` is the dependency crate.
+    write(root, "a/src/bb.rs", "pub struct Other;\n");
+    // Nested inside `a/`, and depending on what `a` does not: `cc` is declared
+    // here and nowhere else, so `a` governing this file loses the edge.
+    write(
+      root,
+      "a/sub/Cargo.toml",
+      ["[package]", 'name = "sub"', 'version = "0.1.0"', 'edition = "2021"', "", "[dependencies]", 'cc = { path = "../../cc" }', ""].join("\n"),
+    );
+    write(root, "a/sub/src/lib.rs", ["use cc::Deep;", "", "pub fn deep() -> Deep {", "    Deep", "}", ""].join("\n"));
+    write(root, "bb/Cargo.toml", ["[package]", 'name = "bb"', 'version = "0.1.0"', 'edition = "2021"', ""].join("\n"));
+    write(root, "bb/src/lib.rs", "pub struct Thing;\n");
+    write(root, "cc/Cargo.toml", ["[package]", 'name = "cc"', 'version = "0.1.0"', 'edition = "2021"', ""].join("\n"));
+    write(root, "cc/src/lib.rs", "pub struct Deep;\n");
+
+    try {
+      execFileSync("cargo", ["check", "--offline", "--quiet", "-p", "pkg", "-p", "sub", "--lib"], {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 120_000,
+      });
+    } catch (err) {
+      const details = err instanceof Error && "stderr" in err ? String(err.stderr) : String(err);
+      throw new Error(`the fixture workspace did not compile, so there is no oracle:\n${details}`);
+    }
+
+    read = sourcesRustcRead(root);
+  }, 180_000);
+
+  afterAll(() => {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it("reads a dep-info that names the dependency and the local module both", () => {
+    expect(read.has("a/src/lib.rs")).toBe(true);
+    expect(read.has("a/src/bb.rs")).toBe(true);
+    expect(read.has("bb/src/lib.rs")).toBe(true);
+    expect(read.has("a/sub/src/lib.rs")).toBe(true);
+    expect(read.has("cc/src/lib.rs")).toBe(true);
+  });
+
+  // Three assertions, three tests: each names a different way the ranking goes
+  // wrong, and one `it` holding all three reports only the first to fail.
+  it("reaches a one-letter member's own dependency, which the root declares nothing of", async () => {
+    // Review finding. Governed by a `[workspace]`-only root, `a` declared
+    // nothing, and the fence turned every crate it names away.
+    const graph = await buildCodeGraph(root);
+    const pairs = graph.edges.map((e) => `${e.source} -> ${e.target}`);
+    expect(pairs).toContain("a/src/lib.rs -> bb/src/lib.rs");
+  });
+
+  it("does not read a one-letter member's 2021 file as edition 2015", async () => {
+    // The root declares no edition either, which defaults to 2015, where a
+    // leading `::` counts from the crate root — turning `use ::bb::Thing` into
+    // a second edge to the local `a/src/bb.rs`. The `mod bb;` declaration draws
+    // one edge there, and it is the only one.
+    const graph = await buildCodeGraph(root);
+    const pairs = graph.edges.map((e) => `${e.source} -> ${e.target}`);
+    expect(pairs.filter((p) => p === "a/src/lib.rs -> a/src/bb.rs")).toHaveLength(1);
+  });
+
+  it("governs a nested member by its own manifest, not its parent package's", async () => {
+    // The other ordering depth decides. `a` declares `bb` and not `cc`, so
+    // `a` governing `a/sub` loses this edge — and `use cc::Deep;` there is
+    // E0432 to rustc, which is what the build above proves it is not.
+    const graph = await buildCodeGraph(root);
+    const pairs = graph.edges.map((e) => `${e.source} -> ${e.target}`);
+    expect(pairs).toContain("a/sub/src/lib.rs -> cc/src/lib.rs");
+  });
+});

--- a/tests/integration/rust-graph-vs-cargo.test.ts
+++ b/tests/integration/rust-graph-vs-cargo.test.ts
@@ -86,8 +86,10 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info", () => {
         "",
         "pub mod env;",
         "",
+        "include!(\"pasted.rs\");",
+        "",
         "pub fn all() -> u32 {",
-        "    hidden::value() + platform::value() + env::value()",
+        "    hidden::value() + platform::value() + env::value() + pasted()",
         "}",
         "",
       ].join("\n"),
@@ -97,6 +99,9 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info", () => {
     write(root, "src/under_unix.rs", "pub fn value() -> u32 {\n    2\n}\n");
     write(root, "src/under_windows.rs", "pub fn value() -> u32 {\n    2\n}\n");
     write(root, "src/env/mod.rs", "pub fn value() -> u32 {\n    3\n}\n");
+    // Pasted rather than declared: `pasted()` is called unqualified from
+    // `lib.rs` above, which only compiles because `include!` puts it there.
+    write(root, "src/pasted.rs", "fn pasted() -> u32 {\n    4\n}\n");
 
     execFileSync("cargo", ["check", "--offline", "--quiet"], {
       cwd: root,

--- a/tests/integration/rust-graph-vs-cargo.test.ts
+++ b/tests/integration/rust-graph-vs-cargo.test.ts
@@ -317,11 +317,23 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info, across a
     ensureDynamicLanguages();
     root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-cargo-ws-"));
 
-    write(root, "Cargo.toml", ['[workspace]', 'members = ["app", "helper", "util"]', 'resolver = "2"', ""].join("\n"));
+    write(root, "Cargo.toml", ['[workspace]', 'members = ["app", "helper", "util", "other"]', 'resolver = "2"', ""].join("\n"));
     write(
       root,
       "app/Cargo.toml",
-      ['[package]', 'name = "app"', 'version = "0.1.0"', 'edition = "2021"', "", "[dependencies]", 'util = { path = "../util" }', ""].join("\n"),
+      [
+        "[package]",
+        'name = "app"',
+        'version = "0.1.0"',
+        'edition = "2021"',
+        "",
+        "[dependencies]",
+        'util = { path = "../util" }',
+        // Declared under its package name; its code is imported under the
+        // library name it sets, which is the name cargo hands rustc.
+        'other = { path = "../other" }',
+        "",
+      ].join("\n"),
     );
     write(
       root,
@@ -333,13 +345,20 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info, across a
         // Written as a `use`: a path inside an expression is not an import to
         // the graph, and this fixture is about what a `use` may reach.
         "use util::value;",
+        "use otherlib::other_value;",
         "",
         "pub fn all() -> u32 {",
-        "    value()",
+        "    value() + other_value()",
         "}",
         "",
       ].join("\n"),
     );
+    write(
+      root,
+      "other/Cargo.toml",
+      ['[package]', 'name = "other"', 'version = "0.1.0"', 'edition = "2021"', "", "[lib]", 'name = "otherlib"', ""].join("\n"),
+    );
+    write(root, "other/src/lib.rs", "pub fn other_value() -> u32 {\n    11\n}\n");
     // Another target of the same package reaches its library by the package's
     // own name, which no manifest declares.
     write(root, "app/src/bin/tool.rs", "use app::all;\n\nfn main() {\n    println!(\"{}\", all());\n}\n");
@@ -392,6 +411,12 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info, across a
     const pairs = new Set(graph.edges.map((e) => `${e.source} -> ${e.target}`));
     expect(pairs.has("app/src/lib.rs -> util/src/lib.rs")).toBe(true);
     expect(pairs.has("app/src/bin/tool.rs -> app/src/lib.rs")).toBe(true);
+    // Declared as `other`, imported as `otherlib`: the first cut of the fence
+    // keyed on declared names alone and turned this edge away, a regression
+    // against the head before it (review finding). rustc reads
+    // `other/src/lib.rs` here, and `use other::…` would be E0432.
+    expect(read.has("other/src/lib.rs")).toBe(true);
+    expect(pairs.has("app/src/lib.rs -> other/src/lib.rs")).toBe(true);
   });
 });
 

--- a/tests/integration/rust-graph-vs-cargo.test.ts
+++ b/tests/integration/rust-graph-vs-cargo.test.ts
@@ -18,8 +18,10 @@ import { buildCodeGraph, ensureDynamicLanguages } from "../../src/services/code-
 //
 // The crate is deliberately dependency-free so the check needs no network, and
 // it carries the shapes that were broken: a `mod` written inside a macro body,
-// a `#[cfg_attr(…, path = …)]` relocation, and a module named `env` — the name
-// the ignore list used to delete at any depth.
+// a `#[cfg_attr(…, path = …)]` relocation, a module named `env` — the name the
+// ignore list used to delete at any depth — and a macro whose body is not items
+// on its own, written inside an inline `mod`, where blanking the braces used to
+// re-parent the rest of the block to file level.
 
 function haveCargo(): boolean {
   try {
@@ -92,8 +94,51 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info (needs ca
         "",
         "include!(\"pasted.rs\");",
         "",
+        // `pick!` has the shape of `cfg_if!`: arms written as an `if` carrying
+        // an attribute, which is not Rust once the head and braces are blanked.
+        // Spelled out here so the crate still depends on nothing.
+        "macro_rules! pick {",
+        "    (if #[cfg($a:meta)] { $($ia:item)* } else if #[cfg($b:meta)] { $($ib:item)* } else { $($ic:item)* }) => {",
+        "        $(#[cfg($a)] $ia)*",
+        "        $(#[cfg(all(not($a), $b))] $ib)*",
+        "        $(#[cfg(all(not($a), not($b)))] $ic)*",
+        "    };",
+        "}",
+        "",
+        "pub mod inner {",
+        "    mod before;",
+        "    pick! {",
+        "        if #[cfg(unix)] {",
+        "            mod arm_a;",
+        "        } else if #[cfg(windows)] {",
+        "            mod arm_b;",
+        "        } else {",
+        "            mod arm_c;",
+        "        }",
+        "    }",
+        "    mod after;",
+        "",
+        "    pub fn value() -> u32 {",
+        "        before::value() + after::value()",
+        "    }",
+        "}",
+        "",
+        // The same shape at file level, where recovery moves nothing and the
+        // declarations stay where rustc reads them. This is the case the guard
+        // is drawn narrowly to keep, so the oracle has to cover it: the arm
+        // this platform builds must be reached.
+        "pick! {",
+        "    if #[cfg(unix)] {",
+        "        mod flat_unix;",
+        "    } else if #[cfg(windows)] {",
+        "        mod flat_windows;",
+        "    } else {",
+        "        mod flat_other;",
+        "    }",
+        "}",
+        "",
         "pub fn all() -> u32 {",
-        "    hidden::value() + platform::value() + env::value() + pasted()",
+        "    hidden::value() + platform::value() + env::value() + pasted() + inner::value()",
         "}",
         "",
       ].join("\n"),
@@ -106,6 +151,22 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info (needs ca
     // Pasted rather than declared: `pasted()` is called unqualified from
     // `lib.rs` above, which only compiles because `include!` puts it there.
     write(root, "src/pasted.rs", "fn pasted() -> u32 {\n    4\n}\n");
+
+    // The block the macro sits in. Its modules live under `src/inner/`, and the
+    // arms are one per platform — only one of them is ever compiled.
+    for (const name of ["before", "after", "arm_a", "arm_b", "arm_c"]) {
+      write(root, `src/inner/${name}.rs`, "pub fn value() -> u32 {\n    5\n}\n");
+    }
+    // The bait, at the level recovery used to re-parent to. A build that
+    // succeeds is the proof rustc never opens these.
+    for (const name of ["arm_a", "arm_b", "arm_c", "after"]) {
+      write(root, `src/${name}.rs`, `compile_error!("src/${name}.rs is never compiled");\n`);
+    }
+    // The file-level arms. Real modules, all three: only one is compiled, and
+    // the graph is expected to draw all of them — it fixes no platform.
+    for (const name of ["flat_unix", "flat_windows", "flat_other"]) {
+      write(root, `src/${name}.rs`, "pub fn value() -> u32 {\n    6\n}\n");
+    }
 
     // `--offline` because the crate declares no dependencies: nothing here
     // should ever reach the network, and asking for it makes that a failure
@@ -136,12 +197,63 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info (needs ca
     }
   });
 
+  // The arm this platform compiles. It is the one file rustc reads that the
+  // graph is not expected to reach: its declaration is written inside a macro
+  // body that is not items on its own, so the body is left unread — the price
+  // of not drawing the three edges the next test names.
+  const compiledArm = process.platform === "win32" ? "src/inner/arm_b.rs" : "src/inner/arm_a.rs";
+
   it("reads a dep-info that names the files rustc opened", () => {
     // Guards the oracle itself: a half-written dep-info would let every
     // assertion below pass by having nothing to check.
     expect(read.has("src/lib.rs")).toBe(true);
     expect(read.has("src/hidden.rs")).toBe(true);
+    expect(read.has(compiledArm)).toBe(true);
     expect(read.size).toBeGreaterThanOrEqual(4);
+  });
+
+  it("draws no edge into the file level a recovered macro body used to spill into", async () => {
+    // `pick!` has `cfg_if!`'s if/else shape, and blanking its head and braces
+    // leaves the parser recovering: it closed `mod inner` after the first arm
+    // and re-parented the rest to file level. The graph drew
+    // `src/lib.rs -> src/arm_b.rs` twice and `src/lib.rs -> src/after.rs`,
+    // three edges into `compile_error!` files that this crate's clean build
+    // proves are never compiled — while `mod after;`, which does belong to the
+    // block, lost the edge it should have had.
+    const graph = await buildCodeGraph(root);
+    const targets = new Set(graph.edges.map((e) => String(e.target)));
+
+    for (const bait of ["src/arm_a.rs", "src/arm_b.rs", "src/arm_c.rs", "src/after.rs"]) {
+      expect(read.has(bait), `${bait} must stay uncompiled for this to be a test`).toBe(false);
+      expect([...targets], `edge into ${bait}`).not.toContain(bait);
+    }
+
+    // The control. Without it this test also passes with macro bodies never
+    // read at all, and with the whole inline-module machinery removed.
+    expect([...targets]).toContain("src/inner/before.rs");
+    expect([...targets]).toContain("src/inner/after.rs");
+    expect([...targets]).toContain("src/hidden.rs");
+  });
+
+  it("still reads the same shape written at file level, where nothing moved", async () => {
+    // The other half of the rule, and the reason the guard tests where recovery
+    // reaches instead of whether an ERROR exists at all. The same `pick!` at
+    // file level leaves an ERROR on the attribute and moves nothing, so the arm
+    // rustc compiles keeps its edge — cargo says which one that is.
+    const graph = await buildCodeGraph(root);
+    const targets = new Set(graph.edges.map((e) => String(e.target)));
+
+    const compiled = process.platform === "win32" ? "src/flat_windows.rs" : "src/flat_unix.rs";
+    expect(read.has(compiled), "cargo must have compiled this arm").toBe(true);
+    expect([...targets]).toContain(compiled);
+
+    // And the arms it does not compile are drawn too: the graph fixes no
+    // platform, so both are dependencies of a build somewhere. Stated here
+    // because it is the reason the test above lists its baits by name instead
+    // of asking for "every file rustc did not read".
+    for (const arm of ["src/flat_unix.rs", "src/flat_windows.rs", "src/flat_other.rs"]) {
+      expect([...targets], `arm ${arm}`).toContain(arm);
+    }
   });
 
   it("reaches every source rustc read, walking from the crate root", async () => {
@@ -164,18 +276,27 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info (needs ca
       }
     }
 
+    // The compiled arm is the declared exception, and naming it rather than
+    // filtering it out is what keeps this test able to fail: anything else
+    // rustc reads and the graph misses still shows up here.
     const missed = [...read].filter((f) => !seen.has(f)).sort();
-    expect(missed).toEqual([]);
+    expect(missed).toEqual([compiledArm]);
   });
 
-  it("draws no edge into a file rustc never opened, apart from the other cfg arm", async () => {
+  it("draws no edge into a file rustc never opened, apart from the other cfg arms", async () => {
     const graph = await buildCodeGraph(root);
-    // The graph fixes no target, so it draws both arms of the `cfg_attr` — the
-    // arm this platform does not build is expected and is the only one.
-    const otherArm = process.platform === "win32" ? "src/under_unix.rs" : "src/under_windows.rs";
+    // The graph fixes neither platform nor feature, so it draws every arm of a
+    // `cfg` choice and not just the one this machine builds: the `cfg_attr`
+    // relocation and the file-level `pick!`. They are listed by name — the
+    // alternative, filtering out everything rustc did not read, would let a
+    // genuinely wrong edge through unnoticed.
+    const otherArms =
+      process.platform === "win32"
+        ? ["src/under_unix.rs", "src/flat_unix.rs", "src/flat_other.rs"]
+        : ["src/under_windows.rs", "src/flat_windows.rs", "src/flat_other.rs"];
     const strangers = graph.edges
-      .map((e) => e.target)
-      .filter((t) => t.endsWith(".rs") && !read.has(t) && t !== otherArm);
+      .map((e) => String(e.target))
+      .filter((t) => t.endsWith(".rs") && !read.has(t) && !otherArms.includes(t));
     expect([...new Set(strangers)]).toEqual([]);
   });
 });

--- a/tests/integration/rust-graph-vs-cargo.test.ts
+++ b/tests/integration/rust-graph-vs-cargo.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildCodeGraph, ensureDynamicLanguages } from "../../src/services/code-graph.js";
+
+// Every other test on the Rust graph builds a tree and asserts what we believe
+// is right. That is how two regressions reached `main`: our belief was wrong in
+// the same way on both sides of the assertion. This one asks the compiler
+// instead — it builds a crate, runs `cargo check`, and takes the dep-info cargo
+// leaves behind (`target/debug/deps/*.d`) as the list of sources rustc actually
+// opened. A file rustc read that our graph never reaches is a defect, whatever
+// our fixtures say.
+//
+// The crate is deliberately dependency-free so the check needs no network, and
+// it carries the shapes that were broken: a `mod` written inside a macro body,
+// a `#[cfg_attr(…, path = …)]` relocation, and a module named `env` — the name
+// the ignore list used to delete at any depth.
+
+function haveCargo(): boolean {
+  try {
+    execFileSync("cargo", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The sources rustc opened, per cargo's own dep-info, relative to the crate. */
+function sourcesRustcRead(root: string): Set<string> {
+  const deps = path.join(root, "target", "debug", "deps");
+  const read = new Set<string>();
+  for (const name of fs.readdirSync(deps)) {
+    if (!name.endsWith(".d")) continue;
+    for (const line of fs.readFileSync(path.join(deps, name), "utf8").split("\n")) {
+      const colon = line.indexOf(":");
+      if (colon === -1) continue;
+      for (const raw of line.slice(colon + 1).trim().split(/\s+/)) {
+        if (!raw.endsWith(".rs")) continue;
+        const rel = path.relative(root, path.resolve(root, raw));
+        if (!rel || rel.startsWith("..") || rel.startsWith("target/")) continue;
+        read.add(rel);
+      }
+    }
+  }
+  return read;
+}
+
+const write = (root: string, rel: string, body: string): void => {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, body);
+};
+
+describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info", () => {
+  let root: string;
+  let read: Set<string>;
+
+  beforeAll(() => {
+    ensureDynamicLanguages();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-cargo-"));
+
+    write(root, "Cargo.toml", ['[package]', 'name = "oracle"', 'version = "0.1.0"', 'edition = "2021"', "", "[dependencies]", ""].join("\n"));
+
+    // A macro body is not a module level: it opens no scope, so `mod plain;`
+    // written inside one still resolves next to the file that wrote it.
+    write(
+      root,
+      "src/lib.rs",
+      [
+        "macro_rules! declare {",
+        "    ($($item:item)*) => { $($item)* };",
+        "}",
+        "",
+        "declare! {",
+        "    mod hidden;",
+        "}",
+        "",
+        "#[cfg_attr(unix, path = \"under_unix.rs\")]",
+        "#[cfg_attr(windows, path = \"under_windows.rs\")]",
+        "mod platform;",
+        "",
+        "pub mod env;",
+        "",
+        "pub fn all() -> u32 {",
+        "    hidden::value() + platform::value() + env::value()",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    write(root, "src/hidden.rs", "pub fn value() -> u32 {\n    1\n}\n");
+    write(root, "src/under_unix.rs", "pub fn value() -> u32 {\n    2\n}\n");
+    write(root, "src/under_windows.rs", "pub fn value() -> u32 {\n    2\n}\n");
+    write(root, "src/env/mod.rs", "pub fn value() -> u32 {\n    3\n}\n");
+
+    execFileSync("cargo", ["check", "--offline", "--quiet"], {
+      cwd: root,
+      stdio: "ignore",
+      timeout: 120_000,
+    });
+
+    read = sourcesRustcRead(root);
+  }, 180_000);
+
+  afterAll(() => {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it("reads a dep-info that names the files rustc opened", () => {
+    // Guards the oracle itself: a half-written dep-info would let every
+    // assertion below pass by having nothing to check.
+    expect(read.has("src/lib.rs")).toBe(true);
+    expect(read.has("src/hidden.rs")).toBe(true);
+    expect(read.size).toBeGreaterThanOrEqual(4);
+  });
+
+  it("reaches every source rustc read, walking from the crate root", async () => {
+    const graph = await buildCodeGraph(root);
+    const outgoing = new Map<string, string[]>();
+    for (const edge of graph.edges) {
+      const from = outgoing.get(edge.source);
+      if (from) from.push(edge.target);
+      else outgoing.set(edge.source, [edge.target]);
+    }
+
+    const seen = new Set<string>(["src/lib.rs"]);
+    const queue = ["src/lib.rs"];
+    while (queue.length > 0) {
+      const current = queue.pop() as string;
+      for (const next of outgoing.get(current) ?? []) {
+        if (seen.has(next)) continue;
+        seen.add(next);
+        queue.push(next);
+      }
+    }
+
+    const missed = [...read].filter((f) => !seen.has(f)).sort();
+    expect(missed).toEqual([]);
+  });
+
+  it("draws no edge into a file rustc never opened, apart from the other cfg arm", async () => {
+    const graph = await buildCodeGraph(root);
+    // The graph fixes no target, so it draws both arms of the `cfg_attr` — the
+    // arm this platform does not build is expected and is the only one.
+    const otherArm = process.platform === "win32" ? "src/under_unix.rs" : "src/under_windows.rs";
+    const strangers = graph.edges
+      .map((e) => e.target)
+      .filter((t) => t.endsWith(".rs") && !read.has(t) && t !== otherArm);
+    expect([...new Set(strangers)]).toEqual([]);
+  });
+});

--- a/tests/integration/rust-graph-vs-cargo.test.ts
+++ b/tests/integration/rust-graph-vs-cargo.test.ts
@@ -56,7 +56,11 @@ const write = (root: string, rel: string, body: string): void => {
   fs.writeFileSync(full, body);
 };
 
-describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info", () => {
+// The condition is in the name because a skip is silent otherwise: vitest
+// prints the title and nothing about why, and a suite that quietly stops
+// running reads exactly like a suite that passes. In CI it cannot skip — the
+// `rust-graph-vs-cargo` job checks `rustc --version` before it gets here.
+describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info (needs cargo on PATH)", () => {
   let root: string;
   let read: Set<string>;
 
@@ -103,11 +107,23 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info", () => {
     // `lib.rs` above, which only compiles because `include!` puts it there.
     write(root, "src/pasted.rs", "fn pasted() -> u32 {\n    4\n}\n");
 
-    execFileSync("cargo", ["check", "--offline", "--quiet"], {
-      cwd: root,
-      stdio: "ignore",
-      timeout: 120_000,
-    });
+    // `--offline` because the crate declares no dependencies: nothing here
+    // should ever reach the network, and asking for it makes that a failure
+    // instead of a slow success.
+    try {
+      execFileSync("cargo", ["check", "--offline", "--quiet"], {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 120_000,
+      });
+    } catch (err) {
+      // Without this the failure surfaces as a bare non-zero exit from
+      // `beforeAll`, which says nothing about the crate that would not build —
+      // and the whole oracle rests on that build.
+      const details = err instanceof Error && "stderr" in err ? String(err.stderr) : String(err);
+      throw new Error(`the fixture crate did not compile, so there is no oracle:\n${details}`);
+    }
 
     read = sourcesRustcRead(root);
   }, 180_000);

--- a/tests/integration/rust-graph-vs-cargo.test.ts
+++ b/tests/integration/rust-graph-vs-cargo.test.ts
@@ -394,3 +394,81 @@ describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info, across a
     expect(pairs.has("app/src/bin/tool.rs -> app/src/lib.rs")).toBe(true);
   });
 });
+
+// Edition 2015, where a leading `::` is the crate root. The child declares a
+// `foo` of its own, moved by `#[path]`, and writes `use ::foo::Item` — which
+// compiles only because `::foo` is the root's module: the local one defines
+// no `Item`. rustc is the oracle for the meaning; the graph has to draw the
+// edge to the file rustc read the name from.
+describe.skipIf(!haveCargo())("the Rust graph against cargo's dep-info, in edition 2015 (needs cargo on PATH)", () => {
+  let root: string;
+  let read: Set<string>;
+
+  beforeAll(() => {
+    ensureDynamicLanguages();
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-cargo-2015-"));
+
+    write(root, "Cargo.toml", ['[package]', 'name = "old"', 'version = "0.1.0"', 'edition = "2015"', ""].join("\n"));
+    write(root, "src/lib.rs", "pub mod foo;\npub mod deep;\n");
+    write(root, "src/foo.rs", "pub struct Item;\n");
+    write(root, "src/deep/mod.rs", "pub mod child;\n");
+    write(
+      root,
+      "src/deep/child.rs",
+      [
+        '#[path = "local.rs"]',
+        "pub mod foo;",
+        "",
+        "use ::foo::Item;",
+        "",
+        "pub fn item() -> Item {",
+        "    Item",
+        "}",
+        "",
+        "pub fn other() -> foo::Other {",
+        "    foo::Other",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    write(root, "src/deep/local.rs", "pub struct Other;\n");
+
+    try {
+      execFileSync("cargo", ["check", "--offline", "--quiet"], {
+        cwd: root,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 120_000,
+      });
+    } catch (err) {
+      const details = err instanceof Error && "stderr" in err ? String(err.stderr) : String(err);
+      throw new Error(`the fixture crate did not compile, so there is no oracle:\n${details}`);
+    }
+
+    read = sourcesRustcRead(root);
+  }, 180_000);
+
+  afterAll(() => {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it("reads a dep-info that names both files called foo", () => {
+    expect(read.has("src/foo.rs")).toBe(true);
+    expect(read.has("src/deep/local.rs")).toBe(true);
+  });
+
+  it("answers the child's leading :: with the root's module, not the one it moved", async () => {
+    // Review finding, left open from an earlier round: the child's own
+    // `#[path]` declaration used to capture `::foo`, and the edge to the
+    // root's `foo` — the one rustc reads `Item` from — was never drawn.
+    const graph = await buildCodeGraph(root);
+    const pairs = new Set(graph.edges.map((e) => `${e.source} -> ${e.target}`));
+    expect(pairs.has("src/deep/child.rs -> src/foo.rs")).toBe(true);
+    // The declaration still draws its own edge to the moved file.
+    expect(pairs.has("src/deep/child.rs -> src/deep/local.rs")).toBe(true);
+  });
+});

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -580,6 +580,21 @@ describe("buildCodeGraph — Rust crate resolution", () => {
         "pub fn shadowed() {}",
       ].join("\n"),
       "crates/cli/src/shadow/inner/serde.rs": "pub struct Local;",
+      // A declared module and a path through it, landing on two different
+      // files: the declaration draws the edge to `holder.rs`, the unanchored
+      // path draws the one to `holder/child.rs`. Edges are a set, so this is
+      // the only shape in which the graph can show that the collected
+      // declarations reach the resolver at all — asserting the declaration's
+      // own edge would stay green with the set emptied.
+      "crates/cli/src/holder_user.rs": [
+        "mod holder;",
+        "",
+        "use holder::child::Thing;",
+        "",
+        "pub fn make() -> Thing { Thing }",
+      ].join("\n"),
+      "crates/cli/src/holder_user/holder.rs": "pub mod child;",
+      "crates/cli/src/holder_user/holder/child.rs": "pub struct Thing;",
     });
     roots.push(dir);
     graph = await buildCodeGraph(dir);
@@ -642,6 +657,19 @@ describe("buildCodeGraph — Rust crate resolution", () => {
     expect(edge("crates/cli/src/shadow.rs", "crates/cli/src/shadow/inner/serde.rs")).toBe(
       true,
     );
+  });
+
+  it("carries the declarations a file makes all the way to the resolver", () => {
+    // Two files, one declaration: `mod holder;` draws the first edge, and the
+    // unanchored `use holder::child::Thing;` can only draw the second if the
+    // declaration reached the resolver. Empty the collected set and this
+    // second assertion fails while the first still holds.
+    expect(edge("crates/cli/src/holder_user.rs", "crates/cli/src/holder_user/holder.rs")).toBe(
+      true,
+    );
+    expect(
+      edge("crates/cli/src/holder_user.rs", "crates/cli/src/holder_user/holder/child.rs"),
+    ).toBe(true);
   });
 
   it("follows a module declared with a dependency's name", () => {

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -1128,6 +1128,27 @@ describe("buildCodeGraph — Rust edges rustc rejects", () => {
     ).toBe(true);
   });
 
+  it("reaches a project crate a [replace] sends a registry name to", async () => {
+    // `[replace]` is the older spelling of the same redirection, keyed by name
+    // and version instead of by source. Cargo still honours it, so the graph
+    // reads it too — and nothing proved that until now: deleting the line that
+    // reads it left all 1313 proofs green.
+    const graph = await graphOf({
+      "Cargo.toml": [
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+        '[dependencies]\nlog = "0.4.34"\n',
+        '[replace]\n"log:0.4.34" = { path = "local-log" }\n',
+      ].join("\n"),
+      "src/lib.rs": "use log::marker;\n\npub fn go() -> marker::Local { marker::Local }",
+      "local-log/Cargo.toml": '[package]\nname = "log"\nversion = "0.4.34"\nedition = "2021"\n',
+      "local-log/src/lib.rs": "pub mod marker { pub struct Local; }",
+    });
+
+    expect(
+      graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "local-log/src/lib.rs"),
+    ).toBe(true);
+  });
+
   it("ignores a [patch] a workspace member declares for itself", async () => {
     // Cargo says so out loud — "patch for the non root package will be ignored,
     // specify patch at the workspace root" — and then fails the build with

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -988,6 +988,60 @@ describe("buildCodeGraph — Rust edges rustc rejects", () => {
     expect(graph.edges.some((e) => e.target === "crates/log/src/lib.rs")).toBe(false);
   });
 
+  it("inherits from the workspace that a dependency is a registry one", async () => {
+    // `log = { workspace = true }` says nothing about where the crate comes
+    // from: the answer is in `[workspace.dependencies]`, and a member that
+    // writes it must read the same one cargo reads. Checked on cargo 1.98.0
+    // with the local crate holding a `compile_error!`: `cargo check -p app`
+    // downloads and builds `log v0.4.34`, and the member is never touched.
+    //
+    // The workspace entry is a table with a version and no `path` on purpose.
+    // Written as the bare string `log = "0.4"` this test passes even on a
+    // resolver that inherits nothing, because a string is not a table and never
+    // reaches the local branch at all — a shape that proves nothing.
+    const graph = await graphOf({
+      "Cargo.toml": [
+        '[workspace]\nmembers = ["crates/app", "crates/log"]\nresolver = "2"\n',
+        '[workspace.dependencies]\nlog = { version = "0.4" }\n',
+      ].join("\n"),
+      "crates/app/Cargo.toml": [
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+        "[dependencies]\nlog = { workspace = true }\n",
+      ].join("\n"),
+      "crates/app/src/lib.rs": 'use log::info;\n\npub fn shout() { info!("from the registry"); }',
+      "crates/log/Cargo.toml": '[package]\nname = "log"\nversion = "0.1.0"\nedition = "2021"\n',
+      "crates/log/src/lib.rs": 'compile_error!("never in scope for app");',
+    });
+
+    expect(graph.edges.some((e) => e.target === "crates/log/src/lib.rs")).toBe(false);
+  });
+
+  it("inherits from the workspace that a dependency is a local one", async () => {
+    // The other half, and the token that flips rustc: the same two manifests
+    // with `"0.4"` replaced by `{ path = "crates/log" }` in the workspace
+    // table. Cargo then compiles the member — it is how the `compile_error!`
+    // above was shown to be reachable at all — so the edge has to be drawn.
+    // Without this half the test above passes on a resolver that calls every
+    // inherited dependency external.
+    const graph = await graphOf({
+      "Cargo.toml": [
+        '[workspace]\nmembers = ["crates/app", "crates/log"]\nresolver = "2"\n',
+        '[workspace.dependencies]\nlog = { path = "crates/log" }\n',
+      ].join("\n"),
+      "crates/app/Cargo.toml": [
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+        "[dependencies]\nlog = { workspace = true }\n",
+      ].join("\n"),
+      "crates/app/src/lib.rs": "use log::marker;\n\npub fn go() -> marker::Local { marker::Local }",
+      "crates/log/Cargo.toml": '[package]\nname = "log"\nversion = "0.1.0"\nedition = "2021"\n',
+      "crates/log/src/lib.rs": "pub mod marker { pub struct Local; }",
+    });
+
+    expect(
+      graph.edges.some((e) => e.source === "crates/app/src/lib.rs" && e.target === "crates/log/src/lib.rs"),
+    ).toBe(true);
+  });
+
   it("reaches a project crate a [patch] sends a registry name to", async () => {
     // The same manifest, one section added, and cargo changes its answer with
     // the graph: `[patch.crates-io] log = { path = … }` builds `log v0.4.34`

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -502,8 +502,21 @@ describe("buildCodeGraph — Rust crate resolution", () => {
     const dir = writeLayout({
       "Cargo.toml": '[workspace]\nmembers = ["crates/cli", "crates/core"]\n',
 
-      "crates/core/Cargo.toml": '[package]\nname = "app-core"\nedition = "2021"\n',
-      "crates/core/src/lib.rs": ["pub mod store;", "", "pub use store::Store;"].join("\n"),
+      "crates/core/Cargo.toml":
+        '[package]\nname = "app-core"\nedition = "2021"\n\n[dependencies]\nserde = "1"\n',
+      // `serde` names both a dependency and a module this file declares. The
+      // declaration is what rustc resolves the path through, so the edge into
+      // the local module has to be drawn — a resolver that answers "no edge"
+      // to every path carrying a dependency's name would pass the third-party
+      // test below and fail here.
+      "crates/core/src/lib.rs": [
+        "pub mod store;",
+        "pub mod serde;",
+        "",
+        "pub use store::Store;",
+        "pub use serde::Local;",
+      ].join("\n"),
+      "crates/core/src/serde.rs": "pub struct Local;",
       "crates/core/src/store.rs": [
         "mod open;",
         "mod support;",
@@ -534,7 +547,8 @@ describe("buildCodeGraph — Rust crate resolution", () => {
         "}",
       ].join("\n"),
 
-      "crates/cli/Cargo.toml": '[package]\nname = "app-cli"\nedition = "2021"\n',
+      "crates/cli/Cargo.toml":
+        '[package]\nname = "app-cli"\nedition = "2021"\n\n[dependencies]\nserde = "1"\n',
       "crates/cli/src/main.rs": [
         "mod runner;",
         "",
@@ -543,6 +557,12 @@ describe("buildCodeGraph — Rust crate resolution", () => {
         "fn main() { runner::run(); }",
       ].join("\n"),
       "crates/cli/src/runner.rs": ["use serde::Deserialize;", "", "pub fn run() {}"].join("\n"),
+      // A file named after the dependency, sitting right beside the importer
+      // and declared by nobody. Cargo 1.70, 1.85 and 1.98 all agree an
+      // undeclared file is not in the module tree and cannot capture the
+      // path: `use serde::Deserialize;` reaches the crate, and the graph must
+      // draw nothing at all.
+      "crates/cli/src/serde.rs": "pub struct Deserialize;",
     });
     roots.push(dir);
     graph = await buildCodeGraph(dir);
@@ -578,15 +598,29 @@ describe("buildCodeGraph — Rust crate resolution", () => {
   });
 
   it("draws no edge into a crate for a third-party path", () => {
-    // `runner.rs` imports `serde` and nothing else. Asserting that every edge
-    // ends in a `.rs` file would hold on an empty set too — and did, while the
-    // resolver was returning nothing at all; the edges leaving this one file
-    // are what says a third-party path resolved to nothing.
+    // `runner.rs` imports `serde` and nothing else, and `crates/cli/src/serde.rs`
+    // sits right beside it carrying that very name without being declared.
+    // Asserting that every edge ends in a `.rs` file would hold on an empty
+    // set too — and did, while the resolver was returning nothing at all; the
+    // edges leaving this one file are what says the third-party path resolved
+    // to nothing rather than to the same-named file next door.
     const leaving = graph.edges
       .filter((e) => e.source === "crates/cli/src/runner.rs")
       .map((e) => e.target);
 
     expect(leaving).toEqual([]);
+    // Said the other way round, so that a resolver drawing the wrong edge is
+    // named by the assertion that fails.
+    expect(edge("crates/cli/src/runner.rs", "crates/cli/src/serde.rs")).toBe(false);
+  });
+
+  it("follows a module declared with a dependency's name", () => {
+    // The hand that keeps the test above honest: here `serde` is declared with
+    // `pub mod serde;`, so rustc reads `pub use serde::Local;` as the local
+    // module and the edge belongs in the graph. A resolver that answers "no
+    // edge" whenever a path's head matches a dependency passes the test above
+    // and fails this one.
+    expect(edge("crates/core/src/lib.rs", "crates/core/src/serde.rs")).toBe(true);
   });
 
   it("draws no edge at the parent module for a test block's glob import", () => {

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -486,3 +486,80 @@ describe("buildCodeGraph — Go module resolution (issues #45 & #82)", () => {
     ).toBe(true);
   });
 });
+
+// ── Rust crate resolution through the real pipeline ───────────────────────
+// Cargo.toml has no AST grammar, so it is never in the graphable file set —
+// the same trap #82 documents for go.mod. These drive the real
+// getGraphableFiles → buildCodeGraph path over a workspace laid out the way
+// Cargo generates one, where every edge below was absent before crate roots
+// were read.
+describe("buildCodeGraph — Rust crate resolution", () => {
+  const roots: string[] = [];
+  let graph: Awaited<ReturnType<typeof buildCodeGraph>>;
+
+  beforeAll(async () => {
+    ensureDynamicLanguages();
+    const dir = writeLayout({
+      "Cargo.toml": '[workspace]\nmembers = ["crates/cli", "crates/core"]\n',
+
+      "crates/core/Cargo.toml": '[package]\nname = "app-core"\n',
+      "crates/core/src/lib.rs": ["pub mod store;", "", "pub use store::Store;"].join("\n"),
+      "crates/core/src/store.rs": [
+        "mod open;",
+        "",
+        "pub struct Store;",
+        "pub struct StoreError;",
+      ].join("\n"),
+      "crates/core/src/store/open.rs": [
+        "use super::Store;",
+        "",
+        "pub fn open() -> Store { Store }",
+      ].join("\n"),
+
+      "crates/cli/Cargo.toml": '[package]\nname = "app-cli"\n',
+      "crates/cli/src/main.rs": [
+        "mod runner;",
+        "",
+        "use app_core::{Store, store::StoreError};",
+        "",
+        "fn main() { runner::run(); }",
+      ].join("\n"),
+      "crates/cli/src/runner.rs": "pub fn run() {}",
+    });
+    roots.push(dir);
+    graph = await buildCodeGraph(dir);
+  });
+
+  afterAll(() => {
+    for (const r of roots) {
+      try { fs.rmSync(r, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  const edge = (source: string, target: string): boolean =>
+    graph.edges.some((e) => e.source === source && e.target === target);
+
+  it("follows a pub mod declaration", () => {
+    expect(edge("crates/core/src/lib.rs", "crates/core/src/store.rs")).toBe(true);
+  });
+
+  it("follows super:: to a parent module living beside its directory", () => {
+    expect(edge("crates/core/src/store/open.rs", "crates/core/src/store.rs")).toBe(true);
+  });
+
+  it("follows a path into a sibling crate by its Cargo name", () => {
+    // `app_core::Store` is re-exported from the library root; the underscored
+    // import name only reaches the dashed package because the manifest says so.
+    expect(edge("crates/cli/src/main.rs", "crates/core/src/lib.rs")).toBe(true);
+    // The group's other leaf names a module one level down, and lands there.
+    expect(edge("crates/cli/src/main.rs", "crates/core/src/store.rs")).toBe(true);
+  });
+
+  it("follows a mod declaration inside a binary crate", () => {
+    expect(edge("crates/cli/src/main.rs", "crates/cli/src/runner.rs")).toBe(true);
+  });
+
+  it("draws no edge into a crate for a third-party path", () => {
+    expect(graph.edges.every((e) => e.target.endsWith(".rs"))).toBe(true);
+  });
+});

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -1149,6 +1149,125 @@ describe("buildCodeGraph — Rust edges rustc rejects", () => {
     ).toBe(true);
   });
 
+  it("reaches the file a literal include! pastes in", async () => {
+    // `include!` is in the Reference like the `#[path]` this resolver already
+    // reads, so it passes the admission rule in `graph-imports.ts`: the
+    // language guarantees it, and knowing no library is required. Verified on
+    // cargo 1.98.0 — `gen.rs` is in the lib's dep-info, and a `compile_error!`
+    // placed in it fails the build, so rustc genuinely reads it.
+    //
+    // It declares no module: `gen.rs` brings no name into scope, and `use
+    // gen::…` beside it is E0432. What it leaves is an edge, and nothing else.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": 'include!("gen.rs");\n\npub fn go() -> u32 { generated() }\n',
+      "src/gen.rs": "fn generated() -> u32 { 1 }\n",
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/gen.rs")).toBe(true);
+  });
+
+  it("counts an include! from the writing file even inside an inline module", async () => {
+    // The half a `#[path]` does differently, and the reason this is its own
+    // test: a `#[path]` written inside `mod inner { … }` files its target under
+    // `inner/`, an `include!` does not — it pastes text, and the Reference
+    // counts its path from the directory of the file that writes it whatever it
+    // is nested in. Reading it like a `#[path]` would look for `src/inner/gen.rs`
+    // and find nothing.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": 'pub mod inner {\n    include!("gen.rs");\n}\n',
+      "src/gen.rs": "pub fn generated() -> u32 { 1 }\n",
+      // The file the other reading would reach. It exists, so the assertion
+      // below fails rather than passes if the base directory ever changes.
+      "src/inner/gen.rs": "pub fn wrong() -> u32 { 2 }\n",
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/gen.rs")).toBe(true);
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/inner/gen.rs")).toBe(false);
+  });
+
+  it("draws no edge for an include! whose path is built at build time", async () => {
+    // `concat!(env!("OUT_DIR"), …)` names a file that does not exist until
+    // `build.rs` has run, so there is nothing in the tree to point at and
+    // guessing one would be an edge rustc never draws. The admission rule
+    // refuses it for that reason and not for effort.
+    //
+    // The decoy is the point: a file named exactly as the concatenation would
+    // suggest sits in the tree, so a resolver that started stitching the pieces
+    // together would find it and this test would fail.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": 'include!(concat!(env!("OUT_DIR"), "/generated.rs"));\n',
+      "src/generated.rs": "pub fn decoy() -> u32 { 1 }\n",
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/generated.rs")).toBe(
+      false,
+    );
+  });
+
+  it("does not read an include! written inside a doc comment", async () => {
+    // Nine of these sit in a 1,256-crate registry cache: a doc example showing
+    // how to use the macro, with a path that is illustrative and often names no
+    // file at all. It is the same trap a `path` written in a doc string is, and
+    // reading the AST rather than the text is what keeps it out — the text of a
+    // comment is never a `macro_invocation` node.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs":
+        '//! Example:\n//!\n//! ```\n//! include!("illustrative.rs");\n//! ```\n\npub fn go() -> u32 { 1 }\n',
+      // The file exists, so an implementation reading the raw text would find
+      // it and draw the edge: the absence below is about the reading, not about
+      // a missing target.
+      "src/illustrative.rs": "pub fn shown() -> u32 { 2 }\n",
+    });
+
+    expect(graph.nodes.some((n) => n.relativePath === "src/illustrative.rs")).toBe(true);
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/illustrative.rs")).toBe(
+      false,
+    );
+  });
+
+  it("draws no edge for a module a third-party macro generates", async () => {
+    // Not a gap left open by accident: it is the admission rule in
+    // `graph-imports.ts` refusing a case, and this test is what stops the
+    // boundary from moving quietly.
+    //
+    // `automod::dir!("tests/builder")` generates one `mod` per file in that
+    // directory, and the declarations are nowhere in the source. Reading it
+    // means teaching the resolver one third-party macro *and* its expansion
+    // rules — where the path counts from, whether it recurses, which names are
+    // excluded — and once that is in, the criterion is no longer "what the
+    // source says" but "which libraries we happen to know".
+    //
+    // If a future change makes this pass, that is a decision to take on
+    // purpose, in the open, with the rule above rewritten — not a green tick.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+      // The written `mod` is the control: same file, same directory level, one
+      // declaration spelled out and one generated. Without it an assertion of
+      // absence proves nothing — a resolver that drew no edge at all here, for
+      // any reason, would satisfy it just as well.
+      "tests/main.rs": 'mod written;\n\nautomod::dir!("tests/cases");\n',
+      "tests/written.rs": "#[test]\nfn written() {}\n",
+      "tests/cases/alpha.rs": "#[test]\nfn alpha() {}\n",
+      "tests/cases/beta.rs": "#[test]\nfn beta() {}\n",
+    });
+
+    expect(
+      graph.edges.some((e) => e.source === "tests/main.rs" && e.target === "tests/written.rs"),
+    ).toBe(true);
+
+    // The generated ones are nodes — they are Rust source and the walk finds
+    // them — so what is missing below is the edge, not the files.
+    expect(graph.nodes.some((n) => n.relativePath === "tests/cases/alpha.rs")).toBe(true);
+    expect(graph.nodes.some((n) => n.relativePath === "tests/cases/beta.rs")).toBe(true);
+    expect(graph.edges.some((e) => e.source === "tests/main.rs" && e.target.startsWith("tests/cases/"))).toBe(
+      false,
+    );
+  });
+
   it("ignores a [patch] aimed at a git remote rather than at the registry", async () => {
     // `[patch]` is keyed by the source it redirects, and only the entry under
     // `crates-io` touches a dependency written as a version. A section keyed by

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -1149,6 +1149,38 @@ describe("buildCodeGraph — Rust edges rustc rejects", () => {
     ).toBe(true);
   });
 
+  it("ignores a [patch] aimed at a git remote rather than at the registry", async () => {
+    // `[patch]` is keyed by the source it redirects, and only the entry under
+    // `crates-io` touches a dependency written as a version. A section keyed by
+    // a git URL redirects *that* remote, so a `log = "0.4"` taken from the
+    // registry is untouched by it and cargo keeps building the registry crate —
+    // verified on 1.98.0, where the dep-info names neither the local directory
+    // nor anything under it.
+    //
+    // The same manifest with `crates-io` in place of the URL is the gemello
+    // above, which does draw the edge: one token apart, opposite answers.
+    // Nothing proved this half — removing the line that checks the source left
+    // the whole battery green.
+    const graph = await graphOf({
+      "Cargo.toml": [
+        '[workspace]\nmembers = ["crates/app", "crates/log"]\nresolver = "2"\n',
+        '[patch."https://github.com/rust-lang/log"]\nlog = { path = "crates/log" }\n',
+      ].join("\n"),
+      "crates/app/Cargo.toml":
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n\n[dependencies]\nlog = "0.4"\n',
+      "crates/app/src/lib.rs": "use log::marker;\n\npub fn shout() -> marker::Local { marker::Local }",
+      "crates/log/Cargo.toml": '[package]\nname = "log"\nversion = "0.4.34"\nedition = "2021"\n',
+      "crates/log/src/lib.rs": "pub mod marker { pub struct Local; }",
+    });
+
+    // The file the edge would land on has to be in the graph, or a broken graph
+    // satisfies this assertion by drawing nothing at all.
+    expect(graph.nodes.some((n) => n.relativePath === "crates/log/src/lib.rs")).toBe(true);
+    expect(
+      graph.edges.some((e) => e.source === "crates/app/src/lib.rs" && e.target === "crates/log/src/lib.rs"),
+    ).toBe(false);
+  });
+
   it("ignores a [patch] a workspace member declares for itself", async () => {
     // Cargo says so out loud — "patch for the non root package will be ignored,
     // specify patch at the workspace root" — and then fails the build with

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -771,7 +771,647 @@ describe("buildCodeGraph — Rust edition 2015 declaration and use", () => {
     expect(edge("src/deep/mod.rs", "src/deep/foo.rs")).toBe(true);
   });
 
-  it("sends the use to the crate root's module of that name", () => {
-    expect(edge("src/deep/mod.rs", "src/foo.rs")).toBe(true);
+  it("leaves the use to the crate root's module unresolved, a declared limit", () => {
+    // In 2015 this path is absolute from the crate root and does compile, but
+    // nothing in the importing file declares it. Drawing it means resolving
+    // what no declaration proves, which is where every wrong edge in this
+    // resolver has come from; `main` draws nothing here either.
+    expect(edge("src/deep/mod.rs", "src/foo.rs")).toBe(false);
+  });
+});
+
+describe("buildCodeGraph — Rust edges rustc rejects", () => {
+  const roots: string[] = [];
+
+  afterAll(() => {
+    for (const r of roots) {
+      try { fs.rmSync(r, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  async function graphOf(layout: Record<string, string>): Promise<Awaited<ReturnType<typeof buildCodeGraph>>> {
+    ensureDynamicLanguages();
+    const dir = writeLayout(layout);
+    roots.push(dir);
+    return buildCodeGraph(dir);
+  }
+
+  it("draws no edge between two integration tests, which are separate crates", async () => {
+    // `cargo check --tests` on this exact layout is `error[E0432]: unresolved
+    // import 'b'`, with the edition key absent and with `edition = "2021"`
+    // alike: two files in `tests/` are separate crates and cannot import each
+    // other under any edition. The 2015 root-relative reading answers from the
+    // crate root without asking for a declaration, which is right for a module
+    // and wrong for another crate's root.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+      "src/lib.rs": "pub fn nothing() {}",
+      "tests/a.rs": "use b::helper;\n\n#[test]\nfn t() { helper(); }",
+      "tests/b.rs": "pub fn helper() {}",
+    });
+
+    expect(graph.edges.some((e) => e.source === "tests/a.rs" && e.target === "tests/b.rs")).toBe(false);
+  });
+
+  it("reads a declared target path written with a leading ./", async () => {
+    // `cargo metadata` reports the binary at `src/tools/tool.rs`, and `cargo
+    // build` compiles against `src/tools/part.rs` — a `compile_error!` in the
+    // deeper file proves the deeper one is never read. Left unnormalized, the
+    // manifest string matched nothing, the declaration was dropped, and
+    // convention rooted the file one directory too deep.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n\n[[bin]]\nname = "tool"\npath = "./src/tools/tool.rs"\n',
+      "src/tools/tool.rs": "mod part;\n\nfn main() { part::x(); }",
+      "src/tools/part.rs": "pub fn x() {}",
+      "src/tools/tool/part.rs": 'compile_error!("wrong file");',
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/tools/tool.rs" && e.target === "src/tools/part.rs")).toBe(true);
+    expect(graph.edges.some((e) => e.target === "src/tools/tool/part.rs")).toBe(false);
+  });
+
+  it("draws no 2015 edge to a module the crate never declares", async () => {
+    // `use ghost::f;` with `src/ghost.rs` present but declared nowhere is
+    // `error[E0432]: unresolved import 'ghost'` on cargo 1.98.0. The
+    // root-relative reading of edition 2015 needs no declaration in the
+    // importing file, but it still needs one somewhere in the crate; matching a
+    // sibling file by name is a filesystem answer to a question about the
+    // module tree.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+      "src/lib.rs": "pub mod client;",
+      "src/client.rs": "use ghost::f;\n\npub fn u() { f(); }",
+      "src/ghost.rs": "pub fn f() {}",
+    });
+
+    expect(graph.edges.some((e) => e.target === "src/ghost.rs")).toBe(false);
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/client.rs")).toBe(true);
+  });
+
+  it("names the cost of the gate: one real 2015 edge left undrawn", async () => {
+    // `use foo::AtRoot;` in `src/deep/mod.rs` compiles with `mod foo;` written
+    // in `lib.rs` and nothing in the importing file — checked on cargo 1.98.0.
+    // The edge is real and stays undrawn, which is the price of resolving only
+    // what a declaration proves. It is a price and not a regression: `main`
+    // does not draw it either. Should this ever need closing, it takes the
+    // crate's declarations gathered from an AST, and every one of the wrong
+    // edges listed in `graph-resolution.ts` has to stay closed with it.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+      "src/lib.rs": "mod deep;\nmod foo;",
+      "src/foo.rs": "pub struct AtRoot;",
+      "src/deep/mod.rs": "use foo::AtRoot;\n\npub fn take() -> AtRoot { AtRoot }",
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/deep/mod.rs" && e.target === "src/foo.rs")).toBe(false);
+    // The declarations themselves still draw theirs.
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/foo.rs")).toBe(true);
+  });
+
+  it("names the cost of the gate: the root-relative path is lost through #[path] too", async () => {
+    // The same price, one step further from the simple case: in 2015 the head
+    // counts from the crate root whatever put the module there, so a `#[path]`
+    // relocation is as good a declaration as a plain `mod`. `use foo::AtRoot;`
+    // in `src/deep/mod.rs` compiles against `src/custom/thing.rs` — checked on
+    // cargo 1.98.0, where renaming the struct in that file is the one token
+    // that flips the build.
+    //
+    // Written only as the simple case, the test said the gate cost less than
+    // it does: whoever weighs closing it has to see every shape of the loss.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "path2015"\nversion = "0.1.0"\nedition = "2015"\n',
+      "src/lib.rs": '#[path = "custom/thing.rs"]\npub mod foo;\npub mod deep;\n',
+      "src/custom/thing.rs": "pub struct AtRoot;",
+      "src/deep/mod.rs": "use foo::AtRoot;\n\npub fn take() -> AtRoot { AtRoot }",
+    });
+
+    expect(
+      graph.edges.some((e) => e.source === "src/deep/mod.rs" && e.target === "src/custom/thing.rs"),
+    ).toBe(false);
+    // The relocation itself still draws its edge.
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/custom/thing.rs")).toBe(
+      true,
+    );
+  });
+
+  it("names the cost of the gate: it applies under a manifest-declared root", async () => {
+    // The crate root is wherever the manifest says, and in 2015 an unanchored
+    // head counts from there. `use helper::AtRoot;` in `src/tools/deep.rs`
+    // compiles against `src/tools/helper.rs`, declared in the `[[bin]]` root
+    // beside it — checked on cargo 1.98.0. The gate drops this one as well.
+    const graph = await graphOf({
+      "Cargo.toml": [
+        '[package]\nname = "bin2015"\nversion = "0.1.0"\nedition = "2015"\n',
+        '[[bin]]\nname = "tool"\npath = "src/tools/tool.rs"\n',
+      ].join("\n"),
+      "src/tools/tool.rs": "mod helper;\nmod deep;\n\nfn main() { let _ = deep::take(); }",
+      "src/tools/helper.rs": "pub struct AtRoot;",
+      "src/tools/deep.rs": "use helper::AtRoot;\n\npub fn take() -> AtRoot { AtRoot }",
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/tools/deep.rs" && e.target === "src/tools/helper.rs")).toBe(
+      false,
+    );
+    // The declared root still reaches both of its modules.
+    expect(graph.edges.some((e) => e.source === "src/tools/tool.rs" && e.target === "src/tools/helper.rs")).toBe(
+      true,
+    );
+  });
+
+  it("draws no edge for a single-segment 2015 use between integration tests", async () => {
+    // The single-segment spelling of the same rule: `use b;` in `tests/a.rs` is
+    // E0432, "no `b` in the root". Guarding only the multi-segment branch left
+    // this one drawing the edge.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+      "src/lib.rs": "pub fn n() {}",
+      "tests/a.rs": "use b;\n\n#[test]\nfn t() {}",
+      "tests/b.rs": "pub fn helper() {}",
+    });
+
+    expect(graph.edges.some((e) => e.source === "tests/a.rs" && e.target === "tests/b.rs")).toBe(false);
+  });
+
+  it("reads a declared target path that climbs out of the package directory", async () => {
+    // `[lib] path = "../bar/src/lib.rs"` is legal and cargo builds it. Joined
+    // without normalizing it read `crates/foo/../bar/src/lib.rs`, which the file
+    // set never holds, so the declaration was dropped — and with it the crate's
+    // name, its roots, and every edge its dependents draw into it.
+    const graph = await graphOf({
+      "Cargo.toml": '[workspace]\nmembers = ["crates/foo", "crates/bar"]\nresolver = "2"\n',
+      "crates/foo/Cargo.toml": '[package]\nname = "foo"\nversion = "0.1.0"\nedition = "2021"\n\n[lib]\npath = "../bar/src/lib.rs"\n',
+      "crates/foo/src/main.rs": "use foo::bar_fn;\n\nfn main() { bar_fn(); }",
+      "crates/bar/Cargo.toml": '[package]\nname = "bar"\nversion = "0.1.0"\nedition = "2021"\n',
+      "crates/bar/src/lib.rs": "pub fn bar_fn() {}",
+    });
+
+    expect(
+      graph.edges.some((e) => e.source === "crates/foo/src/main.rs" && e.target === "crates/bar/src/lib.rs"),
+    ).toBe(true);
+  });
+
+  it("reads a declared target path written as an absolute path", async () => {
+    // Cargo accepts an absolute `path` and builds it. Joined as if it were
+    // relative it produced `crates/foo//Users/…`, matched nothing, and the
+    // crate lost its name and roots along with every edge into it. The fixture
+    // has to build the absolute path at run time, which is why it is written
+    // through a second call rather than as a literal.
+    const dir = writeLayout({
+      "custom/lib.rs": "pub fn from_lib() {}",
+      "src/main.rs": "use app::from_lib;\n\nfn main() { from_lib(); }",
+    });
+    roots.push(dir);
+    fs.writeFileSync(
+      path.join(dir, "Cargo.toml"),
+      `[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n\n[lib]\npath = "${path.join(dir, "custom/lib.rs")}"\n`,
+    );
+    const graph = await buildCodeGraph(dir);
+
+    expect(graph.edges.some((e) => e.source === "src/main.rs" && e.target === "custom/lib.rs")).toBe(true);
+  });
+
+  it("does not reach a project crate whose name is a registry dependency", async () => {
+    // `log = "0.4"` names the registry crate, and a workspace member also
+    // called `log` is a different crate that is never in scope. Checked on
+    // cargo 1.98.0: the package builds against `log v0.4.34` from the registry
+    // with a `compile_error!` sitting in the local one, which proves rustc
+    // never reads it — while the graph drew an edge straight into it.
+    const graph = await graphOf({
+      "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/log"]\nresolver = "2"\n',
+      "crates/app/Cargo.toml":
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n\n[dependencies]\nlog = "0.4"\n',
+      "crates/app/src/lib.rs": "use log::info;\n\npub fn shout() { info!(\"from the registry\"); }",
+      "crates/log/Cargo.toml": '[package]\nname = "log"\nversion = "0.1.0"\nedition = "2021"\n',
+      "crates/log/src/lib.rs": 'compile_error!("never in scope for app");',
+    });
+
+    expect(graph.edges.some((e) => e.target === "crates/log/src/lib.rs")).toBe(false);
+  });
+
+  it("reaches a project crate a [patch] sends a registry name to", async () => {
+    // The same manifest, one section added, and cargo changes its answer with
+    // the graph: `[patch.crates-io] log = { path = … }` builds `log v0.4.34`
+    // from the member. It is how a workspace makes its members depend on each
+    // other by version — tokio patches all five of its crates that way, and
+    // reading the names as registry ones cost 473 real edges there.
+    const graph = await graphOf({
+      "Cargo.toml": [
+        '[workspace]\nmembers = ["crates/app", "crates/log"]\nresolver = "2"\n',
+        '[patch.crates-io]\nlog = { path = "crates/log" }\n',
+      ].join("\n"),
+      "crates/app/Cargo.toml":
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n\n[dependencies]\nlog = "0.4"\n',
+      "crates/app/src/lib.rs": "use log::marker;\n\npub fn shout() -> marker::Local { marker::Local }",
+      "crates/log/Cargo.toml": '[package]\nname = "log"\nversion = "0.4.34"\nedition = "2021"\n',
+      "crates/log/src/lib.rs": "pub mod marker { pub struct Local; }",
+    });
+
+    expect(
+      graph.edges.some((e) => e.source === "crates/app/src/lib.rs" && e.target === "crates/log/src/lib.rs"),
+    ).toBe(true);
+  });
+
+  it("ignores a [patch] a workspace member declares for itself", async () => {
+    // Cargo says so out loud — "patch for the non root package will be ignored,
+    // specify patch at the workspace root" — and then fails the build with
+    // `error[E0432]: unresolved import 'log::marker'`, which is the proof that
+    // it compiled against the registry crate. Honouring the member's patch drew
+    // an edge into a crate the build never touches.
+    const graph = await graphOf({
+      "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/log"]\nresolver = "2"\n',
+      "crates/app/Cargo.toml": [
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+        '[dependencies]\nlog = "0.4"\n',
+        '[patch.crates-io]\nlog = { path = "../log" }\n',
+      ].join("\n"),
+      "crates/app/src/lib.rs": "use log::marker;\n\npub fn go() -> marker::Local { marker::Local }",
+      "crates/log/Cargo.toml": '[package]\nname = "log"\nversion = "0.4.34"\nedition = "2021"\n',
+      "crates/log/src/lib.rs": "pub mod marker { pub struct Local; }",
+    });
+
+    expect(graph.edges.some((e) => e.target === "crates/log/src/lib.rs")).toBe(false);
+  });
+
+  it("matches a [patch] by package name, not by the alias it is imported as", async () => {
+    // `alias = { package = "itoa" }` is patched under `itoa` and written as
+    // `alias`. Matching the two directly left the alias among the external
+    // names and dropped the edge, though cargo 1.98.0 builds
+    // `itoa v1.0.18 (crates/itoa)` from the member.
+    const graph = await graphOf({
+      "Cargo.toml": [
+        '[workspace]\nmembers = ["crates/app", "crates/itoa"]\nresolver = "2"\n',
+        '[patch.crates-io]\nitoa = { path = "crates/itoa" }\n',
+      ].join("\n"),
+      "crates/app/Cargo.toml": [
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+        '[dependencies]\nalias = { package = "itoa", version = "1.0" }\n',
+      ].join("\n"),
+      "crates/app/src/lib.rs": "use alias::marker;\n\npub fn go() -> marker::Local { marker::Local }",
+      "crates/itoa/Cargo.toml": '[package]\nname = "itoa"\nversion = "1.0.18"\nedition = "2021"\n',
+      "crates/itoa/src/lib.rs": "pub mod marker { pub struct Local; }",
+    });
+
+    expect(
+      graph.edges.some((e) => e.source === "crates/app/src/lib.rs" && e.target === "crates/itoa/src/lib.rs"),
+    ).toBe(true);
+  });
+
+  it("does not let a crates-io patch capture a git dependency", async () => {
+    // `[patch.crates-io]` patches that registry and nothing else. Cargo 1.98.0
+    // keeps fetching the git checkout — its dep-info names the clone under
+    // `CARGO_HOME/git` — and the local crate, carrying a `compile_error!`, is
+    // never read, which is what lets the build finish.
+    const graph = await graphOf({
+      "Cargo.toml": [
+        '[workspace]\nmembers = ["crates/app", "crates/itoa"]\nresolver = "2"\n',
+        '[patch.crates-io]\nitoa = { path = "crates/itoa" }\n',
+      ].join("\n"),
+      "crates/app/Cargo.toml": [
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+        '[dependencies]\nitoa = { git = "https://example.invalid/itoa" }\n',
+      ].join("\n"),
+      "crates/app/src/lib.rs": "use itoa::marker;\n\npub fn go() -> marker::Remote { marker::Remote }",
+      "crates/itoa/Cargo.toml": '[package]\nname = "itoa"\nversion = "1.0.18"\nedition = "2021"\n',
+      "crates/itoa/src/lib.rs": 'compile_error!("a crates-io patch does not touch a git dependency");',
+    });
+
+    expect(graph.edges.some((e) => e.target === "crates/itoa/src/lib.rs")).toBe(false);
+  });
+
+  it("reaches a project crate declared by path under the same name", async () => {
+    // The other half of the rule: a `path` dependency is the project's own
+    // crate whatever else carries that name on a registry.
+    const graph = await graphOf({
+      "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/log"]\nresolver = "2"\n',
+      "crates/app/Cargo.toml": [
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+        '[dependencies]\nlog = { path = "../log" }\n',
+      ].join("\n"),
+      "crates/app/src/lib.rs": "use log::marker;\n\npub fn shout() -> marker::Local { marker::Local }",
+      "crates/log/Cargo.toml": '[package]\nname = "log"\nversion = "0.1.0"\nedition = "2021"\n',
+      "crates/log/src/lib.rs": "pub mod marker { pub struct Local; }",
+    });
+
+    expect(
+      graph.edges.some((e) => e.source === "crates/app/src/lib.rs" && e.target === "crates/log/src/lib.rs"),
+    ).toBe(true);
+  });
+
+  it("draws the edge of a module declared inside a macro body", async () => {
+    // Checked on cargo 1.98.0: the package builds and its dep-info lists
+    // `src/hidden.rs`, which nothing but the macro body declares. Left
+    // unparsed, that file had no incoming edge at all — the shape behind 77 of
+    // tokio's false orphans, where `cfg_io_util! { mod … }` hides 36
+    // declarations in one block.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "macromod"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": [
+        "macro_rules! cfg_thing {",
+        "    ($($item:item)*) => { $($item)* };",
+        "}",
+        "",
+        "cfg_thing! {",
+        "    mod hidden;",
+        "    pub use hidden::Thing;",
+        "}",
+        "",
+        "pub fn make() -> Thing { Thing }",
+      ].join("\n"),
+      "src/hidden.rs": "pub struct Thing;",
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/hidden.rs")).toBe(true);
+  });
+
+  it("keeps a macro body inside the module block that encloses it", async () => {
+    // The body is unwrapped where it stands, so the enclosing `mod inner { … }`
+    // still counts and the macro adds no level: the file is `src/inner/deep.rs`.
+    // Reading the body as a scope of its own would have looked one directory
+    // too far down.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "macroscope"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": [
+        "macro_rules! cfg_thing {",
+        "    ($($item:item)*) => { $($item)* };",
+        "}",
+        "",
+        "pub mod inner {",
+        "    cfg_thing! {",
+        "        pub mod deep;",
+        "    }",
+        "}",
+      ].join("\n"),
+      "src/inner/deep.rs": "pub struct Deep;",
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/inner/deep.rs")).toBe(
+      true,
+    );
+  });
+
+  it("draws every file a conditional path attribute can select", async () => {
+    // Checked on cargo 1.98.0: the package builds on unix and its dep-info
+    // lists `src/lib.rs` and `src/unix.rs`. Read as if the attribute were not
+    // there, the graph got both halves wrong at once — an edge to the file the
+    // name alone implies, and none to the one holding the module's whole body.
+    //
+    // The convention is drawn too, and that is not a leftover: a `cfg_attr`
+    // applies only where its condition holds, and where none does the module is
+    // the file its name implies. `errno` writes exactly this shape, and its
+    // `src/sys.rs` says so in its own first line — "a default sys.rs for
+    // unrecognized targets… if lib.rs doesn't recognize the target, it defaults
+    // to using this file".
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "cfgattr"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": [
+        '#[cfg_attr(unix, path = "unix.rs")]',
+        '#[cfg_attr(windows, path = "windows.rs")]',
+        "mod sys;",
+        "",
+        "pub fn errno() -> i32 { sys::errno() }",
+      ].join("\n"),
+      "src/unix.rs": "pub fn errno() -> i32 { 0 }",
+      "src/windows.rs": "pub fn errno() -> i32 { 1 }",
+      "src/sys.rs": 'compile_error!("unsupported target");',
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/unix.rs")).toBe(true);
+    // All three, because the graph fixes no target: the module is one file
+    // here, another there, and the fallback where neither condition holds.
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/windows.rs")).toBe(true);
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/sys.rs")).toBe(true);
+  });
+
+  it("keeps the convention when a conditional path names a file instead", async () => {
+    // With the condition false the attribute is not applied at all:
+    // `#[cfg_attr(any(), path = "ghost.rs")] mod platform;` compiles against
+    // `src/platform.rs` on cargo 1.98.0, whose dep-info names it and not
+    // `ghost.rs`. Reading only the named path lost that edge outright.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "cfgfalse"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": [
+        '#[cfg_attr(any(), path = "ghost.rs")]',
+        "mod platform;",
+        "",
+        "pub fn go() -> platform::Marker { platform::Marker }",
+      ].join("\n"),
+      "src/platform.rs": "pub struct Marker;",
+      "src/ghost.rs": "pub struct Marker;",
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/platform.rs")).toBe(true);
+  });
+
+  it("keeps the convention for an unconditional path attribute out of it", async () => {
+    // The other side: a bare `#[path]` always applies, so the file its name
+    // implies is never read and must draw nothing — even when it exists.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "barepath"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": '#[path = "moved.rs"]\nmod platform;\n\npub fn go() -> platform::Marker { platform::Marker }',
+      "src/moved.rs": "pub struct Marker;",
+      "src/platform.rs": 'compile_error!("never read: the attribute always applies");',
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/moved.rs")).toBe(true);
+    expect(graph.edges.some((e) => e.target === "src/platform.rs")).toBe(false);
+  });
+
+  it("does not read a path named inside a doc string as a relocation", async () => {
+    // `#[cfg_attr(docsrs, doc = r#"… path = "custom.rs" …"#)] mod plain;`
+    // compiles by convention against `src/plain.rs` on cargo 1.98.0, and its
+    // dep-info never names `custom.rs`. Scanning the attribute's raw text read
+    // the doc's own words as a relocation.
+    //
+    // `src/custom.rs` is in the fixture so the assertion can fail: without a
+    // file there the invented path resolves to nothing and the mistake leaves
+    // no trace in the edges.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "docpath"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": [
+        '#[cfg_attr(docsrs, doc = r#"override with path = "custom.rs" if needed"#)]',
+        "mod plain;",
+        "",
+        "pub fn go() { plain::hi(); }",
+      ].join("\n"),
+      "src/plain.rs": "pub fn hi() {}",
+      "src/custom.rs": 'compile_error!("named only inside a doc string");',
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/plain.rs")).toBe(true);
+    expect(graph.edges.some((e) => e.target === "src/custom.rs")).toBe(false);
+  });
+
+  it("falls back to convention for an empty declared target path", async () => {
+    // `path = ""` names no file, and cargo refuses the manifest outright:
+    // "path `…/` for lib `emptylib` is a directory, but a source file was
+    // expected", the same for a `[[bin]]`. There is no build to mirror, so
+    // there is no right answer to read off the oracle — only a choice between
+    // two wrong ones.
+    //
+    // Convention is the cheaper wrong: dropping the target instead would take
+    // the crate's name and roots with it, and every edge its dependents draw
+    // into it — the regression a `[lib] path = "../…"` already caused once.
+    // The declaration is treated as absent, which is what an empty string
+    // effectively says, and the tree still reads.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "emptylib"\nversion = "0.1.0"\nedition = "2021"\n\n[lib]\npath = ""\n',
+      "src/lib.rs": "pub mod part;",
+      "src/part.rs": "pub fn run() {}",
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/part.rs")).toBe(true);
+  });
+
+  it("keeps the inline guard on for a glob over a submodule", async () => {
+    // `use crate::prelude::*;` brings in what that module re-exports, not the
+    // file's own modules: rustc rejects the `use corelib::marker;` beside it
+    // with E0432. Only the anchor itself — `use super::*;` — is the file's
+    // scope, so only that one may switch the guard off.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": [
+        "pub mod corelib;",
+        "pub mod prelude { pub struct Unrelated; }",
+        "",
+        "pub mod block {",
+        "    use crate::prelude::*;",
+        "    use corelib::marker;",
+        "    pub fn f() -> marker::Marker { marker::Marker }",
+        "}",
+      ].join("\n"),
+      "src/corelib.rs": "pub mod marker { pub struct Marker; }",
+    });
+
+    const toCorelib = graph.edges.filter(
+      (e) => e.source === "src/lib.rs" && e.target === "src/corelib.rs",
+    );
+    // Only the one the declaration draws.
+    expect(toCorelib).toHaveLength(1);
+  });
+
+  it("does not treat a nested block's declaration as the enclosing block's", async () => {
+    // `findAll` walks the whole subtree, so `mod corelib` inside `nested`
+    // counted as declared by `outer`, and a bare `use corelib::marker;` in
+    // `outer` was rebased into the block. rustc 1.98.0 rejects that line with
+    // E0432: a name declared in a nested block is in that block's scope only.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": [
+        "pub mod outer {",
+        "    mod nested { pub mod corelib { pub mod marker { pub struct Marker; } } }",
+        "    use corelib::marker;",
+        "    pub fn f() -> marker::Marker { marker::Marker }",
+        "}",
+      ].join("\n"),
+      "src/outer/corelib.rs": 'compile_error!("orphan");',
+    });
+
+    expect(graph.edges.some((e) => e.target === "src/outer/corelib.rs")).toBe(false);
+  });
+
+  it("keeps a block's edge when a glob use puts the name in its scope", async () => {
+    // `use super::*;` brings in every module the file declares, and then the
+    // bare head does reach one — rustc 1.98.0 resolves it, and rejects the same
+    // line with the glob removed. The block's scope is not knowable from the
+    // block alone, so nothing is asserted about it.
+    //
+    // The path reaches a *submodule in its own file*, so the edge it asks for
+    // is one the declaration cannot draw. Written against `src/corelib.rs`
+    // instead, the assertion was answered by `pub mod corelib;` and held
+    // whatever the block did.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": [
+        "pub mod corelib;",
+        "",
+        "pub mod block {",
+        "    use super::*;",
+        "    use corelib::sub::Marker;",
+        "    pub fn f() -> Marker { Marker }",
+        "}",
+      ].join("\n"),
+      "src/corelib/mod.rs": "pub mod sub;",
+      "src/corelib/sub.rs": "pub struct Marker;",
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/corelib/sub.rs")).toBe(true);
+  });
+
+  it("reads the anchor glob through a braced group", async () => {
+    // `use {super::*};` is the anchor written as a group with no prefix, and
+    // `use super::{*};` the same import the other way round. Both compile where
+    // the bare head beside them is E0432 without them — checked on cargo
+    // 1.98.0. Matching only the flat spelling read neither as an anchor, left
+    // the scope guard on, and dropped a real edge.
+    for (const anchor of ["use {super::*};", "use super::{*};", "use {super::{*}};"]) {
+      const graph = await graphOf({
+        "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+        "src/lib.rs": [
+          "pub mod corelib;",
+          "",
+          "pub mod block {",
+          `    ${anchor}`,
+          "    use corelib::sub::Marker;",
+          "    pub fn f() -> Marker { Marker }",
+          "}",
+        ].join("\n"),
+        "src/corelib/mod.rs": "pub mod sub;",
+        "src/corelib/sub.rs": "pub struct Marker;",
+      });
+
+      expect(
+        graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/corelib/sub.rs"),
+        `anchor spelled ${anchor}`,
+      ).toBe(true);
+    }
+  });
+
+  it("keeps the inline guard on for a braced glob over a dependency", async () => {
+    // The mirror of the case above, and the reason the group is walked rather
+    // than matched on its trailing `*`: `use {std::collections::*};` is a group
+    // with no prefix carrying a glob that brings in nothing of this crate.
+    // rustc 1.98.0 answers the bare head beside it with E0433, "cannot find
+    // module or crate `corelib` in this scope".
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": [
+        "pub mod corelib;",
+        "",
+        "pub mod block {",
+        "    use {std::collections::*};",
+        "    use corelib::sub::Marker;",
+        "    pub fn f() -> Marker { Marker }",
+        "}",
+      ].join("\n"),
+      "src/corelib/mod.rs": "pub mod sub;",
+      "src/corelib/sub.rs": "pub struct Marker;",
+    });
+
+    expect(graph.edges.some((e) => e.source === "src/lib.rs" && e.target === "src/corelib/sub.rs")).toBe(false);
+  });
+
+  it("does not let a path inside an inline block reach a module the file declares", async () => {
+    // rustc rejects this with `error[E0432]: unresolved import 'corelib'`,
+    // "help: a similar path exists: super::corelib::marker" — a declaration at
+    // file level is not in the block's scope. The mirror of the case already
+    // handled the other way round. The declaration's own edge stays.
+    const graph = await graphOf({
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+      "src/lib.rs": [
+        "pub mod corelib;",
+        "",
+        "pub mod block {",
+        "    use corelib::marker;",
+        "    pub fn take() -> marker::Marker { marker::Marker }",
+        "}",
+      ].join("\n"),
+      "src/corelib.rs": "pub mod marker { pub struct Marker; }",
+    });
+
+    const toCorelib = graph.edges.filter(
+      (e) => e.source === "src/lib.rs" && e.target === "src/corelib.rs",
+    );
+    // One edge, from `pub mod corelib;`. The `use` inside the block adds none.
+    expect(toCorelib).toHaveLength(1);
   });
 });

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -502,21 +502,39 @@ describe("buildCodeGraph — Rust crate resolution", () => {
     const dir = writeLayout({
       "Cargo.toml": '[workspace]\nmembers = ["crates/cli", "crates/core"]\n',
 
-      "crates/core/Cargo.toml": '[package]\nname = "app-core"\n',
+      "crates/core/Cargo.toml": '[package]\nname = "app-core"\nedition = "2021"\n',
       "crates/core/src/lib.rs": ["pub mod store;", "", "pub use store::Store;"].join("\n"),
       "crates/core/src/store.rs": [
         "mod open;",
+        "mod support;",
         "",
         "pub struct Store;",
         "pub struct StoreError;",
       ].join("\n"),
       "crates/core/src/store/open.rs": [
         "use super::Store;",
+        "mod detail;",
         "",
         "pub fn open() -> Store { Store }",
       ].join("\n"),
+      "crates/core/src/store/support.rs": "pub fn helper() {}",
+      // A test block two levels down: `super` inside it counts from the file,
+      // so reaching `store::support` from here takes one climb more than the
+      // file's own depth suggests.
+      "crates/core/src/store/open/detail.rs": [
+        "pub fn detail() {}",
+        "",
+        "#[cfg(test)]",
+        "mod tests {",
+        "    use super::*;",
+        "    use super::super::super::support::helper;",
+        "",
+        "    #[test]",
+        "    fn works() { detail(); helper(); }",
+        "}",
+      ].join("\n"),
 
-      "crates/cli/Cargo.toml": '[package]\nname = "app-cli"\n',
+      "crates/cli/Cargo.toml": '[package]\nname = "app-cli"\nedition = "2021"\n',
       "crates/cli/src/main.rs": [
         "mod runner;",
         "",
@@ -524,7 +542,7 @@ describe("buildCodeGraph — Rust crate resolution", () => {
         "",
         "fn main() { runner::run(); }",
       ].join("\n"),
-      "crates/cli/src/runner.rs": "pub fn run() {}",
+      "crates/cli/src/runner.rs": ["use serde::Deserialize;", "", "pub fn run() {}"].join("\n"),
     });
     roots.push(dir);
     graph = await buildCodeGraph(dir);
@@ -560,6 +578,29 @@ describe("buildCodeGraph — Rust crate resolution", () => {
   });
 
   it("draws no edge into a crate for a third-party path", () => {
-    expect(graph.edges.every((e) => e.target.endsWith(".rs"))).toBe(true);
+    // `runner.rs` imports `serde` and nothing else. Asserting that every edge
+    // ends in a `.rs` file would hold on an empty set too — and did, while the
+    // resolver was returning nothing at all; the edges leaving this one file
+    // are what says a third-party path resolved to nothing.
+    const leaving = graph.edges
+      .filter((e) => e.source === "crates/cli/src/runner.rs")
+      .map((e) => e.target);
+
+    expect(leaving).toEqual([]);
+  });
+
+  it("draws no edge at the parent module for a test block's glob import", () => {
+    // `use super::*;` inside `#[cfg(test)] mod tests` names the file it is
+    // written in. Counted from the file instead, it lands on the parent
+    // module and closes a cycle with the `mod detail;` pointing the other way.
+    expect(edge("crates/core/src/store/open/detail.rs", "crates/core/src/store/open.rs")).toBe(
+      false,
+    );
+  });
+
+  it("counts the inline test module as a level a super:: path climbs", () => {
+    expect(
+      edge("crates/core/src/store/open/detail.rs", "crates/core/src/store/support.rs"),
+    ).toBe(true);
   });
 });

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -563,6 +563,23 @@ describe("buildCodeGraph — Rust crate resolution", () => {
       // path: `use serde::Deserialize;` reaches the crate, and the graph must
       // draw nothing at all.
       "crates/cli/src/serde.rs": "pub struct Deserialize;",
+      // The same name declared one level in, inside an inline block. That
+      // declaration puts `serde` in scope inside `inner` and nowhere else, so
+      // the `use` written at the file's own level still reaches the
+      // dependency — cargo 1.70.0 and 1.98.0 both compile that shape against
+      // the dependency, and fail with E0432 when it is removed. Reading the
+      // declaration as the file's own handed `crates/cli/src/serde.rs` the
+      // capture back.
+      "crates/cli/src/shadow.rs": [
+        "use serde::Deserialize;",
+        "",
+        "mod inner {",
+        "    mod serde;",
+        "}",
+        "",
+        "pub fn shadowed() {}",
+      ].join("\n"),
+      "crates/cli/src/shadow/inner/serde.rs": "pub struct Local;",
     });
     roots.push(dir);
     graph = await buildCodeGraph(dir);
@@ -614,12 +631,32 @@ describe("buildCodeGraph — Rust crate resolution", () => {
     expect(edge("crates/cli/src/runner.rs", "crates/cli/src/serde.rs")).toBe(false);
   });
 
+  it("does not let a module declared inside an inline block claim the file's own scope", () => {
+    // `mod inner { mod serde; }` declares `serde` inside `inner`. The `use`
+    // written at the file's level is outside that block, so it reaches the
+    // dependency and must draw no edge — least of all to the same-named file
+    // sitting beside the importer.
+    expect(edge("crates/cli/src/shadow.rs", "crates/cli/src/serde.rs")).toBe(false);
+    // The declaration itself is still an edge: it names a real file one level
+    // in, which is what keeps this test from passing on "no edges at all".
+    expect(edge("crates/cli/src/shadow.rs", "crates/cli/src/shadow/inner/serde.rs")).toBe(
+      true,
+    );
+  });
+
   it("follows a module declared with a dependency's name", () => {
-    // The hand that keeps the test above honest: here `serde` is declared with
-    // `pub mod serde;`, so rustc reads `pub use serde::Local;` as the local
-    // module and the edge belongs in the graph. A resolver that answers "no
-    // edge" whenever a path's head matches a dependency passes the test above
-    // and fails this one.
+    // Here `serde` is declared with `pub mod serde;`, so the file that carries
+    // a dependency's name is still in the module tree and its edge belongs in
+    // the graph.
+    //
+    // This asserts the declaration, not the `pub use serde::Local;` beside it:
+    // both land on the same file, and the graph's edges are a set, so nothing
+    // here can tell which of the two drew it. The hand that keeps the
+    // third-party test honest — an unanchored path resolving when the module
+    // is declared and not resolving when it is not — is asserted where it can
+    // fail, on `resolveRustImport` itself, in
+    // "lets an unanchored path reach a module the file declares, and only
+    // then".
     expect(edge("crates/core/src/lib.rs", "crates/core/src/serde.rs")).toBe(true);
   });
 

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -1013,6 +1013,10 @@ describe("buildCodeGraph — Rust edges rustc rejects", () => {
       "crates/log/src/lib.rs": 'compile_error!("never in scope for app");',
     });
 
+    // The absence is the assertion, so the file that would draw the edge has to
+    // be in the graph for the absence to mean anything: a walk that never
+    // reached it would satisfy the line below just as well.
+    expect(graph.nodes.some((n) => n.relativePath === "crates/app/src/lib.rs")).toBe(true);
     expect(graph.edges.some((e) => e.target === "crates/log/src/lib.rs")).toBe(false);
   });
 
@@ -1066,7 +1070,39 @@ describe("buildCodeGraph — Rust edges rustc rejects", () => {
       "crates/log/src/lib.rs": 'compile_error!("never in scope for app");',
     });
 
+    expect(graph.nodes.some((n) => n.relativePath === "crates/app/src/lib.rs")).toBe(true);
     expect(graph.edges.some((e) => e.target === "crates/log/src/lib.rs")).toBe(false);
+  });
+
+  it("inherits a dash-named dependency under the name the source writes", async () => {
+    // Cargo turns dashes into underscores for the importable name, so the
+    // manifest says `my-log` and the source says `my_log`. Both sides of the
+    // inheritance normalise, and nothing proved they normalise the same way:
+    // looking the workspace's answer up under the raw manifest key instead of
+    // the normalised one silently drops the edge, and every other test here
+    // uses a name with no dash, where the two spellings coincide.
+    //
+    // Checked on cargo 1.98.0: `cargo check -p app` compiles the member
+    // `my-log v0.1.0` and then `app`, which imports it as `my_log`.
+    const graph = await graphOf({
+      "Cargo.toml": [
+        '[workspace]\nmembers = ["crates/app", "crates/my-log"]\nresolver = "2"\n',
+        '[workspace.dependencies]\nmy-log = { path = "crates/my-log" }\n',
+      ].join("\n"),
+      "crates/app/Cargo.toml": [
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+        "[dependencies]\nmy-log = { workspace = true }\n",
+      ].join("\n"),
+      "crates/app/src/lib.rs": "use my_log::marker;\n\npub fn go() -> marker::Local { marker::Local }",
+      "crates/my-log/Cargo.toml": '[package]\nname = "my-log"\nversion = "0.1.0"\nedition = "2021"\n',
+      "crates/my-log/src/lib.rs": "pub mod marker { pub struct Local; }",
+    });
+
+    expect(
+      graph.edges.some(
+        (e) => e.source === "crates/app/src/lib.rs" && e.target === "crates/my-log/src/lib.rs",
+      ),
+    ).toBe(true);
   });
 
   it("reaches a project crate a [patch] sends a registry name to", async () => {

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -547,8 +547,10 @@ describe("buildCodeGraph — Rust crate resolution", () => {
         "}",
       ].join("\n"),
 
+      // `app-core` declared, as rustc requires for the sibling to be in
+      // scope at all: a package reaches only the crates its manifest names.
       "crates/cli/Cargo.toml":
-        '[package]\nname = "app-cli"\nedition = "2021"\n\n[dependencies]\nserde = "1"\n',
+        '[package]\nname = "app-cli"\nedition = "2021"\n\n[dependencies]\nserde = "1"\napp-core = { path = "../core" }\n',
       "crates/cli/src/main.rs": [
         "mod runner;",
         "",

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -1149,6 +1149,40 @@ describe("buildCodeGraph — Rust edges rustc rejects", () => {
     ).toBe(true);
   });
 
+  it("does not fall through to a crate when the declared module's file is missing", async () => {
+    // The gate that stops a declaration from becoming an edge into a library of
+    // the same name. `mod log;` says `log` is this file's module, whatever the
+    // manifest carries — so if its file cannot be found, the answer is nothing,
+    // not the crate. rustc agrees loudly: a `#[path]` at a file that does not
+    // exist is E0583, and the build never reaches the dependency.
+    //
+    // Nothing held this: removing the gate left the battery green, and the edge
+    // it draws is the exact shape #118 exists to close — a plausible file in
+    // the project captured by a name that belongs to a dependency.
+    const graph = await graphOf({
+      "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/log"]\nresolver = "2"\n',
+      "crates/app/Cargo.toml":
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n\n[dependencies]\nlog = { path = "../log" }\n',
+      // The declaration names a file that is not there, so the module has no
+      // file at all — and `use log::marker;` below must reach neither.
+      // A single-segment `use`, because that is the shape the gate answers: a
+      // longer path is resolved by walking the module tree and never reaches
+      // the crate fallback at all.
+      "crates/app/src/lib.rs": '#[path = "nowhere.rs"]\nmod log;\n\nuse log;\n\npub fn go() -> u32 { 1 }',
+      "crates/log/Cargo.toml": '[package]\nname = "log"\nversion = "0.1.0"\nedition = "2021"\n',
+      "crates/log/src/lib.rs": "pub mod marker { pub struct Local; }",
+    });
+
+    // The crate's file is in the graph, so the absence is about the gate and
+    // not about a target that was never there.
+    expect(graph.nodes.some((n) => n.relativePath === "crates/log/src/lib.rs")).toBe(true);
+    expect(
+      graph.edges.some(
+        (e) => e.source === "crates/app/src/lib.rs" && e.target === "crates/log/src/lib.rs",
+      ),
+    ).toBe(false);
+  });
+
   it("reaches the file a literal include! pastes in", async () => {
     // `include!` is in the Reference like the `#[path]` this resolver already
     // reads, so it passes the admission rule in `graph-imports.ts`: the

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -726,3 +726,52 @@ describe("buildCodeGraph — Rust crate resolution", () => {
     ).toBe(true);
   });
 });
+
+// ── Edition 2015: a declaration and a use of the same name are different ──
+// They arrive at the resolver as the same string, `foo`, and count from
+// different places: the declaration from the declaring file's own directory,
+// the use from the crate root. Measured on cargo 1.70.0 and 1.98.0 —
+// `use foo::Nested;` beside `mod foo;` in `src/deep/mod.rs` is E0432, while
+// `use foo::AtRoot;` compiles. Only a fixture driven through buildCodeGraph
+// can show that the two are told apart, since that is where the difference is
+// read off the source.
+describe("buildCodeGraph — Rust edition 2015 declaration and use", () => {
+  const roots: string[] = [];
+  let graph: Awaited<ReturnType<typeof buildCodeGraph>>;
+
+  beforeAll(async () => {
+    ensureDynamicLanguages();
+    const dir = writeLayout({
+      // No edition key: Cargo reads 2015.
+      "Cargo.toml": '[package]\nname = "app"\nversion = "0.1.0"\n',
+      "src/lib.rs": ["mod deep;", "mod foo;"].join("\n"),
+      "src/foo.rs": "pub struct AtRoot;",
+      "src/deep/mod.rs": [
+        "mod foo;",
+        "use foo::AtRoot;",
+        "",
+        "pub fn take() -> AtRoot { AtRoot }",
+      ].join("\n"),
+      "src/deep/foo.rs": "pub struct Nested;",
+    });
+    roots.push(dir);
+    graph = await buildCodeGraph(dir);
+  });
+
+  afterAll(() => {
+    for (const r of roots) {
+      try { fs.rmSync(r, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  const edge = (source: string, target: string): boolean =>
+    graph.edges.some((e) => e.source === source && e.target === target);
+
+  it("files the declaration beside the declaring file", () => {
+    expect(edge("src/deep/mod.rs", "src/deep/foo.rs")).toBe(true);
+  });
+
+  it("sends the use to the crate root's module of that name", () => {
+    expect(edge("src/deep/mod.rs", "src/foo.rs")).toBe(true);
+  });
+});

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -1042,6 +1042,33 @@ describe("buildCodeGraph — Rust edges rustc rejects", () => {
     ).toBe(true);
   });
 
+  it("inherits nothing where the member declares the dependency itself", async () => {
+    // A member that writes its own entry inherits nothing, even where the
+    // workspace happens to declare the same name with a `path`. Checked on
+    // cargo 1.98.0 with a `compile_error!` in the member: `cargo check -p app`
+    // builds `log v0.4.34` from the registry and stays clean.
+    //
+    // Without the `workspace === true` guard on the inherited answer, the
+    // workspace's entry would decide for a member that never asked — and the
+    // whole point of reading the manifest is that a dependency with no `path`
+    // is a different crate, whatever the project holds under that name.
+    const graph = await graphOf({
+      "Cargo.toml": [
+        '[workspace]\nmembers = ["crates/app", "crates/log"]\nresolver = "2"\n',
+        '[workspace.dependencies]\nlog = { path = "crates/log" }\n',
+      ].join("\n"),
+      "crates/app/Cargo.toml": [
+        '[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n',
+        '[dependencies]\nlog = { version = "0.4" }\n',
+      ].join("\n"),
+      "crates/app/src/lib.rs": 'use log::info;\n\npub fn shout() { info!("from the registry"); }',
+      "crates/log/Cargo.toml": '[package]\nname = "log"\nversion = "0.1.0"\nedition = "2021"\n',
+      "crates/log/src/lib.rs": 'compile_error!("never in scope for app");',
+    });
+
+    expect(graph.edges.some((e) => e.target === "crates/log/src/lib.rs")).toBe(false);
+  });
+
   it("reaches a project crate a [patch] sends a registry name to", async () => {
     // The same manifest, one section added, and cargo changes its answer with
     // the graph: `[patch.crates-io] log = { path = … }` builds `log v0.4.34`

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -965,7 +965,11 @@ describe("buildCodeGraph — Rust edges rustc rejects", () => {
     roots.push(dir);
     fs.writeFileSync(
       path.join(dir, "Cargo.toml"),
-      `[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n\n[lib]\npath = "${path.join(dir, "custom/lib.rs")}"\n`,
+      // Forward slashes even on Windows: a backslash in a TOML basic string
+      // opens an escape, and `\U` or `\c` out of a drive path is one smol-toml
+      // rejects — the manifest would be dropped and the edge with it, which is
+      // the very thing this asserts (review finding).
+      `[package]\nname = "app"\nversion = "0.1.0"\nedition = "2021"\n\n[lib]\npath = "${path.join(dir, "custom/lib.rs").split(path.sep).join("/")}"\n`,
     );
     const graph = await buildCodeGraph(dir);
 

--- a/tests/unit/graph-discovery.test.ts
+++ b/tests/unit/graph-discovery.test.ts
@@ -595,6 +595,20 @@ describe("buildCodeGraph — Rust crate resolution", () => {
       ].join("\n"),
       "crates/cli/src/holder_user/holder.rs": "pub mod child;",
       "crates/cli/src/holder_user/holder/child.rs": "pub struct Thing;",
+      // The attribute moves the file and keeps the name: `moved` is what the
+      // paths below say, `renamed.rs` is where it lives, and its own child
+      // sits beside that file — `src/deeper.rs`, which is where rustc looks.
+      "crates/cli/src/mover.rs": [
+        '#[path = "renamed.rs"]',
+        "mod moved;",
+        "",
+        "use moved::Item;",
+        "use moved::deeper::Deep;",
+        "",
+        "pub fn take(a: Item, b: Deep) -> (Item, Deep) { (a, b) }",
+      ].join("\n"),
+      "crates/cli/src/renamed.rs": "pub mod deeper;\n\npub struct Item;",
+      "crates/cli/src/deeper.rs": "pub struct Deep;",
     });
     roots.push(dir);
     graph = await buildCodeGraph(dir);
@@ -670,6 +684,15 @@ describe("buildCodeGraph — Rust crate resolution", () => {
     expect(
       edge("crates/cli/src/holder_user.rs", "crates/cli/src/holder_user/holder/child.rs"),
     ).toBe(true);
+  });
+
+  it("follows a path through a module the attribute moved", () => {
+    // The declaration's own edge, and then the two the paths draw: one to the
+    // moved file, one to the child sitting beside it. Before the declaration
+    // carried its file, the paths found no `src/moved.rs` and drew nothing —
+    // or, in a workspace holding a library of that name, drew into it.
+    expect(edge("crates/cli/src/mover.rs", "crates/cli/src/renamed.rs")).toBe(true);
+    expect(edge("crates/cli/src/mover.rs", "crates/cli/src/deeper.rs")).toBe(true);
   });
 
   it("follows a module declared with a dependency's name", () => {

--- a/tests/unit/graph-imports.test.ts
+++ b/tests/unit/graph-imports.test.ts
@@ -765,6 +765,179 @@ impl Thing {
       expect(specs).toContain("crate::in_impl::Marker");
     });
 
+    it("still reads a body the parser recovers from without leaving it", () => {
+      // The complement of the test below, and the reason the guard is drawn
+      // around where recovery reaches rather than around the ERROR node.
+      // `cfg_if!` at file level leaves an ERROR on the attribute and moves
+      // nothing: the declarations in the arms are read where they were written,
+      // which is where rustc reads them too.
+      //
+      // Refusing every body that does not parse as items on its own would cost
+      // this case: 449 macro bodies carrying declarations across a 1,256-crate
+      // registry cache do not, and 431 of them stand at file level. `js-sys`,
+      // `backtrace`, `ahash` and `aes` each lose real module edges that way.
+      const specs = specsOf(`
+cfg_if! {
+    if #[cfg(unix)] {
+        mod arm_a;
+        pub use arm_a::Thing;
+    } else {
+        mod arm_b;
+    }
+}
+
+mod after;
+`);
+
+      expect(specs).toContain("arm_a");
+      expect(specs).toContain("arm_b");
+      expect(specs).toContain("arm_a::Thing");
+      expect(specs).toContain("after");
+    });
+
+    it("reads a macro nested inside one, beside a body the parser recovers from", () => {
+      // The second unwrap pass reads a source the first one rewrote, so the
+      // ERROR a kept `cfg_if!` leaves behind is in its input. Counting that
+      // against the pass cost `deep` its edge — a macro one level further in,
+      // with nothing wrong with it, punished for its neighbour.
+      const specs = specsOf(`
+cfg_if! {
+    if #[cfg(unix)] {
+        mod arm_a;
+    } else {
+        mod arm_b;
+    }
+}
+
+outer! {
+    inner! {
+        mod deep;
+    }
+}
+`);
+
+      expect(specs).toContain("deep");
+      expect(specs).toContain("arm_a");
+    });
+
+    it("leaves a body alone when recovery reaches past the macro", () => {
+      // `cfg_if!` writes its arms as `if #[cfg(…)] { … } else { … }`, and an
+      // `if` carrying an attribute is not Rust anywhere. Blanking the head and
+      // the outer braces hands the parser a fragment it recovers from, and
+      // recovery does not stop at the macro: the enclosing `mod` is closed
+      // after the first arm and what follows is re-parented to file level.
+      //
+      // Cargo-verified: a crate with this shape builds clean while the graph
+      // drew `src/lib.rs -> src/arm_b.rs` twice and `src/lib.rs -> src/dopo.rs`
+      // — three edges into files carrying `compile_error!`, one of them a
+      // module that belongs to the block.
+      //
+      // `cfg_io_util!` is the control. Without it an assertion about what is
+      // missing would also pass with body reading turned off entirely.
+      const specs = specsOf(`
+cfg_io_util! {
+    mod control;
+}
+
+mod inner {
+    mod before;
+    cfg_if! {
+        if #[cfg(unix)] {
+            mod arm_a;
+        } else if #[cfg(windows)] {
+            mod arm_b;
+        } else {
+            mod arm_c;
+        }
+    }
+    mod after;
+}
+`);
+
+      expect(specs).toContain("control");
+      expect(specs).toContain("self::inner::before");
+      expect(specs).toContain("self::inner::after");
+      // Not at file level, and not anywhere: the arms stay unread.
+      expect(specs).not.toContain("after");
+      expect(specs.filter((s) => s.includes("arm_"))).toEqual([]);
+    });
+
+    it("gives up only the macro that let recovery out, not the file it is in", () => {
+      // The retry that saves the rest of the file, and nothing was holding it:
+      // a mutation pass found that pinning `insideBlock` to either value left
+      // the whole suite green. What it costs is measurable — the narrow retry
+      // is worth 22 distinct dependencies across the 153 crates of a registry
+      // cache that carry the shape, ahash and dashmap among them, where one
+      // `cfg_if!` written in an `impl` used to take every file-level one with
+      // it.
+      //
+      // Three macros in one file is what it takes to see: a clean one, an
+      // unparsable one at file level, and an unparsable one inside a block.
+      // Only the last is given up.
+      const specs = specsOf(`
+cfg_clean! {
+    mod clean_mod;
+}
+
+cfg_if! {
+    if #[cfg(unix)] {
+        mod file_arm_a;
+    } else {
+        mod file_arm_b;
+    }
+}
+
+mod inner {
+    mod before;
+    cfg_if! {
+        if #[cfg(unix)] {
+            mod arm_a;
+        } else {
+            mod arm_b;
+        }
+    }
+    mod after;
+}
+`);
+
+      expect(specs).toContain("clean_mod");
+      expect(specs).toContain("file_arm_a");
+      expect(specs).toContain("file_arm_b");
+      // The block keeps its own declarations, and the arms inside it stay unread.
+      expect(specs).toContain("self::inner::before");
+      expect(specs).toContain("self::inner::after");
+      expect(specs.filter((s) => s.includes("arm_a") && !s.startsWith("file_"))).toEqual([]);
+    });
+
+    it("leaves the body alone when the file was already failing to parse", () => {
+      // The way back into the defect, found by trying to get around the guard:
+      // if the ERROR nodes a source already had were forgiven, a file carrying
+      // an unresolved merge marker inside the block would have one at the same
+      // index recovery produces — and the damaged pass came back, with
+      // `mod after;` drawn at file level, where rustc never looks for it.
+      //
+      // So nothing is forgiven but the macros actually unwrapped, and a source
+      // broken for its own reasons gets no unwrapping at all.
+      const specs = specsOf(`
+mod inner {
+    mod before;
+    cfg_if! {
+        if #[cfg(unix)] {
+            mod arm_a;
+        } else {
+            mod arm_b;
+        }
+    }
+    mod after;
+<<<<<<< HEAD
+}
+`);
+
+      expect(specs).toContain("self::inner::before");
+      expect(specs).not.toContain("after");
+      expect(specs.filter((s) => s.includes("arm_"))).toEqual([]);
+    });
+
     it("leaves a parenthesised macro invocation alone", () => {
       // Only `{}` is unwrapped: a `()` or `[]` invocation carries an
       // expression, not items. `automod::dir!("tests/builder")` names modules

--- a/tests/unit/graph-imports.test.ts
+++ b/tests/unit/graph-imports.test.ts
@@ -871,6 +871,52 @@ mod tests {
       expect(specs).toEqual([]);
     });
 
+    // Whether a bare head written inside an inline block may reach the file's
+    // own declarations. It travels as `fromInlineBlock`, not in the specifier,
+    // which is identical under both readings — an assertion on the string would
+    // pass either way and prove nothing.
+    const blockedOf = (source: string, spec: string): boolean | undefined =>
+      extractImports(source, "rust", ".rs").find((i) => i.moduleSpecifier === spec)?.fromInlineBlock;
+
+    it("does not take a glob from another crate as the anchor", () => {
+      // `use ::other::{*};` reaches outside this crate, so it brings in nothing
+      // the file declares and cannot anchor a bare head. The leading `::` says
+      // so, and stripping the prefix before the check is what let a group of
+      // that shape read as an anchor — the same capture the marker exists to
+      // prevent, in its braced spelling.
+      const source = `
+mod helper;
+
+mod tests {
+    use ::other::{*};
+    use helper::build;
+}
+`;
+
+      expect(specsOf(source)).toContain("::other");
+      expect(blockedOf(source, "helper::build")).toBe(true);
+    });
+
+    it("counts the supers of a glob against the depth it is written at", () => {
+      // One `super` leaves an inline block and lands on the file; written two
+      // blocks deep the same word lands halfway, and brings in nothing the file
+      // declares. Only a glob carrying exactly as many `super`s as there are
+      // levels reaches the file's own scope — dropping that count let a shallow
+      // glob anchor a head it cannot see.
+      const source = `
+mod helper;
+
+mod outer {
+    mod inner {
+        use super::*;
+        use helper::build;
+    }
+}
+`;
+
+      expect(blockedOf(source, "helper::build")).toBe(true);
+    });
+
     it("follows a bare head into the inline block that declares it", () => {
       const specs = specsOf(`
 #[cfg(test)]

--- a/tests/unit/graph-imports.test.ts
+++ b/tests/unit/graph-imports.test.ts
@@ -938,6 +938,66 @@ mod inner {
       expect(specs.filter((s) => s.includes("arm_"))).toEqual([]);
     });
 
+    it("does not let a macro accepted on the first pass forgive what the second one breaks", () => {
+      // Found by review. `outer!` wraps items and is accepted whole on the
+      // first pass, with no ERROR anywhere. On the second pass the `cfg_if!`
+      // inside `mod k` closes the block early — the same damage the guard was
+      // written for — but the orphan `}` that should reject the pass now lies
+      // inside `outer!`'s own region. Forgiving everything inside a macro an
+      // earlier pass unwrapped accepted it, and `mod z;` was drawn at file
+      // level again, where rustc never looks for it.
+      //
+      // What an earlier pass hands on is therefore the exact ERRORs its tree
+      // had, and this file has none to hand on.
+      const specs = specsOf(`
+outer! {
+    mod k {
+        mod before;
+        cfg_if! {
+            if #[cfg(unix)] {
+                mod arm_a;
+            } else {
+                mod arm_b;
+            }
+        }
+        mod z;
+    }
+}
+`);
+
+      expect(specs).toContain("self::k::before");
+      expect(specs).toContain("self::k::z");
+      expect(specs).not.toContain("z");
+      expect(specs.filter((s) => s.includes("arm_"))).toEqual([]);
+    });
+
+    it("keeps the second pass's reading of a line the first pass read with less in view", () => {
+      // Found by review. On the first pass the glob is hidden in `cfg_test!`'s
+      // token tree, so `outer::Thing` is a bare head in a block with nothing
+      // anchoring it; the second pass sees the glob and reads the same line as
+      // a path the block may answer. Keyed on that flag, both readings were
+      // kept — and the first, resolved with no declarations in scope, could
+      // reach a workspace crate named `outer` that rustc refuses with E0432.
+      const imports = extractImports(
+        `
+mod outer;
+
+#[cfg(test)]
+mod tests {
+    cfg_test! {
+        use super::*;
+    }
+    use outer::Thing;
+}
+`,
+        "rust",
+        ".rs",
+      ).filter((i) => i.moduleSpecifier === "outer::Thing");
+
+      expect(imports).toHaveLength(1);
+      expect(imports[0].fromInlineBlock).toBeUndefined();
+    });
+
     it("leaves a parenthesised macro invocation alone", () => {
       // Only `{}` is unwrapped: a `()` or `[]` invocation carries an
       // expression, not items. `automod::dir!("tests/builder")` names modules

--- a/tests/unit/graph-imports.test.ts
+++ b/tests/unit/graph-imports.test.ts
@@ -710,6 +710,109 @@ mod tests {
       // and a bare head may name another crate, which rebasing would lose.
       expect(specs).toEqual(["crate::db::Connection", "serde::Deserialize"]);
     });
+
+    it("expands a group whose first leaf is itself a group", () => {
+      const specs = specsOf("use crate::{{parser, printer}, config};");
+
+      // The depth counter has to see the opening brace of the very first
+      // character of the group body. Starting the scan one character in
+      // leaves depth at zero inside the nested group, and the comma that
+      // separates its own leaves is then read as separating the outer ones.
+      expect(specs).toEqual(["crate::parser", "crate::printer", "crate::config"]);
+    });
+
+    it("keeps a single-segment path written inside an inline module", () => {
+      const specs = specsOf(`
+mod tests {
+    use standalone;
+}
+`);
+
+      // One segment is still a path. The block declares nothing by that name,
+      // so it is left alone the way any other bare head is — dropping it
+      // loses the edge entirely.
+      expect(specs).toEqual(["standalone"]);
+    });
+
+    it("keeps a leading :: inside an inline module that declares the same name", () => {
+      const specs = specsOf(`
+mod tests {
+    mod config;
+    use ::config::Item;
+}
+`);
+
+      // The `::` says the head names a crate, and it says so precisely where
+      // a module of that name is in scope — which is the one case where
+      // rebasing the path into the block would reach the wrong file.
+      expect(specs).toEqual(["::config::Item", "self::tests::config"]);
+    });
+
+    it("counts a self:: path from the inline module it is written in", () => {
+      const specs = specsOf(`
+mod tests {
+    use self::helper::run;
+}
+`);
+
+      // Inside `mod tests`, `self` is the block, so read from the file the
+      // path names `tests::helper` — one level below where it would land if
+      // the block were not there.
+      expect(specs).toEqual(["self::tests::helper::run"]);
+    });
+
+    it("joins every inline level a rebased bare head passes through", () => {
+      const specs = specsOf(`
+mod outer {
+    mod inner {
+        mod fixtures;
+        use fixtures::build;
+    }
+}
+`);
+
+      // Two levels, so the separator between them is written rather than
+      // implied — a single level hides a missing `::` because there is
+      // nothing to join.
+      expect(specs).toEqual([
+        "self::outer::inner::fixtures::build",
+        "self::outer::inner::fixtures",
+      ]);
+    });
+
+    it("marks a module declaration as a static import, whichever form it takes", () => {
+      const imports = extractImports(
+        `
+#[path = "elsewhere/moved.rs"]
+mod moved;
+mod conventional;
+`,
+        "rust",
+        ".rs",
+      );
+
+      // The flag decides the edge's type in the graph. A `mod` declaration is
+      // as static as an import gets: nothing about it is decided at run time.
+      expect(imports.map((i) => i.isDynamic)).toEqual([false, false]);
+    });
+
+    it("marks an extern crate declaration as a static import", () => {
+      const imports = extractImports("extern crate serde;", "rust", ".rs");
+
+      expect(imports.map((i) => i.isDynamic)).toEqual([false]);
+    });
+
+    it("records nothing for a crate that renames itself", () => {
+      const specs = specsOf(`
+extern crate self as this_crate;
+extern crate serde;
+`);
+
+      // `extern crate self` names the crate the file is already in, which is
+      // no edge — and resolving the word `self` as a module path would reach
+      // the file's own directory.
+      expect(specs).toEqual(["serde"]);
+    });
   });
 
   // ── Go ─────────────────────────────────────────────────────────────────

--- a/tests/unit/graph-imports.test.ts
+++ b/tests/unit/graph-imports.test.ts
@@ -672,6 +672,32 @@ mod tests {
       expect(specs).toEqual([]);
     });
 
+    it("follows a bare head into the inline block that declares it", () => {
+      const specs = specsOf(`
+#[cfg(test)]
+mod tests {
+    mod fixtures;
+    use fixtures::build_store;
+}
+`);
+
+      // `fixtures` is declared right there, so the path goes into the block —
+      // `src/<file>/tests/fixtures.rs` — and not to a file of that name
+      // sitting beside the declaring one.
+      expect(specs).toEqual(["self::tests::fixtures::build_store", "self::tests::fixtures"]);
+    });
+
+    it("takes the directory of an inline module from its own path attribute", () => {
+      const specs = specsOf(`
+#[path = "other_dir"]
+mod outer {
+    pub mod child;
+}
+`);
+
+      expect(specs).toEqual(["self::other_dir::child"]);
+    });
+
     it("leaves a crate-anchored path alone inside an inline module", () => {
       const specs = specsOf(`
 mod tests {

--- a/tests/unit/graph-imports.test.ts
+++ b/tests/unit/graph-imports.test.ts
@@ -559,6 +559,31 @@ use ::serde::{Serialize, Deserialize};
       expect(specs).toEqual(["::config::Item", "::serde::Serialize", "::serde::Deserialize"]);
     });
 
+    it("keeps the leading :: when the group opens on it", () => {
+      // `::{…}` carries the marker in the group prefix and nowhere else.
+      // Stripping the trailing `::` left the empty string, which reads the same
+      // as a group with no prefix, and the path resolved into the local module
+      // again — the capture the marker exists to prevent.
+      const specs = specsOf(`
+use ::{corelib::marker};
+use ::{corelib::marker, log::Level};
+`);
+
+      expect(specs).toEqual([
+        "::corelib::marker",
+        "::corelib::marker",
+        "::log::Level",
+      ]);
+    });
+
+    it("leaves a group with no prefix alone", () => {
+      // The guard above must not turn every prefix-less group into a global
+      // path: `use {a, b};` names two paths in the file's own scope.
+      const specs = specsOf("use {alpha, beta::Gamma};");
+
+      expect(specs).toEqual(["alpha", "beta::Gamma"]);
+    });
+
     it("finds a path attribute with a comment between it and the mod", () => {
       const specs = specsOf(`
 #[path = "elsewhere/moved.rs"]
@@ -603,6 +628,180 @@ mod conventional;
 `);
 
       expect(specs).toEqual(["elsewhere/moved.rs", "fixtures/support.rs", "conventional"]);
+    });
+
+    it("takes the file of a mod from a cfg_attr path attribute", () => {
+      // The platform-abstraction idiom, and the Rust Reference's own example:
+      // the module `sys` is `unix.rs` here and `windows.rs` there, and
+      // `src/sys.rs` is never read. Reading only the bare form both drew an
+      // edge to that unread file and missed the one carrying the crate body.
+      //
+      // One path per named file, because the graph does not fix a target or a
+      // feature set — the same reading `#[cfg(…)] mod` already gets.
+      //
+      // Nearest the `mod` first: the attributes are walked backwards from it,
+      // which is where a lone `#[path]` was already read from.
+      //
+      // The plain name closes the list, because a `cfg_attr` applies only where
+      // its condition holds and where none does the module is the file its name
+      // implies — `errno`'s own `src/sys.rs` is written for exactly that case.
+      const specs = specsOf(`
+#[cfg_attr(unix, path = "unix.rs")]
+#[cfg_attr(windows, path = "windows.rs")]
+mod sys;
+`);
+
+      expect(specs).toEqual(["windows.rs", "unix.rs", "sys"]);
+    });
+
+    it("reads the declarations written inside a macro invocation", () => {
+      // tree-sitter keeps a macro body as an unparsed token tree, so nothing in
+      // it was a node and half of tokio's `mod` declarations — 256 of 535 —
+      // were invisible, along with 348 `use`. Expansion happens before name
+      // resolution: what is written in there is a declaration like any other.
+      const specs = specsOf(`
+mod plain;
+
+cfg_io_util! {
+    mod async_buf_read_ext;
+    pub use async_buf_read_ext::AsyncBufReadExt;
+
+    mod buf_reader;
+}
+`);
+
+      expect(specs).toContain("plain");
+      expect(specs).toContain("async_buf_read_ext");
+      expect(specs).toContain("buf_reader");
+      expect(specs).toContain("async_buf_read_ext::AsyncBufReadExt");
+    });
+
+    it("does not read a macro body as a module level of its own", () => {
+      // The body is unwrapped in place, so what encloses it still counts and
+      // the macro itself does not: `mod x;` inside `cfg_windows! { … }` written
+      // in `mod inner { … }` names `inner/x`, not `cfg_windows/x` and not `x`.
+      const specs = specsOf(`
+mod inner {
+    cfg_windows! {
+        mod named_pipe;
+    }
+}
+`);
+
+      expect(specs).toEqual(["self::inner::named_pipe"]);
+    });
+
+    it("reads a #[path] declaration written inside a macro invocation", () => {
+      // tokio's `atomic_u64.rs` writes exactly this, twice: the module is
+      // always `imp`, and only the attribute says which file it is.
+      const specs = specsOf(`
+cfg_has_atomic_u64! {
+    #[path = "atomic_u64_native.rs"]
+    mod imp;
+}
+
+cfg_not_has_atomic_u64! {
+    #[path = "atomic_u64_as_mutex.rs"]
+    mod imp;
+}
+`);
+
+      expect(specs).toEqual(["atomic_u64_native.rs", "atomic_u64_as_mutex.rs"]);
+    });
+
+    it("does not read a macro body written as an expression", () => {
+      // A proc-macro's `quote! { … }` builds the tokens its *caller* will get:
+      // the module is declared there, not here. Checked on cargo 1.98.0 with a
+      // `compile_error!` in `src/generated.rs` — the crate builds clean and its
+      // dep-info names `src/lib.rs` alone, while the graph had drawn the file
+      // as a dependency, twice.
+      //
+      // The rule is read off the tree, not off the macro's name: a body holds
+      // items only where the invocation itself may be one. Both spellings are
+      // checked, the method receiver and the tail expression — the second is
+      // the idiom of every `fn … -> TokenStream`, and it is the reason a block
+      // does not count as an item position.
+      for (const body of [
+        "    quote! {\n        mod generated;\n        pub use generated::Thing;\n    }\n    .into()",
+        "    quote! {\n        mod generated;\n        pub use generated::Thing;\n    }",
+      ]) {
+        const specs = specsOf(`
+use quote::quote;
+
+pub fn emit() -> TokenStream {
+${body}
+}
+`);
+
+        expect(specs, `body: ${body}`).not.toContain("generated");
+        expect(specs, `body: ${body}`).not.toContain("generated::Thing");
+      }
+    });
+
+    it("reads a macro body written where an item may stand", () => {
+      // The other side of the same rule, in the two places that count: the file
+      // itself and a `mod` body. An `impl` body counts too — tokio writes a
+      // `cfg_unstable! { fn … { use …; } }` in one.
+      const specs = specsOf(`
+cfg_a! {
+    mod at_file;
+}
+
+mod holder {
+    cfg_b! {
+        mod in_mod;
+    }
+}
+
+impl Thing {
+    cfg_c! {
+        fn f() { use crate::in_impl::Marker; }
+    }
+}
+`);
+
+      expect(specs).toContain("at_file");
+      expect(specs).toContain("self::holder::in_mod");
+      expect(specs).toContain("crate::in_impl::Marker");
+    });
+
+    it("leaves a parenthesised macro invocation alone", () => {
+      // Only `{}` is unwrapped: a `()` or `[]` invocation carries an
+      // expression, not items. `automod::dir!("tests/builder")` names modules
+      // that are nowhere written, and no reading of the source can find them.
+      const specs = specsOf(`
+mod real;
+automod::dir!("tests/builder");
+let v = vec![1, 2, 3];
+`);
+
+      expect(specs).toEqual(["real"]);
+    });
+
+    it("does not report a declaration twice when it sits outside every macro", () => {
+      // The unwrapped source is re-read whole, so everything the first pass
+      // found comes back with it. Subtracting as a multiset is what keeps the
+      // existing edges, repeats included, exactly as they were.
+      const specs = specsOf(`
+mod outside;
+cfg_io_util! {
+    mod inside;
+}
+`);
+
+      expect(specs.filter((s) => s === "outside")).toHaveLength(1);
+      expect(specs.filter((s) => s === "inside")).toHaveLength(1);
+    });
+
+    it("reads a cfg_attr that names no path as naming none", () => {
+      // Only `path` is picked out of what a `cfg_attr` would apply; a
+      // `cfg_attr` carrying anything else leaves the module on convention.
+      const specs = specsOf(`
+#[cfg_attr(docsrs, doc(cfg(feature = "full")))]
+mod plain;
+`);
+
+      expect(specs).toEqual(["plain"]);
     });
 
     it("marks a path attribute written inside an inline module", () => {

--- a/tests/unit/graph-imports.test.ts
+++ b/tests/unit/graph-imports.test.ts
@@ -575,6 +575,20 @@ mod conventional;
       expect(specs).toEqual(["elsewhere/moved.rs", "fixtures/support.rs", "conventional"]);
     });
 
+    it("marks a path attribute written inside an inline module", () => {
+      const specs = specsOf(`
+mod block {
+    #[path = "moved.rs"]
+    mod inner;
+}
+`);
+
+      // rustc counts this one from the file's own module directory, one
+      // directory deeper per inline level — unlike a declared module, which
+      // counts from the directory the file sits in.
+      expect(specs).toEqual(["self/block/moved.rs"]);
+    });
+
     it("extracts an extern crate declaration", () => {
       const specs = specsOf(`
 extern crate serde;

--- a/tests/unit/graph-imports.test.ts
+++ b/tests/unit/graph-imports.test.ts
@@ -539,6 +539,36 @@ use crate::{
       expect(specs).toEqual(["crate::alpha", "crate::beta::Gamma"]);
     });
 
+    it("keeps the module a group leaf names when that leaf is renamed", () => {
+      const specs = specsOf(`
+use crate::config::{self as cfg, Config};
+use crate::helpers::{* };
+`);
+
+      // `{self as cfg}` names the same module `{self}` does; comparing the
+      // leaf before removing the alias dropped the import altogether.
+      expect(specs).toEqual(["crate::config", "crate::config::Config", "crate::helpers"]);
+    });
+
+    it("keeps the leading :: that says the head is a crate", () => {
+      const specs = specsOf(`
+use ::config::Item;
+use ::serde::{Serialize, Deserialize};
+`);
+
+      expect(specs).toEqual(["::config::Item", "::serde::Serialize", "::serde::Deserialize"]);
+    });
+
+    it("finds a path attribute with a comment between it and the mod", () => {
+      const specs = specsOf(`
+#[path = "elsewhere/moved.rs"]
+// kept here because the generator writes it there
+mod moved;
+`);
+
+      expect(specs).toEqual(["elsewhere/moved.rs"]);
+    });
+
     it("ignores comments written between the leaves of a use group", () => {
       const specs = specsOf(`
 use crate::{

--- a/tests/unit/graph-imports.test.ts
+++ b/tests/unit/graph-imports.test.ts
@@ -538,6 +538,108 @@ use crate::{
 
       expect(specs).toEqual(["crate::alpha", "crate::beta::Gamma"]);
     });
+
+    it("ignores comments written between the leaves of a use group", () => {
+      const specs = specsOf(`
+use crate::{
+    // the one we need
+    models::User,
+    /* and this one */ helpers::format,
+};
+`);
+
+      expect(specs).toEqual(["crate::models::User", "crate::helpers::format"]);
+    });
+
+    it("names the module a raw identifier escapes, not its escape", () => {
+      const specs = specsOf(`
+pub mod r#async;
+use crate::r#type::Kind;
+use crate::r#match::Pattern as r#final;
+`);
+
+      // `use` declarations are read before `mod` ones, hence the order.
+      expect(specs).toEqual(["crate::type::Kind", "crate::match::Pattern", "async"]);
+    });
+
+    it("takes the file of a mod from its path attribute", () => {
+      const specs = specsOf(`
+#[path = "elsewhere/moved.rs"]
+mod moved;
+#[cfg(test)]
+#[path = "fixtures/support.rs"]
+mod support;
+mod conventional;
+`);
+
+      expect(specs).toEqual(["elsewhere/moved.rs", "fixtures/support.rs", "conventional"]);
+    });
+
+    it("extracts an extern crate declaration", () => {
+      const specs = specsOf(`
+extern crate serde;
+#[macro_use]
+extern crate log;
+extern crate my_lib as shorthand;
+`);
+
+      expect(specs).toEqual(["serde", "log", "my_lib"]);
+    });
+
+    it("places a mod declared inside an inline module under that module", () => {
+      const specs = specsOf(`
+mod outer {
+    mod inner;
+    mod deeper {
+        mod leaf;
+    }
+}
+mod beside;
+`);
+
+      expect(specs).toEqual(["self::outer::inner", "self::outer::deeper::leaf", "beside"]);
+    });
+
+    it("counts an inline module as a level a super:: path climbs", () => {
+      const specs = specsOf(`
+use super::sibling::Thing;
+
+#[cfg(test)]
+mod tests {
+    use super::helper;
+    use super::super::sibling::Other;
+}
+`);
+
+      // At file level `super` reaches the parent module; the same word inside
+      // `mod tests` reaches the file itself, so it takes one more to leave it.
+      expect(specs).toEqual(["super::sibling::Thing", "self::helper", "super::sibling::Other"]);
+    });
+
+    it("records nothing for a glob import of the module a test block sits in", () => {
+      const specs = specsOf(`
+#[cfg(test)]
+mod tests {
+    use super::*;
+}
+`);
+
+      // `use super::*;` inside `mod tests` names the file it is written in.
+      expect(specs).toEqual([]);
+    });
+
+    it("leaves a crate-anchored path alone inside an inline module", () => {
+      const specs = specsOf(`
+mod tests {
+    use crate::db::Connection;
+    use serde::Deserialize;
+}
+`);
+
+      // `crate::` counts from the crate root, which no inline module moves;
+      // and a bare head may name another crate, which rebasing would lose.
+      expect(specs).toEqual(["crate::db::Connection", "serde::Deserialize"]);
+    });
   });
 
   // ── Go ─────────────────────────────────────────────────────────────────

--- a/tests/unit/graph-imports.test.ts
+++ b/tests/unit/graph-imports.test.ts
@@ -455,6 +455,9 @@ import static java.lang.Math.PI;
   // ── Rust ───────────────────────────────────────────────────────────────
 
   describe("Rust imports", () => {
+    const specsOf = (source: string): string[] =>
+      extractImports(source, "rust", ".rs").map((i) => i.moduleSpecifier);
+
     it("extracts use statements", () => {
       const source = `
 use std::collections::HashMap;
@@ -465,6 +468,75 @@ mod config;
       const specs = imports.map((i) => i.moduleSpecifier);
 
       expect(specs.length).toBeGreaterThan(0);
+    });
+
+    it("extracts module declarations behind a visibility modifier", () => {
+      const specs = specsOf(`
+mod private_one;
+pub mod public_one;
+pub(crate) mod crate_visible;
+pub(in crate::outer) mod scoped;
+`);
+
+      expect(specs).toEqual(["private_one", "public_one", "crate_visible", "scoped"]);
+    });
+
+    it("extracts re-exports", () => {
+      const specs = specsOf(`
+pub use crate::config::Config;
+pub(crate) use crate::db::Pool;
+`);
+
+      expect(specs).toEqual(["crate::config::Config", "crate::db::Pool"]);
+    });
+
+    it("still skips inline module definitions", () => {
+      const specs = specsOf(`
+pub mod inline {
+    pub fn thing() {}
+}
+mod declared;
+`);
+
+      expect(specs).toEqual(["declared"]);
+    });
+
+    it("expands a use group into one path per leaf", () => {
+      const specs = specsOf("use crate::{parser, printer::Printer};");
+
+      expect(specs).toEqual(["crate::parser", "crate::printer::Printer"]);
+    });
+
+    it("expands nested use groups", () => {
+      const specs = specsOf("use crate::{a::{b, c}, d};");
+
+      expect(specs).toEqual(["crate::a::b", "crate::a::c", "crate::d"]);
+    });
+
+    it("reads self and glob leaves as the module they name", () => {
+      const specs = specsOf(`
+use crate::config::{self, Config};
+use crate::helpers::*;
+`);
+
+      expect(specs).toEqual(["crate::config", "crate::config::Config", "crate::helpers"]);
+    });
+
+    it("drops the alias from a renamed import", () => {
+      const specs = specsOf("use crate::models::User as DomainUser;");
+
+      expect(specs).toEqual(["crate::models::User"]);
+    });
+
+    it("reads a use declaration split across lines", () => {
+      const specs = specsOf(`
+use crate::{
+    alpha,
+    beta::Gamma,
+};
+`);
+
+      expect(specs).toEqual(["crate::alpha", "crate::beta::Gamma"]);
     });
   });
 

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -2156,15 +2156,28 @@ describe("graph-resolution", () => {
       expect(resolveRustImport("registry::write", "src/client.rs", fileSet, crates)).toBeNull();
     });
 
-    it("reads an unanchored path from the module itself from edition 2018 on", () => {
+    it("reads an unanchored path from the file's own module directory, never the crate root", () => {
       const crates = rustProject({
         "Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
         "src/lib.rs": "",
+        // The crate root's `registry`, which is what the 2015 reading would
+        // reach and this one must not.
         "src/registry.rs": "",
         "src/client.rs": "",
+        "src/client/registry.rs": "",
       });
 
-      expect(resolveRustImport("registry::write", "src/client.rs", fileSet, crates)).toBeNull();
+      // `src/client.rs` owns `src/client/`, so the head is read from there and
+      // the crate root's `registry` is not it. The rule holds in every
+      // edition — the 2015 case above is the same walk with nothing to find.
+      // Review finding: this asserted `null` on a fixture without
+      // `src/client/registry.rs`, which is also what the 2015 case answers, so
+      // it passed on the absence of a file and proved nothing. Its name said
+      // "from edition 2018 on", a distinction the resolver stopped making when
+      // the declaration gate was turned on for every edition.
+      expect(resolveRustImport("registry::write", "src/client.rs", fileSet, crates)).toBe(
+        "src/client/registry.rs",
+      );
     });
 
     it("lets a local module win over a sibling crate of the same name", () => {

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -2108,6 +2108,47 @@ describe("graph-resolution", () => {
         .toBe("crates/config/src/lib.rs");
     });
 
+    it("lets an unanchored path reach a module the file declares, and only then", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n\n[dependencies]\nserde = "1"\n',
+        "src/lib.rs": "",
+        "src/serde.rs": "",
+      });
+
+      // Both hands in one place, which is what the graph-level assertion
+      // cannot do: there the `mod serde;` declaration draws the same edge, so
+      // the edge stays whatever the unanchored path resolves to.
+      expect(
+        resolveRustImport("serde::Local", "src/lib.rs", fileSet, crates, new Set(["serde"])),
+      ).toBe("src/serde.rs");
+      expect(
+        resolveRustImport("serde::Local", "src/lib.rs", fileSet, crates, new Set()),
+      ).toBeNull();
+    });
+
+    it("leaves a single-segment path on the crate when no declaration names it", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/bar"]\n',
+        "crates/app/Cargo.toml":
+          '[package]\nname = "app"\nedition = "2021"\n\n[dependencies]\nbar = { path = "../bar" }\n',
+        "crates/app/src/lib.rs": "",
+        // An orphan left by a refactor: on disk, in no module tree.
+        "crates/app/src/bar.rs": "",
+        "crates/bar/Cargo.toml": '[package]\nname = "bar"\nedition = "2021"\n',
+        "crates/bar/src/lib.rs": "",
+      });
+
+      // `use bar;` and `mod bar;` arrive in the same shape, and only the
+      // declaration may reach the file. cargo 1.70.0 and 1.98.0 compile
+      // `use bar;` against the dependency with that orphan sitting there.
+      expect(
+        resolveRustImport("bar", "crates/app/src/lib.rs", fileSet, crates, new Set()),
+      ).toBe("crates/bar/src/lib.rs");
+      expect(
+        resolveRustImport("bar", "crates/app/src/lib.rs", fileSet, crates, new Set(["bar"])),
+      ).toBe("crates/app/src/bar.rs");
+    });
+
     it("follows a dependency renamed in the manifest to the crate it points at", () => {
       const crates = rustProject({
         "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/core"]\n',

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -2049,7 +2049,7 @@ describe("graph-resolution", () => {
         .toBe("src/area/block/moved.rs");
     });
 
-    it("reads an unanchored path from the crate root in edition 2015", () => {
+    it("leaves an unanchored 2015 path unresolved, a declared limit", () => {
       const crates = rustProject({
         "Cargo.toml": '[package]\nname = "app"\n',
         "src/lib.rs": "",
@@ -2057,10 +2057,15 @@ describe("graph-resolution", () => {
         "src/client.rs": "",
       });
 
-      // `use registry::write;` in `src/client.rs` compiles in 2015 and names
-      // `src/registry.rs`; rustc rejects the same line from 2018 on.
-      expect(resolveRustImport("registry::write", "src/client.rs", fileSet, crates))
-        .toBe("src/registry.rs");
+      // `use registry::write;` in `src/client.rs` does compile in 2015 when
+      // `mod registry;` is written in `lib.rs`, and names `src/registry.rs`.
+      // The edge is left undrawn on purpose: acting on the root-relative
+      // reading means answering a path with no declaration behind it, and every
+      // attempt to bound that drew an edge rustc rejects — a bare `use b;`
+      // between two integration-test crates, an undeclared sibling file, a
+      // `mod` declared in a nested block, a virtual workspace's root crate
+      // claiming its members' declarations. `main` drew nothing here either.
+      expect(resolveRustImport("registry::write", "src/client.rs", fileSet, crates)).toBeNull();
     });
 
     it("reads an unanchored path from the module itself from edition 2018 on", () => {
@@ -2254,7 +2259,7 @@ describe("graph-resolution", () => {
       ).toBe("crates/config/src/lib.rs");
     });
 
-    it("keeps an edition 2015 unanchored path out of the declaration gate", () => {
+    it("holds the declaration gate on in edition 2015 too", () => {
       const crates = rustProject({
         // No edition key: Cargo reads 2015, and there the path below is
         // absolute from the crate root.
@@ -2264,22 +2269,20 @@ describe("graph-resolution", () => {
         "src/client.rs": "",
       });
 
-      // `mod registry;` is written in lib.rs; client.rs declares nothing at
-      // all, and `use registry::write;` compiles there on cargo 1.70.0 and
-      // 1.98.0. The gate is a 2018 rule: applied here it would drop the edge
-      // on every crate whose manifest omits the edition key.
+      // The gate is a 2018 rule that this resolver applies to every edition,
+      // and the reason is the tail behind the alternative: answering a
+      // root-relative path means resolving one no declaration proves, and each
+      // bound put on that turned out to draw an edge rustc rejects. Both
+      // spellings stay unresolved — the multi-segment path and the bare head
+      // that arrives in the shape a declaration does.
       expect(
         resolveRustImport("registry::write", "src/client.rs", fileSet, crates, new Map()),
-      ).toBe("src/registry.rs");
-      // And a bare head in the same position, which arrives in the shape a
-      // declaration does.
+      ).toBeNull();
       // `false` says this is a `use` and not a `mod` declaration: the two
-      // arrive as the same string, and in 2015 they count from different
-      // places — `use foo::Nested;` beside `mod foo;` is E0432 on 1.70.0 and
-      // 1.98.0, while `use foo::AtRoot;` reaches the root's module.
+      // arrive as the same string.
       expect(
         resolveRustImport("registry", "src/client.rs", fileSet, crates, new Map(), false),
-      ).toBe("src/registry.rs");
+      ).toBeNull();
       // And the declaration in the same position still counts from the file.
       expect(
         resolveRustImport("registry", "src/deep.rs", fileSet, crates, new Map(), true),

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -1849,6 +1849,48 @@ describe("graph-resolution", () => {
       expect(crates[0].roots).toEqual(["src/lib.rs"]);
     });
 
+    it("finds a target declared by name alone at the path Cargo gives that name", () => {
+      // `[[bin]] name = "tool"` with no `path` is resolved by convention from
+      // the name: src/bin/tool.rs, tests/cli.rs, examples/demo.rs,
+      // benches/speed.rs. Edition 2015 is what makes this test able to fail —
+      // there the declarations turn autodiscovery off, so the name is the only
+      // route left to those files. `cargo metadata` reports exactly these five
+      // targets for this manifest on 1.70.0, 1.85.0 and 1.98.0.
+      const crates = rustProject({
+        "Cargo.toml": [
+          '[package]',
+          'name = "app"',
+          'edition = "2015"',
+          '',
+          '[[bin]]',
+          'name = "tool"',
+          '',
+          '[[test]]',
+          'name = "cli"',
+          '',
+          '[[example]]',
+          'name = "demo"',
+          '',
+          '[[bench]]',
+          'name = "speed"',
+          '',
+        ].join("\n"),
+        "src/lib.rs": "",
+        "src/bin/tool.rs": "",
+        "tests/cli.rs": "",
+        "examples/demo.rs": "",
+        "benches/speed.rs": "",
+      });
+
+      expect(crates[0].roots).toEqual([
+        "benches/speed.rs",
+        "examples/demo.rs",
+        "src/bin/tool.rs",
+        "src/lib.rs",
+        "tests/cli.rs",
+      ]);
+    });
+
     it("shuts off autodiscovery for declared target types in edition 2015 but keeps it in 2018+", () => {
       const crates2015 = rustProject({
         "Cargo.toml":

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -2164,6 +2164,44 @@ describe("graph-resolution", () => {
         .toBe("crates/app/src/config.rs");
     });
 
+    it("answers a 2015 leading :: from the crate root, not from the child's own declarations", () => {
+      // Review finding, left open from an earlier round. `src/deep/child.rs`
+      // declares `#[path = "local.rs"] mod foo;` of its own, and the root
+      // declares `mod foo;` too. `use ::foo::Item` written in the child names
+      // the root's — `::` is the crate root in 2015 — yet the child's
+      // declaration map was consulted first and answered with `local.rs`.
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\nedition = "2015"\n',
+        "src/lib.rs": "",
+        "src/foo.rs": "",
+        "src/deep/mod.rs": "",
+        "src/deep/child.rs": "",
+        "src/deep/local.rs": "",
+      });
+      const childDeclares = new Map([["foo", "local.rs"]]);
+
+      expect(resolveRustImport("::foo::Item", "src/deep/child.rs", fileSet, crates, childDeclares))
+        .toBe("src/foo.rs");
+      expect(resolveRustImport("::foo", "src/deep/child.rs", fileSet, crates, childDeclares))
+        .toBe("src/foo.rs");
+      // Without the marker the child's own `foo` is the one in scope.
+      expect(resolveRustImport("foo::Item", "src/deep/child.rs", fileSet, crates, childDeclares))
+        .toBe("src/deep/local.rs");
+    });
+
+    it("leaves a 2015 leading :: unresolved when no target root covers the file", () => {
+      // A file outside every Cargo target has no root to count from, and a
+      // guess would be an edge rustc never draws.
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\nedition = "2015"\n',
+        "src/lib.rs": "",
+        "src/foo.rs": "",
+        "scratch/loose.rs": "",
+      });
+
+      expect(resolveRustImport("::foo::Item", "scratch/loose.rs", fileSet, crates)).toBeNull();
+    });
+
     it("lets an unanchored path reach a module the file declares, and only then", () => {
       const crates = rustProject({
         "Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n\n[dependencies]\nserde = "1"\n',

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -1370,11 +1370,26 @@ describe("graph-resolution", () => {
         {
           dir: ".",
           name: "my_app_core",
+          packageName: "my_app_core",
           libRoot: "src/lib.rs",
           roots: ["src/lib.rs"],
           edition: "2021",
         },
       ]);
+    });
+
+    it("keeps the package name beside a library name that differs from it", () => {
+      // A dependency on this crate is declared under the package name; the
+      // code that uses it writes the library name. Both are needed to tell
+      // whether an import names a crate the importing package declared.
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "rust-crypto"\n\n[lib]\nname = "crypto"\n',
+        "src/lib.rs": "",
+      });
+
+      expect(crates[0].name).toBe("crypto");
+      expect(crates[0].packageName).toBe("rust_crypto");
+      expect(crates[0].manifestUnread).toBeUndefined();
     });
 
     it("inherits the edition a workspace declares for its members", () => {
@@ -1680,6 +1695,49 @@ describe("graph-resolution", () => {
       expect(resolveRustImport("tools::Thing", "app/src/lib.rs", fileSet, crates)).toBe("helper/src/lib.rs");
       expect(resolveRustImport("util::Thing", "app/src/lib.rs", fileSet, crates)).toBe("util/src/lib.rs");
       expect(resolveRustImport("app::run", "app/src/bin/tool.rs", fileSet, crates)).toBe("app/src/lib.rs");
+    });
+
+    it("admits a declared dependency by the library name its code is imported under", () => {
+      // Review finding on the fence's first cut. A dependency is declared
+      // under its package name, and the code writes its library name: `other`
+      // in the manifest, `otherlib` in the `use`, wherever `[lib] name` is
+      // set — `rust-crypto` is imported as `crypto`. Keyed on the declared
+      // names alone, the fence turned that edge away, a regression against the
+      // head before it. Renamed, the alias is the only name in scope: with
+      // `dep = { package = "other" }` the code writes `dep`, and `otherlib`
+      // is E0432.
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["app", "renamer", "other"]\n',
+        "app/Cargo.toml": '[package]\nname = "app"\n\n[dependencies]\nother = { path = "../other" }\n',
+        "app/src/lib.rs": "",
+        "renamer/Cargo.toml": '[package]\nname = "renamer"\n\n[dependencies]\ndep = { path = "../other", package = "other" }\n',
+        "renamer/src/lib.rs": "",
+        "other/Cargo.toml": '[package]\nname = "other"\n\n[lib]\nname = "otherlib"\n',
+        "other/src/lib.rs": "",
+        "other/src/deep.rs": "",
+      });
+
+      expect(resolveRustImport("otherlib::deep::Thing", "app/src/lib.rs", fileSet, crates)).toBe("other/src/deep.rs");
+      expect(resolveRustImport("other::Thing", "app/src/lib.rs", fileSet, crates)).toBeNull();
+      expect(resolveRustImport("dep::deep::Thing", "renamer/src/lib.rs", fileSet, crates)).toBe("other/src/deep.rs");
+      expect(resolveRustImport("otherlib::Thing", "renamer/src/lib.rs", fileSet, crates)).toBeNull();
+    });
+
+    it("does not fence a package whose manifest could not be read", () => {
+      // Review finding. An unparseable `Cargo.toml` declares nothing that can
+      // be known, and reading that as "declares nothing" cost the package every
+      // cross-crate edge — where the map's own promise is that one unreadable
+      // manifest must not cost the project its Rust edges.
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["app", "util"]\n',
+        "app/Cargo.toml": '[package]\nname = "app"\n\n[[[broken\n',
+        "app/src/lib.rs": "",
+        "util/Cargo.toml": '[package]\nname = "util"\n',
+        "util/src/lib.rs": "",
+      });
+
+      expect(crates.find((c) => c.dir === "app")?.manifestUnread).toBe(true);
+      expect(resolveRustImport("util::Thing", "app/src/lib.rs", fileSet, crates)).toBe("util/src/lib.rs");
     });
 
     it("leaves a third-party crate unresolved", () => {
@@ -2189,17 +2247,52 @@ describe("graph-resolution", () => {
         .toBe("src/deep/local.rs");
     });
 
-    it("leaves a 2015 leading :: unresolved when no target root covers the file", () => {
-      // A file outside every Cargo target has no root to count from, and a
-      // guess would be an edge rustc never draws.
+    it("answers a 2015 leading :: with a declared crate when the root has no such module", () => {
+      // Review finding on the branch's first cut: the walk from the root fell
+      // back on the root file whenever nothing matched, so the crate lookup
+      // after it never ran — a declared sibling lost its edge to the
+      // importer's own `lib.rs`, and a registry crate gained one. In 2015
+      // `extern crate foo;` at the root puts the crate at the root; the
+      // sibling resolves, the registry crate resolves to nothing, and a name
+      // rustc provides on its own — `core` — is not an item of this crate.
       const crates = rustProject({
-        "Cargo.toml": '[package]\nname = "app"\nedition = "2015"\n',
-        "src/lib.rs": "",
-        "src/foo.rs": "",
-        "scratch/loose.rs": "",
+        "Cargo.toml": '[workspace]\nmembers = ["old", "foo"]\n',
+        "old/Cargo.toml": '[package]\nname = "old"\nedition = "2015"\n\n[dependencies]\nfoo = { path = "../foo" }\ncfg-if = "1"\n',
+        "old/src/lib.rs": "",
+        "old/src/bar.rs": "",
+        "old/src/deep/mod.rs": "",
+        "old/src/deep/child.rs": "",
+        "old/tests/it.rs": "",
+        "foo/Cargo.toml": '[package]\nname = "foo"\n',
+        "foo/src/lib.rs": "",
+        "foo/src/item.rs": "",
       });
 
-      expect(resolveRustImport("::foo::Item", "scratch/loose.rs", fileSet, crates)).toBeNull();
+      expect(resolveRustImport("::foo::item::Item", "old/src/deep/child.rs", fileSet, crates)).toBe("foo/src/item.rs");
+      expect(resolveRustImport("::foo", "old/src/deep/child.rs", fileSet, crates)).toBe("foo/src/lib.rs");
+      expect(resolveRustImport("::cfg_if::cfg_if", "old/src/deep/child.rs", fileSet, crates)).toBeNull();
+      expect(resolveRustImport("::core::fmt", "old/src/deep/child.rs", fileSet, crates)).toBeNull();
+      // A module of the root still wins, and an item of the root is the root.
+      expect(resolveRustImport("::bar::BarItem", "old/src/deep/child.rs", fileSet, crates)).toBe("old/src/bar.rs");
+      expect(resolveRustImport("::RootItem", "old/src/deep/child.rs", fileSet, crates)).toBe("old/src/lib.rs");
+      // An integration test reaches the library by its crate name.
+      expect(resolveRustImport("::old::bar::BarItem", "old/tests/it.rs", fileSet, crates)).toBe("old/src/bar.rs");
+    });
+
+    it("leaves a 2015 leading :: unresolved when no target root covers the file", () => {
+      // A file outside every Cargo target has no root to count from, and a
+      // guess would be an edge rustc never draws. `foo` is declared, so the
+      // fence is not what answers here: it is the missing root.
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["app", "foo"]\n',
+        "app/Cargo.toml": '[package]\nname = "app"\nedition = "2015"\n\n[dependencies]\nfoo = { path = "../foo" }\n',
+        "app/src/lib.rs": "",
+        "app/scratch/loose.rs": "",
+        "foo/Cargo.toml": '[package]\nname = "foo"\n',
+        "foo/src/lib.rs": "",
+      });
+
+      expect(resolveRustImport("::foo::Item", "app/scratch/loose.rs", fileSet, crates)).toBeNull();
     });
 
     it("lets an unanchored path reach a module the file declares, and only then", () => {

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -1805,6 +1805,8 @@ describe("graph-resolution", () => {
         undefined,
         undefined,
         undefined,
+        undefined,
+        undefined,
         crates,
       );
 

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -11,10 +11,13 @@ import {
   buildGoModuleInfo,
   buildJvmSuffixMap,
   buildPythonManifests,
+  buildRustCrateMap,
   hasLiteralShellPathShape,
   type PythonManifest,
   pythonRootsForFile,
+  type RustCrate,
   resolveImport,
+  resolveRustImport,
 } from "../../src/services/graph-resolution.js";
 
 // ── Helper to create temp project layouts ─────────────────────────────
@@ -1345,6 +1348,361 @@ describe("graph-resolution", () => {
       );
 
       expect(result).toBeNull();
+    });
+
+    // ── Crate map ──────────────────────────────────────────────────────
+
+    /** Lay out a project and read its crates the way buildCodeGraph does. */
+    let fileSet = new Set<string>();
+    const rustProject = (files: Record<string, string>): RustCrate[] => {
+      project = createTempProject(files);
+      fileSet = project.fileSet;
+      return buildRustCrateMap(fileSet, project.root);
+    };
+
+    it("records a crate under the name Cargo lets others import it by", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "my-app-core"\n',
+        "src/lib.rs": "",
+      });
+
+      expect(crates).toEqual([
+        { dir: ".", name: "my_app_core", libRoot: "src/lib.rs", roots: ["src/lib.rs"] },
+      ]);
+    });
+
+    it("takes the library path a manifest declares over the conventional one", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "odd"\n\n[lib]\npath = "lib/entry.rs"\n',
+        "lib/entry.rs": "",
+        "src/lib.rs": "",
+      });
+
+      expect(crates[0].libRoot).toBe("lib/entry.rs");
+    });
+
+    it("takes the library name over the package name", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "the-package"\n\n[lib]\nname = "the_lib"\n',
+        "src/lib.rs": "",
+      });
+
+      expect(crates[0].name).toBe("the_lib");
+    });
+
+    it("gives no importable name to a crate with no library", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "just-a-binary"\n',
+        "src/main.rs": "",
+      });
+
+      expect(crates[0]).toMatchObject({ name: null, libRoot: null, roots: ["src/main.rs"] });
+    });
+
+    it("records every target as a root of its own module tree", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "many"\n\n[[bin]]\nname = "declared"\npath = "extra/tool.rs"\n',
+        "src/lib.rs": "",
+        "src/main.rs": "",
+        "src/bin/one.rs": "",
+        "src/bin/two/main.rs": "",
+        "src/bin/two/helper.rs": "",
+        "extra/tool.rs": "",
+        "tests/it.rs": "",
+        "examples/demo.rs": "",
+        "benches/bench.rs": "",
+        "build.rs": "",
+      });
+
+      expect(crates[0].roots).toEqual([
+        "benches/bench.rs",
+        "build.rs",
+        "examples/demo.rs",
+        "extra/tool.rs",
+        "src/bin/one.rs",
+        "src/bin/two/main.rs",
+        "src/lib.rs",
+        "src/main.rs",
+        "tests/it.rs",
+      ]);
+    });
+
+    it("keeps a malformed manifest's conventional targets and gives it no name", () => {
+      const crates = rustProject({
+        "Cargo.toml": "[package\nname = ",
+        "src/lib.rs": "",
+      });
+
+      expect(crates[0]).toMatchObject({ name: null, roots: ["src/lib.rs"] });
+    });
+
+    it("ignores the manifests Cargo unpacks under target/", () => {
+      const crates = rustProject({
+        // DEFAULT_IGNORE_PATTERNS lists `target`, so only a negation reaches
+        // the unconditional skip — and a negation is all it takes for every
+        // vendored dependency to register as a crate of this project.
+        ".socraticodeignore": "!target/\n",
+        "Cargo.toml": '[package]\nname = "real"\n',
+        "src/lib.rs": "",
+        "target/package/vendored-0.1.0/Cargo.toml": '[package]\nname = "vendored"\n',
+        "target/package/vendored-0.1.0/src/lib.rs": "",
+      });
+
+      expect(crates.map((c) => c.name)).toEqual(["real"]);
+    });
+
+    // ── Module paths ───────────────────────────────────────────────────
+
+    it("resolves crate:: against the crate root", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/db/pool.rs": "",
+        "src/db/mod.rs": "",
+      });
+
+      expect(resolveRustImport("crate::db::pool", "src/lib.rs", fileSet, crates))
+        .toBe("src/db/pool.rs");
+    });
+
+    it("stops at the deepest path segment that names a file", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/db.rs": "",
+      });
+
+      // `Connection` is a type inside db.rs, not a module below it.
+      expect(resolveRustImport("crate::db::Connection", "src/lib.rs", fileSet, crates))
+        .toBe("src/db.rs");
+    });
+
+    it("resolves a path naming only root items to the root module", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/other.rs": "",
+      });
+
+      expect(resolveRustImport("crate::Error", "src/other.rs", fileSet, crates))
+        .toBe("src/lib.rs");
+    });
+
+    it("resolves super:: to the parent module's sibling", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/api/routes.rs": "",
+        "src/api/state.rs": "",
+      });
+
+      expect(resolveRustImport("super::state::State", "src/api/routes.rs", fileSet, crates))
+        .toBe("src/api/state.rs");
+    });
+
+    it("climbs one module per super", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/a/b/c.rs": "",
+        "src/a/shared.rs": "",
+      });
+
+      expect(resolveRustImport("super::super::shared", "src/a/b/c.rs", fileSet, crates))
+        .toBe("src/a/shared.rs");
+    });
+
+    it("does not let super:: climb out of the crate", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["crates/app"]\n',
+        "crates/app/Cargo.toml": '[package]\nname = "app"\n',
+        "crates/app/src/lib.rs": "",
+        "crates/app/src/thing.rs": "",
+        // Beside the crate's src/, so an unchecked second climb lands on it.
+        "crates/app/outside.rs": "",
+      });
+
+      // `thing` sits directly under the crate root, so `super` is already the
+      // root and a second climb would leave the module tree entirely.
+      expect(resolveRustImport("super::super::outside", "crates/app/src/thing.rs", fileSet, crates))
+        .toBeNull();
+    });
+
+    it("does not draw an edge from a module file to itself", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/a/mod.rs": "",
+      });
+
+      // `use super::a::Thing;` inside `mod tests` in a/mod.rs walks back down
+      // to the file it started from.
+      expect(resolveRustImport("super::a::Thing", "src/a/mod.rs", fileSet, crates))
+        .toBeNull();
+    });
+
+    it("resolves self:: to a submodule of the importing file", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/parser.rs": "",
+        "src/parser/lexer.rs": "",
+      });
+
+      expect(resolveRustImport("self::lexer::Token", "src/parser.rs", fileSet, crates))
+        .toBe("src/parser/lexer.rs");
+    });
+
+    it("resolves a sibling crate by the name Cargo gives it", () => {
+      const crates = rustProject({
+        "Cargo.toml": "[workspace]\nmembers = [\"crates/cli\", \"crates/core\"]\n",
+        "crates/cli/Cargo.toml": '[package]\nname = "app-cli"\n',
+        "crates/cli/src/main.rs": "",
+        "crates/core/Cargo.toml": '[package]\nname = "app-core"\n',
+        "crates/core/src/lib.rs": "",
+        "crates/core/src/config.rs": "",
+      });
+
+      expect(resolveRustImport("app_core::config::Config", "crates/cli/src/main.rs", fileSet, crates))
+        .toBe("crates/core/src/config.rs");
+    });
+
+    it("leaves a third-party crate unresolved", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/models.rs": "",
+      });
+
+      expect(resolveRustImport("serde::Deserialize", "src/lib.rs", fileSet, crates))
+        .toBeNull();
+    });
+
+    it("resolves a uniform path to a module in scope", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/store.rs": "",
+      });
+
+      // `mod store;` beside `pub use store::Store;` — the 2018 spelling that
+      // omits `self::`, which is how a crate republishes its own modules.
+      expect(resolveRustImport("store::Store", "src/lib.rs", fileSet, crates))
+        .toBe("src/store.rs");
+    });
+
+    it("resolves super:: to the parent module's own file", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/store.rs": "",
+        "src/store/open.rs": "",
+      });
+
+      // The parent of `store::open` is `store`, which lives in store.rs beside
+      // the directory — the layout rustc recommends over store/mod.rs.
+      expect(resolveRustImport("super::Store", "src/store/open.rs", fileSet, crates))
+        .toBe("src/store.rs");
+    });
+
+
+    it("resolves a mod declaration into the declaring file's own directory", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/parser.rs": "",
+        "src/parser/lexer.rs": "",
+        "src/lexer.rs": "",
+      });
+
+      // `mod lexer;` inside src/parser.rs is src/parser/lexer.rs — the file
+      // beside parser.rs is a different module with the same name.
+      expect(resolveRustImport("lexer", "src/parser.rs", fileSet, crates))
+        .toBe("src/parser/lexer.rs");
+    });
+
+    it("resolves a mod declaration in a crate root beside it", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/config.rs": "",
+      });
+
+      expect(resolveRustImport("config", "src/lib.rs", fileSet, crates))
+        .toBe("src/config.rs");
+    });
+
+    it("treats a binary under src/bin as its own crate root", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/helper.rs": "",
+        "src/bin/tool.rs": "",
+        "src/bin/helper.rs": "",
+      });
+
+      // The binary's module tree starts in src/bin, so its `crate::helper` is
+      // src/bin/helper.rs and not the library's src/helper.rs.
+      expect(resolveRustImport("crate::helper", "src/bin/tool.rs", fileSet, crates))
+        .toBe("src/bin/helper.rs");
+    });
+
+    it("prefers the crate whose directory holds the importing file", () => {
+      const crates = rustProject({
+        "workspace-a/Cargo.toml": '[package]\nname = "shared"\n',
+        "workspace-a/src/lib.rs": "",
+        "workspace-a/src/thing.rs": "",
+        "workspace-b/Cargo.toml": '[package]\nname = "shared"\n',
+        "workspace-b/src/lib.rs": "",
+        "workspace-b/src/thing.rs": "",
+        "workspace-b/src/user.rs": "",
+      });
+
+      expect(resolveRustImport("shared::thing", "workspace-b/src/user.rs", fileSet, crates))
+        .toBe("workspace-b/src/thing.rs");
+    });
+
+    it("resolves mod, self and super with no manifest in the tree", () => {
+      project = createTempProject({
+        "src/lib.rs": "",
+        "src/api.rs": "",
+        "src/api/routes.rs": "",
+        "src/api/state.rs": "",
+      });
+
+      expect(resolveRustImport("routes", "src/api.rs", project.fileSet, []))
+        .toBe("src/api/routes.rs");
+      expect(resolveRustImport("super::state", "src/api/routes.rs", project.fileSet, []))
+        .toBe("src/api/state.rs");
+      expect(resolveRustImport("crate::api::state", "src/api/routes.rs", project.fileSet, []))
+        .toBeNull();
+    });
+
+    it("resolves through resolveImport with the crate map passed in", () => {
+      project = createTempProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/config.rs": "",
+      });
+      const crates = buildRustCrateMap(project.fileSet, project.root);
+
+      const result = resolveImport(
+        "crate::config::Config",
+        path.join(project.root, "src/lib.rs"),
+        project.root,
+        project.fileSet,
+        "rust",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        crates,
+      );
+
+      expect(result).toBe("src/config.rs");
     });
   });
 

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -1801,11 +1801,12 @@ describe("graph-resolution", () => {
       expect(crates2018[0].roots).toEqual(["custom/tool.rs", "src/bin/other.rs", "src/lib.rs"]);
     });
 
-    it("excludes manifests matching [workspace.exclude] from being importable by name", () => {
+    it("keeps a member under [workspace] exclude importable by name", () => {
       const crates = rustProject({
         "Cargo.toml":
           '[workspace]\nmembers = ["crates/*"]\nexclude = ["crates/ignored", "crates/fixtures/*"]\n',
-        "crates/app/Cargo.toml": '[package]\nname = "app"\n',
+        "crates/app/Cargo.toml":
+          '[package]\nname = "app"\n\n[dependencies]\nignored-crate = { path = "../ignored" }\n',
         "crates/app/src/lib.rs": "",
         "crates/ignored/Cargo.toml": '[package]\nname = "ignored-crate"\n',
         "crates/ignored/src/lib.rs": "",
@@ -1815,15 +1816,14 @@ describe("graph-resolution", () => {
         "standalone/src/lib.rs": "",
       });
 
-      const appCrate = crates.find((c) => c.dir === "crates/app");
-      const ignoredCrate = crates.find((c) => c.dir === "crates/ignored");
-      const fixtureCrate = crates.find((c) => c.dir === "crates/fixtures/demo");
-      const standaloneCrate = crates.find((c) => c.dir === "standalone");
-
-      expect(appCrate?.name).toBe("app");
-      expect(ignoredCrate?.name).toBeNull();
-      expect(fixtureCrate?.name).toBeNull();
-      expect(standaloneCrate?.name).toBe("standalone");
+      // `exclude` keeps a member out of the default set of workspace-wide
+      // commands; it says nothing about who may depend on it. A member can
+      // and does depend on an excluded package by path — built and compiled
+      // to check — so reading `exclude` as "not importable" loses that edge.
+      expect(crates.find((c) => c.dir === "crates/app")?.name).toBe("app");
+      expect(crates.find((c) => c.dir === "crates/ignored")?.name).toBe("ignored_crate");
+      expect(crates.find((c) => c.dir === "crates/fixtures/demo")?.name).toBe("demo_fixture");
+      expect(crates.find((c) => c.dir === "standalone")?.name).toBe("standalone");
     });
 
     it("records renamed dependency aliases in crate aliases map", () => {
@@ -1897,7 +1897,7 @@ describe("graph-resolution", () => {
       expect(spentaCrate?.name).toBe("spenta");
       expect(spentaCrate?.roots).toEqual(["membri/spenta/src/lib.rs"]);
 
-      expect(fuoriCrate?.name).toBeNull();
+      expect(fuoriCrate?.name).toBe("fuori_dal_giro");
       expect(fuoriCrate?.roots).toEqual(["membri/fuori/src/lib.rs"]);
     });
 

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -2119,10 +2119,51 @@ describe("graph-resolution", () => {
       // cannot do: there the `mod serde;` declaration draws the same edge, so
       // the edge stays whatever the unanchored path resolves to.
       expect(
-        resolveRustImport("serde::Local", "src/lib.rs", fileSet, crates, new Set(["serde"])),
+        resolveRustImport("serde::Local", "src/lib.rs", fileSet, crates, new Map([["serde", "serde"]])),
       ).toBe("src/serde.rs");
       expect(
-        resolveRustImport("serde::Local", "src/lib.rs", fileSet, crates, new Set()),
+        resolveRustImport("serde::Local", "src/lib.rs", fileSet, crates, new Map()),
+      ).toBeNull();
+    });
+
+    it("reaches a module the attribute moved, and its children beside that file", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/foo"]\n',
+        "crates/app/Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        "crates/app/src/lib.rs": "",
+        "crates/app/src/custom.rs": "",
+        "crates/app/src/inner.rs": "",
+        // A library carrying the module's name, which is what the path used to
+        // land on once the name alone found no file.
+        "crates/foo/Cargo.toml": '[package]\nname = "foo"\nedition = "2021"\n',
+        "crates/foo/src/lib.rs": "",
+      });
+
+      // `#[path = "custom.rs"] mod foo;` — the name is `foo`, the file is
+      // `custom.rs`, and the declaration carries both.
+      const declared = new Map([["foo", "custom.rs"]]);
+
+      expect(
+        resolveRustImport("foo::Item", "crates/app/src/lib.rs", fileSet, crates, declared),
+      ).toBe("crates/app/src/custom.rs");
+
+      // The children sit beside that file, not under a directory named after
+      // it: rustc says `src/inner.rs` with E0583, on 1.70.0 and 1.98.0.
+      expect(
+        resolveRustImport("foo::inner::Thing", "crates/app/src/lib.rs", fileSet, crates, declared),
+      ).toBe("crates/app/src/inner.rs");
+
+      // The hand that makes this fail if the declared file is dropped: with
+      // the name alone the path found nothing and fell through to the
+      // same-named library.
+      expect(
+        resolveRustImport(
+          "foo::Item",
+          "crates/app/src/lib.rs",
+          fileSet,
+          crates,
+          new Map([["foo", "foo"]]),
+        ),
       ).toBeNull();
     });
 
@@ -2145,7 +2186,7 @@ describe("graph-resolution", () => {
           "crates/app/src/lib.rs",
           fileSet,
           crates,
-          new Set(["config"]),
+          new Map([["config", "config"]]),
         ),
       ).toBe("crates/config/src/lib.rs");
     });
@@ -2165,13 +2206,21 @@ describe("graph-resolution", () => {
       // 1.98.0. The gate is a 2018 rule: applied here it would drop the edge
       // on every crate whose manifest omits the edition key.
       expect(
-        resolveRustImport("registry::write", "src/client.rs", fileSet, crates, new Set()),
+        resolveRustImport("registry::write", "src/client.rs", fileSet, crates, new Map()),
       ).toBe("src/registry.rs");
       // And a bare head in the same position, which arrives in the shape a
       // declaration does.
-      expect(resolveRustImport("registry", "src/client.rs", fileSet, crates, new Set())).toBe(
-        "src/registry.rs",
-      );
+      // `false` says this is a `use` and not a `mod` declaration: the two
+      // arrive as the same string, and in 2015 they count from different
+      // places — `use foo::Nested;` beside `mod foo;` is E0432 on 1.70.0 and
+      // 1.98.0, while `use foo::AtRoot;` reaches the root's module.
+      expect(
+        resolveRustImport("registry", "src/client.rs", fileSet, crates, new Map(), false),
+      ).toBe("src/registry.rs");
+      // And the declaration in the same position still counts from the file.
+      expect(
+        resolveRustImport("registry", "src/deep.rs", fileSet, crates, new Map(), true),
+      ).toBeNull();
     });
 
     it("leaves a single-segment path on the crate when no declaration names it", () => {
@@ -2190,10 +2239,10 @@ describe("graph-resolution", () => {
       // declaration may reach the file. cargo 1.70.0 and 1.98.0 compile
       // `use bar;` against the dependency with that orphan sitting there.
       expect(
-        resolveRustImport("bar", "crates/app/src/lib.rs", fileSet, crates, new Set()),
+        resolveRustImport("bar", "crates/app/src/lib.rs", fileSet, crates, new Map()),
       ).toBe("crates/bar/src/lib.rs");
       expect(
-        resolveRustImport("bar", "crates/app/src/lib.rs", fileSet, crates, new Set(["bar"])),
+        resolveRustImport("bar", "crates/app/src/lib.rs", fileSet, crates, new Map([["bar", "bar"]])),
       ).toBe("crates/app/src/bar.rs");
     });
 

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -1920,6 +1920,23 @@ describe("graph-resolution", () => {
       expect(resolveRustImport("nowhere/absent.rs", "src/lib.rs", fileSet, crates)).toBeNull();
     });
 
+    it("counts a path attribute inside an inline module from the module directory", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        "src/lib.rs": "",
+        "src/area.rs": "",
+        "src/block/moved.rs": "",
+        "src/area/block/moved.rs": "",
+      });
+
+      // From the crate root the module directory is `src`; from `src/area.rs`
+      // it is `src/area`. Both then take one directory per inline level.
+      expect(resolveRustImport("self/block/moved.rs", "src/lib.rs", fileSet, crates))
+        .toBe("src/block/moved.rs");
+      expect(resolveRustImport("self/block/moved.rs", "src/area.rs", fileSet, crates))
+        .toBe("src/area/block/moved.rs");
+    });
+
     it("reads an unanchored path from the crate root in edition 2015", () => {
       const crates = rustProject({
         "Cargo.toml": '[package]\nname = "app"\n',

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -2167,6 +2167,28 @@ describe("graph-resolution", () => {
       ).toBeNull();
     });
 
+    it("reaches a module an attribute inside an inline block moved", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        "src/lib.rs": "",
+        "src/tests/moved.rs": "",
+      });
+
+      // Written inside `mod tests { #[path = "moved.rs"] mod fixtures; }`, the
+      // attribute counts from the file's own module directory and one level
+      // deeper per inline block — which extractImports marks with a `self/`
+      // head, since nothing in the path itself tells the two forms apart.
+      expect(
+        resolveRustImport(
+          "fixtures::build",
+          "src/lib.rs",
+          fileSet,
+          crates,
+          new Map([["fixtures", "self/tests/moved.rs"]]),
+        ),
+      ).toBe("src/tests/moved.rs");
+    });
+
     it("keeps a leading :: out of the local modules for a bare head too", () => {
       const crates = rustProject({
         "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/config"]\n',

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -2126,6 +2126,30 @@ describe("graph-resolution", () => {
       ).toBeNull();
     });
 
+    it("keeps a leading :: out of the local modules for a bare head too", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/config"]\n',
+        "crates/app/Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        "crates/app/src/lib.rs": "",
+        "crates/app/src/config.rs": "",
+        "crates/config/Cargo.toml": '[package]\nname = "config"\nedition = "2021"\n',
+        "crates/config/src/lib.rs": "",
+      });
+
+      // `use ::config;` beside `mod config;`: the marker says the head names a
+      // crate, and it says it in the one shape where the local module would
+      // otherwise win outright — a head with nothing below it.
+      expect(
+        resolveRustImport(
+          "::config",
+          "crates/app/src/lib.rs",
+          fileSet,
+          crates,
+          new Set(["config"]),
+        ),
+      ).toBe("crates/config/src/lib.rs");
+    });
+
     it("keeps an edition 2015 unanchored path out of the declaration gate", () => {
       const crates = rustProject({
         // No edition key: Cargo reads 2015, and there the path below is

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -1362,12 +1362,18 @@ describe("graph-resolution", () => {
 
     it("records a crate under the name Cargo lets others import it by", () => {
       const crates = rustProject({
-        "Cargo.toml": '[package]\nname = "my-app-core"\n',
+        "Cargo.toml": '[package]\nname = "my-app-core"\nedition = "2021"\n',
         "src/lib.rs": "",
       });
 
       expect(crates).toEqual([
-        { dir: ".", name: "my_app_core", libRoot: "src/lib.rs", roots: ["src/lib.rs"] },
+        {
+          dir: ".",
+          name: "my_app_core",
+          libRoot: "src/lib.rs",
+          roots: ["src/lib.rs"],
+          edition: "2021",
+        },
       ]);
     });
 
@@ -1401,7 +1407,8 @@ describe("graph-resolution", () => {
 
     it("records every target as a root of its own module tree", () => {
       const crates = rustProject({
-        "Cargo.toml": '[package]\nname = "many"\n\n[[bin]]\nname = "declared"\npath = "extra/tool.rs"\n',
+        "Cargo.toml":
+          '[package]\nname = "many"\nedition = "2021"\n\n[[bin]]\nname = "declared"\npath = "extra/tool.rs"\n',
         "src/lib.rs": "",
         "src/main.rs": "",
         "src/bin/one.rs": "",
@@ -1423,6 +1430,35 @@ describe("graph-resolution", () => {
         "src/bin/two/main.rs",
         "src/lib.rs",
         "src/main.rs",
+        "tests/it.rs",
+      ]);
+    });
+
+    it("stops discovering binaries when a 2015 manifest declares one by hand", () => {
+      // Same tree as above with the edition key removed, which is what a 2015
+      // manifest looks like. `cargo metadata` on it reports six targets, not
+      // nine: declaring a `[[bin]]` by hand turns off the autodiscovery of the
+      // rest in that edition, and `src/main.rs` is one of the rest.
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "many"\n\n[[bin]]\nname = "declared"\npath = "extra/tool.rs"\n',
+        "src/lib.rs": "",
+        "src/main.rs": "",
+        "src/bin/one.rs": "",
+        "src/bin/two/main.rs": "",
+        "extra/tool.rs": "",
+        "tests/it.rs": "",
+        "examples/demo.rs": "",
+        "benches/bench.rs": "",
+        "build.rs": "",
+      });
+
+      expect(crates[0].edition).toBe("2015");
+      expect(crates[0].roots).toEqual([
+        "benches/bench.rs",
+        "build.rs",
+        "examples/demo.rs",
+        "extra/tool.rs",
+        "src/lib.rs",
         "tests/it.rs",
       ]);
     });
@@ -1703,6 +1739,255 @@ describe("graph-resolution", () => {
       );
 
       expect(result).toBe("src/config.rs");
+    });
+
+    it("disables target autodiscovery when autobins, autotests, autoexamples, or autobenches is false", () => {
+      const crates = rustProject({
+        "Cargo.toml":
+          '[package]\nname = "spenta"\nautobins = false\nautotests = false\nautoexamples = false\nautobenches = false\n',
+        "src/lib.rs": "",
+        "src/bin/tool.rs": "",
+        "tests/integration.rs": "",
+        "examples/demo.rs": "",
+        "benches/bench.rs": "",
+      });
+
+      expect(crates[0].roots).toEqual(["src/lib.rs"]);
+    });
+
+    it("disables library autodiscovery when autolib is false", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "no-lib"\nautolib = false\n',
+        "src/lib.rs": "",
+        "src/main.rs": "",
+      });
+
+      expect(crates[0]).toMatchObject({
+        name: null,
+        libRoot: null,
+        roots: ["src/main.rs"],
+      });
+    });
+
+    it("does not register build.rs when package build is false", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "no-build"\nbuild = false\n',
+        "src/lib.rs": "",
+        "build.rs": "",
+      });
+
+      expect(crates[0].roots).toEqual(["src/lib.rs"]);
+    });
+
+    it("shuts off autodiscovery for declared target types in edition 2015 but keeps it in 2018+", () => {
+      const crates2015 = rustProject({
+        "Cargo.toml":
+          '[package]\nname = "e2015"\nedition = "2015"\n\n[[bin]]\nname = "explicit"\npath = "custom/tool.rs"\n',
+        "src/lib.rs": "",
+        "custom/tool.rs": "",
+        "src/bin/other.rs": "",
+      });
+      // In 2015, manual [[bin]] turns off autobins by default
+      expect(crates2015[0].roots).toEqual(["custom/tool.rs", "src/lib.rs"]);
+
+      const crates2018 = rustProject({
+        "Cargo.toml":
+          '[package]\nname = "e2018"\nedition = "2018"\n\n[[bin]]\nname = "explicit"\npath = "custom/tool.rs"\n',
+        "src/lib.rs": "",
+        "custom/tool.rs": "",
+        "src/bin/other.rs": "",
+      });
+      // In 2018+, manual [[bin]] leaves autodiscovery on
+      expect(crates2018[0].roots).toEqual(["custom/tool.rs", "src/bin/other.rs", "src/lib.rs"]);
+    });
+
+    it("excludes manifests matching [workspace.exclude] from being importable by name", () => {
+      const crates = rustProject({
+        "Cargo.toml":
+          '[workspace]\nmembers = ["crates/*"]\nexclude = ["crates/ignored", "crates/fixtures/*"]\n',
+        "crates/app/Cargo.toml": '[package]\nname = "app"\n',
+        "crates/app/src/lib.rs": "",
+        "crates/ignored/Cargo.toml": '[package]\nname = "ignored-crate"\n',
+        "crates/ignored/src/lib.rs": "",
+        "crates/fixtures/demo/Cargo.toml": '[package]\nname = "demo-fixture"\n',
+        "crates/fixtures/demo/src/lib.rs": "",
+        "standalone/Cargo.toml": '[package]\nname = "standalone"\n',
+        "standalone/src/lib.rs": "",
+      });
+
+      const appCrate = crates.find((c) => c.dir === "crates/app");
+      const ignoredCrate = crates.find((c) => c.dir === "crates/ignored");
+      const fixtureCrate = crates.find((c) => c.dir === "crates/fixtures/demo");
+      const standaloneCrate = crates.find((c) => c.dir === "standalone");
+
+      expect(appCrate?.name).toBe("app");
+      expect(ignoredCrate?.name).toBeNull();
+      expect(fixtureCrate?.name).toBeNull();
+      expect(standaloneCrate?.name).toBe("standalone");
+    });
+
+    it("records renamed dependency aliases in crate aliases map", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["crates/*"]\n',
+        "crates/core/Cargo.toml": '[package]\nname = "app-core"\n',
+        "crates/core/src/lib.rs": "",
+        "crates/app/Cargo.toml":
+          '[package]\nname = "app"\n\n[dependencies]\nmy_alias = { package = "app-core", path = "../core" }\n',
+        "crates/app/src/lib.rs": "",
+      });
+
+      const appCrate = crates.find((c) => c.dir === "crates/app");
+      expect(appCrate?.aliases).toEqual({
+        my_alias: "app_core",
+      });
+    });
+
+    it("resolves workspace dependency aliases defined in [workspace.dependencies]", () => {
+      const crates = rustProject({
+        "Cargo.toml":
+          '[workspace]\nmembers = ["crates/*"]\n\n[workspace.dependencies]\nshared-alias = { package = "actual-core", path = "crates/core" }\n',
+        "crates/core/Cargo.toml": '[package]\nname = "actual-core"\n',
+        "crates/core/src/lib.rs": "",
+        "crates/app/Cargo.toml":
+          '[package]\nname = "app"\n\n[dependencies]\nshared-alias = { workspace = true }\n',
+        "crates/app/src/lib.rs": "",
+      });
+
+      const appCrate = crates.find((c) => c.dir === "crates/app");
+      expect(appCrate?.aliases).toEqual({
+        shared_alias: "actual_core",
+      });
+    });
+
+    it("skips custom build directories marked with CACHEDIR.TAG or .cargo-ok", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "my-app"\n',
+        "src/lib.rs": "",
+        "custom-target/CACHEDIR.TAG": "Signature: 8a477f597d28d172783f06886806bc55\n",
+        "custom-target/vendored/Cargo.toml": '[package]\nname = "vendored"\n',
+        "custom-target/vendored/src/lib.rs": "",
+      });
+
+      expect(crates.map((c) => c.name)).toEqual(["my_app"]);
+    });
+
+    it("correctly resolves the benchmark workspace with disabled autodiscovery and excluded member", () => {
+      const crates = rustProject({
+        "Cargo.toml":
+          '[workspace]\nmembers = ["membri/*"]\nexclude = ["membri/fuori"]\n',
+        "membri/app/Cargo.toml": '[package]\nname = "app"\n',
+        "membri/app/src/lib.rs": "",
+        "membri/spenta/Cargo.toml":
+          '[package]\nname = "spenta"\nautobins = false\nautotests = false\nautoexamples = false\n',
+        "membri/spenta/src/lib.rs": "",
+        "membri/spenta/src/bin/ignorato.rs": "",
+        "membri/spenta/tests/ignorato.rs": "",
+        "membri/spenta/examples/ignorato.rs": "",
+        "membri/fuori/Cargo.toml": '[package]\nname = "fuori-dal-giro"\n',
+        "membri/fuori/src/lib.rs": "",
+      });
+
+      const appCrate = crates.find((c) => c.dir === "membri/app");
+      const spentaCrate = crates.find((c) => c.dir === "membri/spenta");
+      const fuoriCrate = crates.find((c) => c.dir === "membri/fuori");
+
+      expect(appCrate?.name).toBe("app");
+      expect(appCrate?.roots).toEqual(["membri/app/src/lib.rs"]);
+
+      expect(spentaCrate?.name).toBe("spenta");
+      expect(spentaCrate?.roots).toEqual(["membri/spenta/src/lib.rs"]);
+
+      expect(fuoriCrate?.name).toBeNull();
+      expect(fuoriCrate?.roots).toEqual(["membri/fuori/src/lib.rs"]);
+    });
+
+    // ── Paths the conventions do not reach ─────────────────────────────
+
+    it("takes the file of a mod from the path its attribute declares", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        "src/lib.rs": "",
+        "src/area.rs": "",
+        "src/elsewhere/moved.rs": "",
+      });
+
+      // The attribute is relative to the directory the declaring file sits in,
+      // never to the directory that file's own submodules live in.
+      expect(resolveRustImport("elsewhere/moved.rs", "src/area.rs", fileSet, crates))
+        .toBe("src/elsewhere/moved.rs");
+      expect(resolveRustImport("elsewhere/moved.rs", "src/lib.rs", fileSet, crates))
+        .toBe("src/elsewhere/moved.rs");
+      expect(resolveRustImport("nowhere/absent.rs", "src/lib.rs", fileSet, crates)).toBeNull();
+    });
+
+    it("reads an unanchored path from the crate root in edition 2015", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/registry.rs": "",
+        "src/client.rs": "",
+      });
+
+      // `use registry::write;` in `src/client.rs` compiles in 2015 and names
+      // `src/registry.rs`; rustc rejects the same line from 2018 on.
+      expect(resolveRustImport("registry::write", "src/client.rs", fileSet, crates))
+        .toBe("src/registry.rs");
+    });
+
+    it("reads an unanchored path from the module itself from edition 2018 on", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        "src/lib.rs": "",
+        "src/registry.rs": "",
+        "src/client.rs": "",
+      });
+
+      expect(resolveRustImport("registry::write", "src/client.rs", fileSet, crates)).toBeNull();
+    });
+
+    it("lets a local module win over a sibling crate of the same name", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/config"]\n',
+        "crates/app/Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        "crates/app/src/lib.rs": "",
+        "crates/app/src/config.rs": "",
+        "crates/config/Cargo.toml": '[package]\nname = "config"\nedition = "2021"\n',
+        "crates/config/src/lib.rs": "",
+      });
+
+      // rustc consults the extern prelude last, so a module in scope wins. The
+      // other order drew an edge into an unrelated crate whenever a local
+      // module carried a published crate's name.
+      expect(resolveRustImport("config::Settings", "crates/app/src/lib.rs", fileSet, crates))
+        .toBe("crates/app/src/config.rs");
+    });
+
+    it("follows a dependency renamed in the manifest to the crate it points at", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/core"]\n',
+        "crates/app/Cargo.toml":
+          '[package]\nname = "app"\nedition = "2021"\n\n[dependencies]\nnucleus = { package = "app-core", path = "../core" }\n',
+        "crates/app/src/lib.rs": "",
+        "crates/core/Cargo.toml": '[package]\nname = "app-core"\nedition = "2021"\n',
+        "crates/core/src/lib.rs": "",
+        "crates/core/src/state.rs": "",
+      });
+
+      // The code writes the alias, which appears in no `[package] name`.
+      expect(resolveRustImport("nucleus::state::State", "crates/app/src/lib.rs", fileSet, crates))
+        .toBe("crates/core/src/state.rs");
+    });
+
+    it("never resolves a path to the file that wrote it", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        "src/lib.rs": "",
+        "src/db.rs": "",
+      });
+
+      // `use crate::db::Connection;` inside `#[cfg(test)] mod tests` in db.rs
+      // names that same file; as an edge it is a node depending on itself.
+      expect(resolveRustImport("crate::db::Connection", "src/db.rs", fileSet, crates)).toBeNull();
     });
   });
 

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -1979,6 +1979,23 @@ describe("graph-resolution", () => {
         .toBe("crates/app/src/config.rs");
     });
 
+    it("keeps a leading :: out of the local modules", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/config"]\n',
+        "crates/app/Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        "crates/app/src/lib.rs": "",
+        "crates/app/src/config.rs": "",
+        "crates/config/Cargo.toml": '[package]\nname = "config"\nedition = "2021"\n',
+        "crates/config/src/lib.rs": "",
+      });
+
+      // Without the marker this is the same path as `config::Settings`, which
+      // the local module answers — and the leading `::` is written precisely
+      // to say it should not.
+      expect(resolveRustImport("::config::Settings", "crates/app/src/lib.rs", fileSet, crates))
+        .toBe("crates/config/src/lib.rs");
+    });
+
     it("follows a dependency renamed in the manifest to the crate it points at", () => {
       const crates = rustProject({
         "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/core"]\n',

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -1377,6 +1377,57 @@ describe("graph-resolution", () => {
       ]);
     });
 
+    it("inherits the edition a workspace declares for its members", () => {
+      // `edition.workspace = true` is a table, not a string, so reading the
+      // key as a plain string dropped the member to 2015 — and 2015 turns
+      // autodiscovery off next to a declared `[[bin]]`, so `due.rs` stopped
+      // being a crate root at all. Cargo 1.70, 1.85 and 1.98 all keep it.
+      const crates = rustProject({
+        "Cargo.toml":
+          '[workspace]\nmembers = ["app"]\n\n[workspace.package]\nedition = "2021"\n',
+        "app/Cargo.toml":
+          '[package]\nname = "app"\nedition.workspace = true\n\n[[bin]]\nname = "uno"\npath = "src/bin/uno.rs"\n',
+        "app/src/lib.rs": "",
+        "app/src/bin/uno.rs": "",
+        "app/src/bin/due.rs": "",
+      });
+
+      const member = crates.find((crate) => crate.dir === "app");
+      expect(member?.edition).toBe("2021");
+      expect(member?.roots).toContain("app/src/bin/due.rs");
+    });
+
+    it("keeps a member that asks for no edition on the 2015 rules", () => {
+      // The other hand of the test above: inheritance happens only when the
+      // member spells it out. With the key absent, Cargo reads 2015 — and
+      // then the declared `[[bin]]` does turn autodiscovery off, which is
+      // what makes the assertion above mean something.
+      const crates = rustProject({
+        "Cargo.toml":
+          '[workspace]\nmembers = ["app"]\n\n[workspace.package]\nedition = "2021"\n',
+        "app/Cargo.toml":
+          '[package]\nname = "app"\n\n[[bin]]\nname = "uno"\npath = "src/bin/uno.rs"\n',
+        "app/src/lib.rs": "",
+        "app/src/bin/uno.rs": "",
+        "app/src/bin/due.rs": "",
+      });
+
+      const member = crates.find((crate) => crate.dir === "app");
+      expect(member?.edition).toBe("2015");
+      expect(member?.roots).not.toContain("app/src/bin/due.rs");
+    });
+
+    it("keeps a member's own edition over the one the workspace declares", () => {
+      const crates = rustProject({
+        "Cargo.toml":
+          '[workspace]\nmembers = ["app"]\n\n[workspace.package]\nedition = "2021"\n',
+        "app/Cargo.toml": '[package]\nname = "app"\nedition = "2015"\n',
+        "app/src/lib.rs": "",
+      });
+
+      expect(crates.find((crate) => crate.dir === "app")?.edition).toBe("2015");
+    });
+
     it("takes the library path a manifest declares over the conventional one", () => {
       const crates = rustProject({
         "Cargo.toml": '[package]\nname = "odd"\n\n[lib]\npath = "lib/entry.rs"\n',
@@ -1681,6 +1732,25 @@ describe("graph-resolution", () => {
       // src/bin/helper.rs and not the library's src/helper.rs.
       expect(resolveRustImport("crate::helper", "src/bin/tool.rs", fileSet, crates))
         .toBe("src/bin/helper.rs");
+    });
+
+    it("does not let a root's directory capture a file whose name merely begins with it", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/helper.rs": "",
+        "src/bin/tool.rs": "",
+        "src/bindings.rs": "",
+      });
+
+      // `src/bindings.rs` belongs to the library. Its path begins with the
+      // string "src/bin", but not with the directory "src/bin/" — comparing
+      // the prefix without the separator hands the file the binary's root,
+      // and `crate::helper` then looks for `src/bin/helper.rs`, which is not
+      // the file the library declares. The guard is one character wide, so
+      // nothing else in the suite fails when it is removed.
+      expect(resolveRustImport("crate::helper", "src/bindings.rs", fileSet, crates))
+        .toBe("src/helper.rs");
     });
 
     it("prefers the crate whose directory holds the importing file", () => {

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -2126,6 +2126,30 @@ describe("graph-resolution", () => {
       ).toBeNull();
     });
 
+    it("keeps an edition 2015 unanchored path out of the declaration gate", () => {
+      const crates = rustProject({
+        // No edition key: Cargo reads 2015, and there the path below is
+        // absolute from the crate root.
+        "Cargo.toml": '[package]\nname = "app"\n',
+        "src/lib.rs": "",
+        "src/registry.rs": "",
+        "src/client.rs": "",
+      });
+
+      // `mod registry;` is written in lib.rs; client.rs declares nothing at
+      // all, and `use registry::write;` compiles there on cargo 1.70.0 and
+      // 1.98.0. The gate is a 2018 rule: applied here it would drop the edge
+      // on every crate whose manifest omits the edition key.
+      expect(
+        resolveRustImport("registry::write", "src/client.rs", fileSet, crates, new Set()),
+      ).toBe("src/registry.rs");
+      // And a bare head in the same position, which arrives in the shape a
+      // declaration does.
+      expect(resolveRustImport("registry", "src/client.rs", fileSet, crates, new Set())).toBe(
+        "src/registry.rs",
+      );
+    });
+
     it("leaves a single-segment path on the crate when no declaration names it", () => {
       const crates = rustProject({
         "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/bar"]\n',

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -2108,6 +2108,25 @@ describe("graph-resolution", () => {
         .toBe("crates/config/src/lib.rs");
     });
 
+    it("reads a leading :: as the crate root in edition 2015", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/config"]\n',
+        "crates/app/Cargo.toml": '[package]\nname = "app"\nedition = "2015"\n',
+        "crates/app/src/lib.rs": "",
+        "crates/app/src/config.rs": "",
+        "crates/config/Cargo.toml": '[package]\nname = "config"\nedition = "2021"\n',
+        "crates/config/src/lib.rs": "",
+      });
+
+      // The same specifier, one edition earlier, means the opposite thing:
+      // there is no extern prelude to point at, and `::` is the crate root an
+      // unanchored path already counts from. Checked on 1.98.0, where a crate
+      // with `pub mod log;` and `use ::log::LocalMarker;` compiles under 2015
+      // and is E0432 under 2018.
+      expect(resolveRustImport("::config::Settings", "crates/app/src/lib.rs", fileSet, crates))
+        .toBe("crates/app/src/config.rs");
+    });
+
     it("lets an unanchored path reach a module the file declares, and only then", () => {
       const crates = rustProject({
         "Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n\n[dependencies]\nserde = "1"\n',

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -2189,6 +2189,28 @@ describe("graph-resolution", () => {
       ).toBe("src/tests/moved.rs");
     });
 
+    it("does not read a file whose name begins with self as the inline form", () => {
+      const crates = rustProject({
+        "Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        "src/lib.rs": "",
+        "src/self_check.rs": "",
+      });
+
+      // `#[path = "self_check.rs"] mod checks;` is the ordinary form: the
+      // marker for the inline one is the `self/` head, separator included.
+      // Matching on `self` alone cut five characters off this path and looked
+      // for `heck.rs`.
+      expect(
+        resolveRustImport(
+          "checks::run",
+          "src/lib.rs",
+          fileSet,
+          crates,
+          new Map([["checks", "self_check.rs"]]),
+        ),
+      ).toBe("src/self_check.rs");
+    });
+
     it("keeps a leading :: out of the local modules for a bare head too", () => {
       const crates = rustProject({
         "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/config"]\n',

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -1643,7 +1643,9 @@ describe("graph-resolution", () => {
     it("resolves a sibling crate by the name Cargo gives it", () => {
       const crates = rustProject({
         "Cargo.toml": "[workspace]\nmembers = [\"crates/cli\", \"crates/core\"]\n",
-        "crates/cli/Cargo.toml": '[package]\nname = "app-cli"\n',
+        // Declared, as rustc requires: a sibling the manifest never names is
+        // not in the extern prelude, whatever the workspace holds.
+        "crates/cli/Cargo.toml": '[package]\nname = "app-cli"\n\n[dependencies]\napp-core = { path = "../core" }\n',
         "crates/cli/src/main.rs": "",
         "crates/core/Cargo.toml": '[package]\nname = "app-core"\n',
         "crates/core/src/lib.rs": "",
@@ -1652,6 +1654,32 @@ describe("graph-resolution", () => {
 
       expect(resolveRustImport("app_core::config::Config", "crates/cli/src/main.rs", fileSet, crates))
         .toBe("crates/core/src/config.rs");
+    });
+
+    it("does not reach a sibling crate the importing package never declared", () => {
+      // Review finding. Only what a package declares is in its extern prelude:
+      // `use helper::Thing` in a package whose manifest names no `helper` is
+      // E0432 to rustc, yet the raw name used to be searched across every crate
+      // of the workspace and drew an edge into the sibling. Declared under
+      // another name, the alias is what the code writes; the package's own
+      // library is the one name reached without declaring it.
+      const crates = rustProject({
+        "Cargo.toml": '[workspace]\nmembers = ["app", "helper", "util"]\n',
+        "app/Cargo.toml": '[package]\nname = "app"\n\n[dependencies]\nutil = { path = "../util" }\ntools = { path = "../helper", package = "helper" }\n',
+        "app/src/lib.rs": "",
+        "app/src/bin/tool.rs": "",
+        "helper/Cargo.toml": '[package]\nname = "helper"\n',
+        "helper/src/lib.rs": "",
+        "util/Cargo.toml": '[package]\nname = "util"\n',
+        "util/src/lib.rs": "",
+        // `util` declares nothing, so `helper` is out of its reach too.
+      });
+
+      expect(resolveRustImport("helper::Thing", "app/src/lib.rs", fileSet, crates)).toBeNull();
+      expect(resolveRustImport("helper::Thing", "util/src/lib.rs", fileSet, crates)).toBeNull();
+      expect(resolveRustImport("tools::Thing", "app/src/lib.rs", fileSet, crates)).toBe("helper/src/lib.rs");
+      expect(resolveRustImport("util::Thing", "app/src/lib.rs", fileSet, crates)).toBe("util/src/lib.rs");
+      expect(resolveRustImport("app::run", "app/src/bin/tool.rs", fileSet, crates)).toBe("app/src/lib.rs");
     });
 
     it("leaves a third-party crate unresolved", () => {
@@ -2084,7 +2112,8 @@ describe("graph-resolution", () => {
     it("lets a local module win over a sibling crate of the same name", () => {
       const crates = rustProject({
         "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/config"]\n',
-        "crates/app/Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        // Declared, as rustc requires for the sibling to be in scope at all.
+        "crates/app/Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n\n[dependencies]\nconfig = { path = "../config" }\n',
         "crates/app/src/lib.rs": "",
         "crates/app/src/config.rs": "",
         "crates/config/Cargo.toml": '[package]\nname = "config"\nedition = "2021"\n',
@@ -2101,7 +2130,8 @@ describe("graph-resolution", () => {
     it("keeps a leading :: out of the local modules", () => {
       const crates = rustProject({
         "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/config"]\n',
-        "crates/app/Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        // Declared, as rustc requires for the sibling to be in scope at all.
+        "crates/app/Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n\n[dependencies]\nconfig = { path = "../config" }\n',
         "crates/app/src/lib.rs": "",
         "crates/app/src/config.rs": "",
         "crates/config/Cargo.toml": '[package]\nname = "config"\nedition = "2021"\n',
@@ -2240,7 +2270,8 @@ describe("graph-resolution", () => {
     it("keeps a leading :: out of the local modules for a bare head too", () => {
       const crates = rustProject({
         "Cargo.toml": '[workspace]\nmembers = ["crates/app", "crates/config"]\n',
-        "crates/app/Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n',
+        // Declared, as rustc requires for the sibling to be in scope at all.
+        "crates/app/Cargo.toml": '[package]\nname = "app"\nedition = "2021"\n\n[dependencies]\nconfig = { path = "../config" }\n',
         "crates/app/src/lib.rs": "",
         "crates/app/src/config.rs": "",
         "crates/config/Cargo.toml": '[package]\nname = "config"\nedition = "2021"\n',


### PR DESCRIPTION
## Summary

On Rust projects the file graph is the list of a crate's private modules and nothing else. Two causes combine:

- `graph-imports.ts` extracts module declarations with `/^mod\s+(\w+)\s*;/`, which no `pub mod` matches, and `use` declarations with `/^use\s+/`, which no `pub use` matches. Neither reaches the resolver.
- `graph-resolution.ts`, `case "rust"`: only specifiers **without** `::` resolve. Every `use crate::…`, `super::…`, `self::…` and `other_crate::…` hits `return null`.

Rust was the only language marked Full Support with no manifest-derived name map — Go reads `go.mod`, PHP `composer.json`, Dart `pubspec.yaml`, Python `pyproject.toml` since #112. Rust has `Cargo.toml`, which nothing read.

The second commit closes the gap the first one left: **a Rust path means what it means from the point in the source that writes it**, and four things a file says about its own position were still being read off the file instead — an inline `mod` block, a `#[path]` attribute, a raw identifier, and the edition the manifest declares.

## Changes

### Reading the manifest (first commit)

- `buildRustCrateMap` records every crate the tree declares: its importable name (`[lib] name` or `[package] name`, dashes turned into underscores, as Cargo does), its library root, and every target that is the top of its own module tree — library, binaries, integration tests, examples, benches, build script — declared in the manifest or autodiscovered the way Cargo does. Discovery walks the filesystem with the graphable walk's ignore filter (`Cargo.toml` is never in `fileSet` — the #82 trap) and skips `target/`, where Cargo unpacks a manifest for every dependency it builds. The manifest is parsed with `smol-toml`, already in the tree from #112.
- `resolveRustImport` resolves `crate::` against the file's own crate root, `super::` and `self::` against its position in the module tree, and a leading segment naming a crate in this project against that crate's library root. Trailing segments name items, not modules, so the longest prefix that names a file wins.
- The module-declaration and `use` regexes accept a visibility modifier, and a `use` tree is flattened into one path per leaf.

Two Rust layout rules the old resolver got wrong are now honoured. `mod bar;` inside `src/foo.rs` is `src/foo/bar.rs`, not `src/bar.rs` — a crate root and a `mod.rs` own the directory they sit in, every other file owns the directory named after it. And a binary at `src/bin/tool.rs` is its own crate root.

### Reading the position the source writes from (second commit)

- **An inline `mod` block is a module level the filesystem does not show.** `#[cfg(test)] mod tests { use super::*; }` sits in a large share of all Rust files, and every `super::` inside it was counted one level too high. `extractImports` now walks the chain of enclosing `mod` blocks and rebases the path: a `super::` inside one inline level names the file itself, which is no edge, and it takes one more to leave the file. A `mod` declared inside `mod outer { … }` lands under `outer/`, which is where rustc looks.
- **`#[path = "…"]`** is read off the attribute preceding the declaration and travels as the path it names. The two forms count from different places, which is the part that is easy to get wrong: a declared module resolves it against the directory the declaring file sits in, while one written inside an inline `mod` resolves it against that file's own module directory, one directory deeper per inline level. Both were checked against rustc.
- **A raw identifier names the module it escapes**: `mod r#async;` declares `async`, whose file is `async.rs`. Left alone, `crate::r#async::poll` resolved to nothing and fell back to the crate root.
- **`extern crate serde;`** is extracted. The crate it names cannot collide with a local module of the same name — rustc rejects that — so the bare name resolves the way a `mod` declaration does.
- **Three markers a `use` writes are kept.** Comments inside a `use` tree no longer become path segments, nor do they end the walk to a `#[path]` attribute above the `mod` it belongs to. A group leaf renamed with `as` is the same leaf — comparing it before removing the alias dropped `use crate::config::{self as cfg};` whole. And a leading `::` says the head names a crate rather than a module in scope, which matters precisely because a local module now wins otherwise.
- **A dependency renamed in the manifest** (`dep = { package = "real-name" }`) is followed. `RustCrate` gains `aliases`, read from `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]`, `[target.*.dependencies]` and `[workspace.dependencies]` via `workspace = true`. The same crate answers to different names in two members of one workspace, so the map is consulted from the importing package.
- **Target autodiscovery is turned off from the manifest**: `autobins`, `autotests`, `autoexamples`, `autobenches`, `autolib`, and `build = false`. `RustCrate` gains `edition`, defaulting to `"2015"` when the key is absent as Cargo does — and in 2015 declaring one target by hand stops the discovery of the rest of its kind.
- **A build directory under another name** (`CARGO_TARGET_DIR`) is recognised by the markers Cargo writes into it (`CACHEDIR.TAG`, `.cargo-ok`) rather than by the name `target`. The comment that promised this defence now matches the code.

Two orderings now follow rustc rather than convenience (an earlier draft listed a third here, the unanchored 2015 path; later rounds turned it off and it is a known limit below):

- **A module in scope wins over a crate of the same name.** The extern prelude is consulted last. Reading the crate names first drew an edge into an unrelated sibling crate whenever a local module carried a published crate's name — `config`, `log` and `utils` are both.
- **A path that names the file it was written in is not an edge.** `use crate::db::Connection;` inside `#[cfg(test)] mod tests` in `db.rs` names that same file.

`rustRootForFile` is memoised per crate map: it answers the same for every import in a file, and a hundred-crate workspace asked it a hundred and twenty thousand times.

### What the review rounds added

- **A macro body is read where rustc reads it.** `cfg_if! { … mod unix; … }` and the `macro_rules!` wrappers tokio, libc and clap write around their module declarations hid every module they declare — of the 487 files under tokio's `src/` that are not a crate root, 323 had no edge into them on `main`; none has now. The invocation's head and braces are blanked so the body parses in place, and the pass is kept only while every parse error sits inside a macro that was unwrapped: recovery that reaches past the macro (which is what happens to a body inside an inline `mod`) drops the pass, first for that body, then for the file. The shape is pinned by the cargo-oracle test below, with `compile_error!` files where a spilled declaration would land.
- **The manifest is read the way Cargo reads it**: `[workspace.dependencies]` inherited by members, `[patch]` and `[replace]` redirecting a registry name to a project crate, a renamed dependency, a dash-named one imported under its underscore, and the edition a workspace declares — each checked against `cargo metadata`.
- **A leading `::`** is read by the edition that wrote it, and **`include!("…")`** draws an edge, since the file it names is compiled into this one.
- **The cargo-oracle test runs in CI** (`rust-graph-vs-cargo` job, needs a toolchain), rather than counting as coverage only where a toolchain happens to exist.
- **A package reaches only the crates it declares.** `use helper::Thing` in a package whose manifest names no `helper` is E0432 to rustc, yet the raw name used to be searched across every crate of the workspace and drew an edge into the undeclared sibling. The fence is what the manifest declares, admitted under the name rustc knows the crate by: a renamed alias, or the *library* name of a crate declared under its package name (`other = { path = … }` with `[lib] name = "otherlib"` is imported as `otherlib`). The package's own library is the one name reached without declaring it; a package whose manifest cannot be parsed is not fenced. Cargo-verified in a workspace whose undeclared sibling carries a `compile_error!` and whose declared one sets a `[lib] name`.
- **The manifest that governs a file is the innermost one containing it**, and the root's `"."` is the empty prefix rather than a one-character directory. Measured by length it tied with every member directory of one character and won the tie, so every file of `a/` was governed by the workspace root: with a `[workspace]`-only root that declares no dependency and no edition, `a`'s path dependencies went unreachable and its 2021 files were read as 2015 — which turned `use ::bb::Thing;` into an edge to `a`'s own `bb` module. Cargo-verified in a workspace with a one-letter member and a second package nested inside it, because depth decides two orderings and not one: root against member, and a member against the one nested in it. Ranking by raw length turns both halves of the first red; answering "0 for the root, 1 for everything else" turns the second red.
- **In edition 2015 a leading `::` is answered from the crate root**, never from the importing file's own declarations: a child's `#[path] mod foo;` used to capture `use ::foo::Item` that names the root's `foo`. A name at the root is a module of the root, else a crate the package declares (a registry crate resolves to nothing), else an item of the root — the root file, unless rustc provides the name itself. Cargo-verified with a child whose local `foo` defines no `Item`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test coverage improvement

## Testing

Measured against the **real `buildCodeGraph`**, on two Rust trees, at all three states:

| | `main` | first commit | now |
|---|---|---|---|
| A — 88 `.rs` files, 11-crate Cargo workspace | 34 edges | 680 | **701** |
| B — 149 `.rs` files, 10-crate Cargo workspace | 64 edges | 621 | **619** |

The second commit moves few edges, and that is the point: it removes the wrong ones and adds the right ones. On tree A, **six false edges go and fifteen true ones arrive** — every one of the six came from a `super::` written inside `#[cfg(test)] mod tests`, landing at the parent module the source never imports and closing a cycle with the `mod` declaration pointing the other way. The fifteen are the test-support modules those blocks really import, two levels up. Each was checked against the source: `entry.rs` writes `use super::super::test_support::{…}` inside its test block, and `flows.rs` declares `mod test_support;`. On tree B the edge set is unchanged and two redundant specifiers stop resolving.

**The crate map is checked against `cargo metadata --no-deps`**, which is the only authority on what a project's targets are. On both real workspaces and on a tree built to hold every awkward declaration — `[lib] name` different from the package, every target path declared by hand, a build script renamed, autodiscovery off, a proc-macro crate, a renamed dependency, edition 2015 — the targets and importable names agree **exactly**: 26/26, 15/15, 8/8.

Where the layout rules were in doubt, **rustc decided, not us**: each case was built as a crate with the file in one candidate position, and `cargo check` said which one compiles. That is how four things were settled — a binary in `src/bin/` owns the directory it sits in (so a module of `src/bin/tool.rs` is `src/bin/helper.rs`, not `src/bin/tool/helper.rs`); `#[path]` on a declared module is relative to the declaring file's own directory, while inside an inline block it is not; a module declared inside an inline `mod` lands under it; and a member under `[workspace] exclude` is still importable by a member that depends on it by path — which is why an earlier attempt to treat `exclude` as "not importable" was withdrawn rather than kept. It also corrected a test on this branch that asserted nine targets where Cargo reports six.

Every new guard is mutation-tested: **seventeen mutations, seventeen red batteries**. The one test the first commit left green on a vacuous assertion (`every(e => e.target.endsWith(".rs"))`, true on an empty set) now asserts the edges leaving the file that imports a third-party crate, and fails when the inline-module walk is disabled.

On three public trees against `main` at `3d99883`, edge lists sorted and diffed line by line — not counts:

| | `main` | this branch | this branch, distinct pairs |
|---|---|---|---|
| ripgrep | 76 | **612** | 261 |
| tokio | 167 | **3,922** | 2,210 |
| clap | 78 | **1,196** | 507 |

The third column is there because the first two count edge *records*, and a Rust `use` tree yields one per leaf — see the known limit on it below. `main` has no duplicates to speak of because almost nothing resolved.

The only edges `main` draws that this branch does not are four that pointed at a sibling where rustc reads the child. Python, TypeScript, JavaScript and Go trees come out identical edge for edge. Building tokio's graph costs 1,286 → 2,096 ms (nine paired runs, median), which is the price of reading the modules the macros declare.

**Cargo is the oracle** in `tests/integration/rust-graph-vs-cargo.test.ts`: a fixture crate is built, its dep-info (`target/debug/deps/*.d`) lists what rustc compiled, and every edge the graph draws must land on that list — files that must *not* be read carry `compile_error!`, so a wrong edge is one a clean build proves false. It runs in CI when a toolchain is present.

- [x] Unit tests pass (`npm run test:unit`) — **1,608 passed**, 4 skipped, on macOS and in `node:18`, `node:20` and `node:22` containers
- [x] Integration tests pass (`npm run test:integration`) — full suite **1,818 passed** with Ollama, cargo-oracle test included
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Lint clean (`npm run lint`)
- [x] New tests added for new/changed functionality

## Known limits

- A path with a bare head written inside an inline module is rebased onto that module only when the block declares a module by that name (`mod tests { mod fixtures; use fixtures::build; }`). Any other bare head is left alone, because the commoner shape by far is `mod tests { use some_crate::Thing; }` — how a test reaches another crate of the project — and rebasing that would lose the edge. A module in scope through some other route than a declaration in the same block is the case left uncovered.
- `crate::missing_module::Item` resolves to the crate root rather than to nothing: no prefix of the path names a file, and the root is where the module would have been declared. It is the same fallback that makes `crate::SomeType` reach the root correctly, and separating the two would take knowing which segments name items. In edition 2015 a leading `::` shares it for a name the manifest does not declare and rustc does not provide: `::RootItem` is the root, and so is `::nothing::Item`.
- A `mod` under `#[cfg(…)]` is always followed, whatever the feature flags say. The graph has no feature resolution, and a module behind a flag is still a file in the tree.
- **An unanchored path in edition 2015 is absolute from the crate root, and that reading is not acted on.** `use registry::write;` in `src/client.rs` compiles with `mod registry;` written only in `lib.rs`, and no edge is drawn. Acting on it means answering a path with no declaration behind it, and each way of bounding that produced a fresh edge rustc rejects — a bare `use b;` between two integration-test crates, an undeclared sibling file, a `mod` in a nested block, a virtual workspace's root claiming its members' declarations — every one found by a reviewer running cargo. `main` drew none of these edges either, so the gate costs nothing already published. The reasoning sits above `edition2015` in `graph-resolution.ts`.
- **One edge record per `use` leaf.** `use crate::io::{A, B, C};` resolves three times to the same file and pushes three records; nothing deduplicates, here or for any other language. On these trees that is 612 records for 261 distinct pairs (ripgrep), 3,922 for 2,210 (tokio). It matters to what reads `graph.edges` as connections — `graph_stats.totalEdges`, `avgDependencies`, `mostConnected`, `findCircularDependencies` and the HTML visualisation all count records — and to `node.imports`, which grows the same way: `qdrant.ts` sums it as `importCount`, and `graph-tools.ts` prints the same specifier twice under `Imports (N)`. Deduplicating at `edges.push` would change every language's numbers, so it is not folded into a Rust bug fix; happy to send it separately.
- **A package whose `Cargo.toml` cannot be parsed is not fenced.** `use helper::Thing;` in such a package still reaches an undeclared sibling. The alternative costs that package every cross-crate edge on a manifest we merely failed to read.
- **Two `#[path]` declarations of one name under opposite `cfg`s: the last one wins for paths through it.** Both declarations draw their own edge, so neither file is unreachable, but `pub use sys::Handle;` beside `#[cfg(unix)] #[path = "sys_unix.rs"] mod sys;` and its `windows` twin resolves to whichever was written last, on every platform. The graph has no feature or target resolution.
- A macro body is read only while blanking the invocation leaves the rest of the file parsing as it did. Where it does not — a `cfg_if!` inside an inline `mod` or `impl`, whose arms close the block early, or libc's `freebsd/mod.rs`, which parses as one error from line 1 — the body is left alone and its declarations draw no edge. A macro written inside a `cfg_if!` arm is not reached either: after blanking, the arm is the block of a recovered `if`, and a block is not where an item is read from. Measured over the 153 crates of a 1,256-crate registry cache that carry the shape, that is 56 dependencies not read; ripgrep, tokio and clap lose none. Reading each body in isolation with the invocation's scope would remove both limits and is a follow-up.

## Note on a duplication I did not introduce

`findCargoManifests` is the fifth near-identical manifest walk in this file, after the ones for `go.mod`, `composer.json`, `pubspec.yaml` and `pyproject.toml` — they differ only in the filename and the one directory each skips. I followed the existing convention rather than fold a refactor into a bug fix. Happy to send one that collapses all five into a parameterised walk, separately, if you want it.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate
- [ ] I have updated documentation (README.md / DEVELOPER.md) if needed
- [ ] I have addressed all [CodeRabbit](https://coderabbit.ai) review comments (or marked as resolved with explanation)
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

## Related issues

No issue open for this one — happy to file one if you would rather have the report separate from the fix.

Related: #111. This adds a thirteenth parameter to `resolveImport` and a sixth `build*Map` helper, so the count in DEVELOPER.md moves again; I left the docs alone rather than fold them in here.

Structurally this follows #112 (Python) and #108 (Dart): the same disease, a manifest the resolver never read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Rust project analysis across Cargo workspaces, editions, dependency aliases, custom targets, and `#[path]`-mapped modules.
  * Added broader support for Rust macros, inline modules, re-exports, `include!`, `extern crate`, raw identifiers, and conditional path attributes.
  * Added Elixir module and template analysis, plus improved PHP namespace and file inclusion resolution.
  * Graph status now reports the builder version.

* **Bug Fixes**
  * Prevented incorrect links to unrelated, undeclared, shadowed, or self-referencing modules.
  * Improved resolution for nested modules and edition-specific import paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

