### PR TITLE
fix(embeddings): bound the Ollama connection pool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "openai": "^6.22.0",
         "proper-lockfile": "^4.1.2",
         "smol-toml": "^1.8.0",
+        "undici": "^6.28.0",
         "web-tree-sitter": "^0.26.12",
         "zod": "^3.24.2"
       },
@@ -6342,9 +6343,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -6586,9 +6587,9 @@
       }
     },
     "node_modules/web-tree-sitter": {
-      "version": "0.26.12",
-      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.12.tgz",
-      "integrity": "sha512-fvqTNZQBGUgUgfP0mHw+iHf9Yf6bRQrp0A3pSf2v/hSKxkT1beCoIWoLVmlPL7O6dmySfSb/t1aJoJvrgTRStw==",
+      "version": "0.26.13",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.13.tgz",
+      "integrity": "sha512-5bUZ7vbQ1kcondet96wzP974+JfCZDeQ7bTpacICm2nnvHpa5cO0ByRsoMcAhUP+743vpkb4m0BFlVSm+Ye9VA==",
       "license": "MIT"
     },
     "node_modules/whatwg-fetch": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "openai": "^6.22.0",
     "proper-lockfile": "^4.1.2",
     "smol-toml": "^1.8.0",
+    "undici": "^6.28.0",
     "web-tree-sitter": "^0.26.12",
     "zod": "^3.24.2"
   },
@@ -108,7 +109,7 @@
     "vitest": "^4.0.18"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.17.0"
   },
   "overrides": {
     "vitest": {

--- a/src/services/embedding-config.ts
+++ b/src/services/embedding-config.ts
@@ -27,6 +27,9 @@
  *                          Default for docker mode: http://localhost:11435
  *                          Default for external mode: http://localhost:11434
  *   OLLAMA_API_KEY:        Optional API key for authenticated Ollama proxies.
+ *   OLLAMA_MAX_CONNECTIONS: Max concurrent HTTP connections to Ollama.
+ *                          Positive integer. Default: 4. Requests beyond the
+ *                          cap queue client-side instead of opening sockets.
  *
  * Cloud provider-specific:
  *   OPENAI_API_KEY:        Required for openai provider.
@@ -71,6 +74,13 @@ export interface EmbeddingConfig {
   ollamaMode: OllamaMode;
   /** Ollama API URL (only relevant when embeddingProvider is "ollama"). */
   ollamaUrl: string;
+  /**
+   * Per-origin cap on concurrent HTTP connections to Ollama. Node's default
+   * fetch pool is unbounded, so concurrent embeds from several processes or
+   * overlapping tool calls stack sockets without limit (issue 114); excess
+   * requests queue on the bounded agent instead of opening new connections.
+   */
+  ollamaMaxConnections: number;
   /** LM Studio OpenAI-compatible base URL (only relevant when embeddingProvider is "lmstudio"). */
   lmstudioUrl: string;
   /** LiteLLM proxy OpenAI-compatible base URL (only relevant when embeddingProvider is "litellm"). */
@@ -234,6 +244,14 @@ export function loadEmbeddingConfig(): EmbeddingConfig {
   }
   const embeddingDimensions = rawDimensions;
 
+  const rawMaxConnections = Number(process.env.OLLAMA_MAX_CONNECTIONS || 4);
+  if (!Number.isInteger(rawMaxConnections) || rawMaxConnections <= 0) {
+    throw new Error(
+      `Invalid OLLAMA_MAX_CONNECTIONS: "${process.env.OLLAMA_MAX_CONNECTIONS}". Must be a positive integer.`,
+    );
+  }
+  const ollamaMaxConnections = rawMaxConnections;
+
   const contextLengthEnv = process.env.EMBEDDING_CONTEXT_LENGTH;
 
   _config = {
@@ -256,6 +274,7 @@ export function loadEmbeddingConfig(): EmbeddingConfig {
         })()
       : guessContextLength(embeddingModel),
     ollamaApiKey: process.env.OLLAMA_API_KEY || undefined,
+    ollamaMaxConnections,
   };
 
   logger.info("Embedding config loaded", {
@@ -263,6 +282,7 @@ export function loadEmbeddingConfig(): EmbeddingConfig {
     ...(embeddingProvider === "ollama" ? {
       ollamaMode: _config.ollamaMode,
       ollamaUrl: _config.ollamaUrl,
+      ollamaMaxConnections: _config.ollamaMaxConnections,
     } : {}),
     ...(embeddingProvider === "lmstudio" ? {
       lmstudioUrl: _config.lmstudioUrl,

--- a/src/services/provider-ollama.ts
+++ b/src/services/provider-ollama.ts
@@ -8,6 +8,7 @@
  */
 
 import { Ollama } from "ollama";
+import { Agent, fetch as undiciFetch } from "undici";
 import type { InfraProgressCallback } from "./docker.js";
 import { ensureOllamaContainerReady, isDockerAvailable, isOllamaImagePresent, isOllamaRunning, isQdrantRunning } from "./docker.js";
 import { getEmbeddingConfig, setResolvedOllamaMode } from "./embedding-config.js";
@@ -18,14 +19,66 @@ import { logger } from "./logger.js";
 
 let ollamaClient: Ollama | null = null;
 let ollamaClientHost: string | null = null;
+let ollamaClientConnections: number | null = null;
+let ollamaDispatcher: Agent | null = null;
 
 function getClient(): Ollama {
   const config = getEmbeddingConfig();
-  if (!ollamaClient || ollamaClientHost !== config.ollamaUrl) {
-    ollamaClient = new Ollama({ host: config.ollamaUrl });
+  if (
+    !ollamaClient ||
+    ollamaClientHost !== config.ollamaUrl ||
+    ollamaClientConnections !== config.ollamaMaxConnections
+  ) {
+    // An orphaned pool keeps its idle sockets until they time out, so close
+    // the previous dispatcher whenever the client is rebuilt.
+    const previous = ollamaDispatcher;
+    if (previous) {
+      previous.close().catch((err: unknown) => {
+        logger.debug("Closing previous Ollama dispatcher failed", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
+    // Node's default fetch pool has no per-origin connection cap, so
+    // concurrent embeds from several server processes or overlapping tool
+    // calls stack sockets to Ollama without limit (issue 114). A bounded
+    // undici Agent caps them; requests beyond the cap queue on the agent.
+    // The Agent must be paired with undici's own fetch: handing it to the
+    // built-in fetch fails its dispatcher handler validation.
+    const dispatcher = new Agent({
+      connections: config.ollamaMaxConnections,
+      keepAliveTimeout: 30_000,
+      keepAliveMaxTimeout: 30_000,
+    });
+    ollamaDispatcher = dispatcher;
+    ollamaClient = new Ollama({
+      host: config.ollamaUrl,
+      // undici's Response type predates the global one (no .bytes()), so the
+      // wrapper cannot satisfy `typeof fetch` structurally; the runtime shape
+      // is what the ollama client consumes and matches.
+      fetch: ((input: Parameters<typeof undiciFetch>[0], init?: Parameters<typeof undiciFetch>[1]) =>
+        undiciFetch(input, { ...init, dispatcher })) as unknown as typeof fetch,
+    });
     ollamaClientHost = config.ollamaUrl;
+    ollamaClientConnections = config.ollamaMaxConnections;
   }
   return ollamaClient;
+}
+
+/** Drop the cached client and drain its connection pool. */
+export function resetOllamaClient(): void {
+  const previous = ollamaDispatcher;
+  ollamaClient = null;
+  ollamaClientHost = null;
+  ollamaClientConnections = null;
+  ollamaDispatcher = null;
+  if (previous) {
+    previous.close().catch((err: unknown) => {
+      logger.debug("Closing Ollama dispatcher failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
 }
 
 // ── Availability checks ─────────────────────────────────────────────────

--- a/src/services/provider-ollama.ts
+++ b/src/services/provider-ollama.ts
@@ -30,7 +30,12 @@ function getClient(): Ollama {
     ollamaClientConnections !== config.ollamaMaxConnections
   ) {
     // An orphaned pool keeps its idle sockets until they time out, so close
-    // the previous dispatcher whenever the client is rebuilt.
+    // the previous dispatcher whenever the client is rebuilt. close() stops
+    // the old agent accepting new dispatches immediately and lets in-flight
+    // requests finish, so during a rebuild the old pool only shrinks while
+    // the new one grows: the brief overlap is bounded by the two caps and
+    // resolves itself, and no request is aborted. Serialising the swap would
+    // buy nothing beyond that and would force this accessor async.
     const previous = ollamaDispatcher;
     if (previous) {
       previous.close().catch((err: unknown) => {

--- a/tests/integration/symbol-graph-scale.test.ts
+++ b/tests/integration/symbol-graph-scale.test.ts
@@ -151,7 +151,20 @@ describe.skipIf(!dockerAvailable)(
       expect(impactMs).toBeLessThan(COLD_QUERY_BUDGET_MS);
     });
 
-    it("Phase F incremental update is significantly faster than a full rebuild", async () => {
+    // retry: a wall-clock ratio on shared hardware can lose to a transient
+    // load spike (measured: a saturated box turns the 4x margin into 1.4x).
+    // A retry re-measures both sides under fresh conditions; a genuine
+    // Phase F regression fails every attempt.
+    it("Phase F incremental update is significantly faster than a full rebuild", { retry: 2 }, async () => {
+      // Re-measure the full rebuild HERE rather than reusing the timing from
+      // the earlier it block: the two blocks run minutes apart under
+      // different machine state (Qdrant warm-up, GC, background load), and
+      // comparing timings across that boundary flaked on unmodified runs.
+      // Both numbers in this assertion now come from the same block.
+      const fullStart = Date.now();
+      await rebuildGraph(projectRoot);
+      const freshFullRebuildMs = Date.now() - fullStart;
+
       // Touch one file: append a new symbol.
       const rel = "pkg/mod_42.py";
       const abs = path.join(projectRoot, rel);
@@ -175,13 +188,13 @@ describe.skipIf(!dockerAvailable)(
           [],
         );
         const incrementalMs = Date.now() - start;
-        console.log(`[scale] Phase F incremental update (1 file in ${N_FILES}-file repo): ${incrementalMs} ms (full rebuild was ${fullRebuildMs} ms)`);
+        console.log(`[scale] Phase F incremental update (1 file in ${N_FILES}-file repo): ${incrementalMs} ms (full rebuild was ${freshFullRebuildMs} ms)`);
         expect(result.fullRebuildRequired).toBe(false);
         expect(result.filesChanged).toBeGreaterThanOrEqual(1);
         // Phase F's whole reason to exist: must beat full rebuild on a small
         // change set by a wide margin. We allow 4× as a deliberately loose
         // threshold to avoid CI flakiness.
-        expect(incrementalMs * INCREMENTAL_SPEEDUP_MIN).toBeLessThan(fullRebuildMs);
+        expect(incrementalMs * INCREMENTAL_SPEEDUP_MIN).toBeLessThan(freshFullRebuildMs);
       } finally {
         fs.writeFileSync(abs, original, "utf-8");
       }

--- a/tests/unit/embedding-config.test.ts
+++ b/tests/unit/embedding-config.test.ts
@@ -20,6 +20,7 @@ describe("embedding-config", () => {
     delete process.env.EMBEDDING_DIMENSIONS;
     delete process.env.EMBEDDING_CONTEXT_LENGTH;
     delete process.env.OLLAMA_API_KEY;
+    delete process.env.OLLAMA_MAX_CONNECTIONS;
     delete process.env.OPENAI_API_KEY;
     delete process.env.GOOGLE_API_KEY;
     delete process.env.LMSTUDIO_URL;
@@ -142,6 +143,29 @@ describe("embedding-config", () => {
     });
   });
 
+  describe("OLLAMA_MAX_CONNECTIONS", () => {
+    it("defaults to 4", () => {
+      expect(loadEmbeddingConfig().ollamaMaxConnections).toBe(4);
+    });
+
+    it("honours a custom positive integer", () => {
+      process.env.OLLAMA_MAX_CONNECTIONS = "8";
+      expect(loadEmbeddingConfig().ollamaMaxConnections).toBe(8);
+    });
+
+    it("throws for a non-integer or non-positive value", () => {
+      // A silently-clamped bad value would hide a config typo behind a
+      // working pool of the wrong size; the loader must refuse instead.
+      for (const bad of ["0", "-2", "four", "2.5"]) {
+        resetEmbeddingConfig();
+        process.env.OLLAMA_MAX_CONNECTIONS = bad;
+        expect(() => loadEmbeddingConfig(), bad).toThrow(
+          `Invalid OLLAMA_MAX_CONNECTIONS: "${bad}". Must be a positive integer.`,
+        );
+      }
+    });
+  });
+
   describe("singleton behavior", () => {
     it("caches config after first load", () => {
       const first = loadEmbeddingConfig();
@@ -189,6 +213,7 @@ describe("embedding-config", () => {
         embeddingDimensions: 1024,
         embeddingContextLength: 512,
         ollamaApiKey: "secret",
+        ollamaMaxConnections: 4,
       });
     });
   });

--- a/tests/unit/provider-ollama-connection-pool.test.ts
+++ b/tests/unit/provider-ollama-connection-pool.test.ts
@@ -109,6 +109,17 @@ describe("ollama connection pool", () => {
     expect(opened).toBeLessThanOrEqual(4);
   });
 
+  /** Poll until the open-socket count satisfies `predicate`, or fail loudly. */
+  async function waitForSockets(predicate: (n: number) => boolean): Promise<void> {
+    const deadline = Date.now() + 5_000;
+    while (!predicate(openSockets.size)) {
+      if (Date.now() > deadline) {
+        throw new Error(`open sockets stayed at ${openSockets.size} past the deadline`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+
   it("drains the pool on resetOllamaClient", async () => {
     // Idle keep-alive sockets belong to the dispatcher; closing it must
     // release them rather than leaving them to a timeout.
@@ -116,8 +127,7 @@ describe("ollama connection pool", () => {
     await Promise.all(Array.from({ length: 8 }, (_, i) => provider.embed([`d-${i}`])));
     expect(openSockets.size).toBeGreaterThan(0);
     resetOllamaClient();
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    expect(openSockets.size).toBe(0);
+    await waitForSockets((n) => n === 0);
   });
 
   it("rebuilds the pool when the cap changes", async () => {
@@ -130,7 +140,6 @@ describe("ollama connection pool", () => {
     process.env.OLLAMA_MAX_CONNECTIONS = "2";
     resetEmbeddingConfig();
     await Promise.all(Array.from({ length: 8 }, (_, i) => provider.embed([`b-${i}`])));
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    expect(openSockets.size).toBeLessThanOrEqual(2);
+    await waitForSockets((n) => n <= 2);
   });
 });

--- a/tests/unit/provider-ollama-connection-pool.test.ts
+++ b/tests/unit/provider-ollama-connection-pool.test.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import { createServer, type Server } from "node:http";
+import type { Socket } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resetEmbeddingConfig } from "../../src/services/embedding-config.js";
+import { OllamaEmbeddingProvider, resetOllamaClient } from "../../src/services/provider-ollama.js";
+
+/**
+ * Issue 114: the Ollama client rode Node's default fetch pool, which has no
+ * per-origin connection cap, so concurrent embeds stacked sockets to Ollama
+ * without limit. The provider now supplies a bounded undici Agent through the
+ * client's fetch override. These tests count connections on the FIXTURE
+ * SERVER side ('connection' events), which is portable and needs no lsof.
+ */
+describe("ollama connection pool", () => {
+  const originalEnv = { ...process.env };
+  let server: Server;
+  let port = 0;
+  let opened = 0;
+  let openSockets: Set<Socket>;
+  let failNext = 0;
+
+  beforeEach(async () => {
+    opened = 0;
+    failNext = 0;
+    openSockets = new Set();
+    server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        if (failNext > 0) {
+          failNext--;
+          res.writeHead(500, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: "fixture failure" }));
+          return;
+        }
+        const body = JSON.stringify({ embeddings: [[0.1, 0.2, 0.3]] });
+        // A small delay keeps requests genuinely concurrent, so the peak
+        // socket count measures the pool bound rather than scheduling luck.
+        setTimeout(() => {
+          res.writeHead(200, {
+            "content-type": "application/json",
+            "content-length": String(Buffer.byteLength(body)),
+          });
+          res.end(body);
+        }, 30);
+      });
+    });
+    // Defeat the server-side 5s idle reaper so client behavior, not the
+    // fixture, decides when sockets close.
+    server.keepAliveTimeout = 120_000;
+    server.on("connection", (socket) => {
+      opened++;
+      openSockets.add(socket);
+      socket.on("close", () => openSockets.delete(socket));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    port = typeof address === "object" && address ? address.port : 0;
+
+    resetEmbeddingConfig();
+    resetOllamaClient();
+    process.env.EMBEDDING_PROVIDER = "ollama";
+    process.env.OLLAMA_MODE = "external";
+    process.env.OLLAMA_URL = `http://127.0.0.1:${port}`;
+    delete process.env.OLLAMA_MAX_CONNECTIONS;
+  });
+
+  afterEach(async () => {
+    resetOllamaClient();
+    resetEmbeddingConfig();
+    process.env = { ...originalEnv };
+    for (const socket of openSockets) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("caps concurrent connections at the default bound", async () => {
+    // 3 rounds of 20 concurrent embeds against a default cap of 4: without
+    // the bounded agent the fixture accepts 20 sockets in the first round
+    // (measured on the pre-fix provider), with it the total ever opened
+    // stays at the cap and later rounds reuse the pooled connections.
+    const provider = new OllamaEmbeddingProvider();
+    for (let round = 0; round < 3; round++) {
+      await Promise.all(
+        Array.from({ length: 20 }, (_, i) => provider.embed([`text-${round}-${i}`])),
+      );
+    }
+    expect(opened).toBeLessThanOrEqual(4);
+  });
+
+  it("honours OLLAMA_MAX_CONNECTIONS", async () => {
+    process.env.OLLAMA_MAX_CONNECTIONS = "2";
+    resetEmbeddingConfig();
+    const provider = new OllamaEmbeddingProvider();
+    await Promise.all(Array.from({ length: 12 }, (_, i) => provider.embed([`t-${i}`])));
+    expect(opened).toBeLessThanOrEqual(2);
+  });
+
+  it("rejects on a failing response and stays bounded through failures", async () => {
+    // The bound must hold on the failure path too: a connection consumed by
+    // an error response has to return to the pool, not leak and be replaced.
+    const provider = new OllamaEmbeddingProvider();
+    failNext = 6;
+    const results = await Promise.allSettled(
+      Array.from({ length: 12 }, (_, i) => provider.embed([`f-${i}`])),
+    );
+    expect(results.some((r) => r.status === "rejected")).toBe(true);
+    await Promise.all(Array.from({ length: 12 }, (_, i) => provider.embed([`ok-${i}`])));
+    expect(opened).toBeLessThanOrEqual(4);
+  });
+
+  it("drains the pool on resetOllamaClient", async () => {
+    // Idle keep-alive sockets belong to the dispatcher; closing it must
+    // release them rather than leaving them to a timeout.
+    const provider = new OllamaEmbeddingProvider();
+    await Promise.all(Array.from({ length: 8 }, (_, i) => provider.embed([`d-${i}`])));
+    expect(openSockets.size).toBeGreaterThan(0);
+    resetOllamaClient();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(openSockets.size).toBe(0);
+  });
+
+  it("rebuilds the pool when the cap changes", async () => {
+    // A config change must not leave the old dispatcher's sockets behind:
+    // the client rebuild closes the previous pool before the new one opens.
+    const provider = new OllamaEmbeddingProvider();
+    await Promise.all(Array.from({ length: 8 }, (_, i) => provider.embed([`a-${i}`])));
+    const firstPool = opened;
+    expect(firstPool).toBeLessThanOrEqual(4);
+    process.env.OLLAMA_MAX_CONNECTIONS = "2";
+    resetEmbeddingConfig();
+    await Promise.all(Array.from({ length: 8 }, (_, i) => provider.embed([`b-${i}`])));
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(openSockets.size).toBeLessThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
Closes #114.

## Problem

Reported in #114: the Ollama client was constructed with no fetch override, so every request rode Node's default fetch pool, which has no per-origin connection cap. Concurrent embeds from several server processes or overlapping tool calls stacked sockets to Ollama without limit. Reproducing the report also established the mechanism more precisely: idle keep-alive sockets drain within seconds, so sockets that persist are requests still in flight, and the pile-up under concurrency is what the cap addresses.

## Fix

- The client now supplies a bounded undici `Agent` through its public fetch override. Requests beyond the cap queue on the agent instead of opening connections. The agent is paired with undici's own fetch, since handing it to the built-in fetch fails dispatcher handler validation.
- `OLLAMA_MAX_CONNECTIONS` configures the cap (default 4, matching the strictly sequential per-process embed pipeline plus headroom for overlapping tool calls). An invalid value refuses to load rather than clamping.
- The pool is drained whenever the client is rebuilt (URL or cap change), and a new `resetOllamaClient()` exposes the same drain, mirroring the other providers' reset functions.
- `undici ^6.28.0` joins the dependencies, deduplicating with the copy the Qdrant client already bundles. Its declared floor is Node 18.17, so `engines.node` rises from `>=18.0.0` to `>=18.17.0`: the manifest now states what the dependency tree already requires, and 18.0 through 18.16 are superseded patch lines of the same major.

## Testing

Nine new tests. The five pool tests count connections on the fixture server's side ('connection' events), so they run anywhere without `lsof`: the cap holds across three rounds of twenty concurrent embeds, a custom cap is honoured, the bound holds through failing responses, the pool drains on reset, and a cap change rebuilds the pool without leaving the old one's sockets behind. Four config tests pin the default, a custom value, and the refusal on invalid input.

Mutation-checked: removing the dispatcher from the fetch wrapper fails all five pool tests, removing the drain on reset fails the drain test, and hardcoding the cap fails four of five.

A second commit deflakes `symbol-graph-scale`'s Phase F assertion, which compared timings measured in different `it` blocks minutes apart and failed on unmodified runs; both sides of the ratio are now measured in one block, with a retry so a transient load spike re-measures while a real regression still fails every attempt.

- Unit tests: 1181 passed, tsc, biome and build clean, CodeRabbit CLI no findings.
- Integration: full suite passed pre-change baseline and with the change before this push; the machine hosting the live-Qdrant suite is currently rebooting from a crash, so the final local integration confirmation follows in a comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for simultaneous Ollama connections, with a default of four.
  * Improved Ollama connection reuse and cleanup for more reliable request handling.
  * Updated the minimum supported Node.js version to 18.17.0.

* **Bug Fixes**
  * Improved recovery and connection management after failed Ollama requests.

* **Tests**
  * Added coverage for connection limits, configuration validation, pool reuse, and reset behavior.
  * Improved reliability of incremental-update performance testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->