### PR TITLE
feat: add OrcaRouter as a named embedding provider

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -705,7 +705,7 @@ Factory that creates and caches the active `EmbeddingProvider` instance. Uses dy
 | `getEmbeddingProvider` | `(onProgress?) → Promise<EmbeddingProvider>` — Get (or create) the active provider singleton. Re-creates if config changed. |
 | `resetEmbeddingProvider` | `() → void` — Clear cached provider (for testing). |
 
-Provider selected via `EMBEDDING_PROVIDER` env var (`ollama` / `openai` / `google`).
+Provider selected via `EMBEDDING_PROVIDER` env var (`ollama` / `openai` / `google` / `lmstudio` / `litellm` / `orcarouter`).
 
 ### provider-ollama.ts
 
@@ -743,6 +743,37 @@ Google Generative AI embedding provider. Requires `GOOGLE_API_KEY`.
 | `resetGoogleClient` | `() → void` — Clear cached client (for testing). |
 
 `ensureReady()` validates the API key and makes a minimal test embedding call. Pre-truncates to 2048 tokens (~3 chars/token). Default model is `gemini-embedding-001` (3072 dims).
+
+### provider-litellm.ts
+
+LiteLLM embedding provider. Points at a LiteLLM Proxy Server (OpenAI-compatible gateway in front
+of 100+ providers). Requires `LITELLM_API_KEY` plus explicit `EMBEDDING_MODEL` (a proxy alias) and
+`EMBEDDING_DIMENSIONS` (the alias's underlying dim). `LITELLM_URL` defaults to
+`http://localhost:4000/v1`.
+
+| Export | Description |
+|--------|-------------|
+| `LiteLLMEmbeddingProvider` | Provider class. Iterates `/v1/models` in `ensureReady()` to fail early when the alias is not registered on the proxy. |
+| `resetLiteLLMClient` | `() → void` — Clear cached client (for testing or URL/key hot-swap). |
+
+`embed()` forwards `encoding_format: "float"` (required — see the class comment for the base64
+decode bug) and optionally `dimensions` when `LITELLM_SEND_DIMENSIONS=true`.
+
+### provider-orcarouter.ts
+
+OrcaRouter embedding provider. Points at the OrcaRouter AI gateway (OpenAI-compatible endpoint,
+provider/model namespace like OpenRouter). Requires `ORCAROUTER_API_KEY` plus explicit
+`EMBEDDING_MODEL` (a `provider/model` id from the gateway's `/v1/models`, e.g.
+`google/gemini-embedding-001`) and `EMBEDDING_DIMENSIONS` (the chosen model's dim).
+`ORCAROUTER_URL` defaults to `https://api.orcarouter.ai/v1`.
+
+| Export | Description |
+|--------|-------------|
+| `OrcaRouterEmbeddingProvider` | Provider class. Iterates `/v1/models` in `ensureReady()` to fail early when the model id is not registered on the gateway. |
+| `resetOrcaRouterClient` | `() → void` — Clear cached client (for testing or URL/key hot-swap). |
+
+`embed()` forwards `encoding_format: "float"` (required — same base64 decode bug as LiteLLM) and
+optionally `dimensions` when `ORCAROUTER_SEND_DIMENSIONS=true`.
 
 ### qdrant.ts
 
@@ -1454,7 +1485,7 @@ Edit `CHUNK_SIZE` and `CHUNK_OVERLAP` in `src/constants.ts`. Smaller chunks give
 
 ### Switching embedding model or provider
 
-1. Set `EMBEDDING_PROVIDER` in your MCP config env block (`ollama`, `openai`, or `google`).
+1. Set `EMBEDDING_PROVIDER` in your MCP config env block (`ollama`, `openai`, `google`, `lmstudio`, `litellm`, or `orcarouter`).
 2. Optionally override `EMBEDDING_MODEL` and `EMBEDDING_DIMENSIONS` for the chosen provider (auto-detected defaults exist for all built-in models).
 3. Re-index all projects (`codebase_remove` then `codebase_index`) since existing vectors have different dimensions.
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ On VS Code's 2.45M‑line codebase, SocratiCode answers architectural questions 
 - **Hybrid code search** — Built on Qdrant, a purpose-built vector database with HNSW indexing, concurrent read/write, and payload filtering. Each chunk stores both a dense vector and a BM25 sparse vector; the Query API runs both sub-queries in a single round-trip and fuses results with Reciprocal Rank Fusion (RRF). Semantic search handles conceptual queries like "authentication middleware" even when those exact words don't appear in the code. BM25 handles exact identifier and keyword lookups. You get the best of both in every query with no tuning required.
 - **Configurable Qdrant** — Use the built-in Docker Qdrant (default, zero config) or connect to your own instance (self-hosted, remote server, or Qdrant Cloud). Configure via `QDRANT_MODE`, `QDRANT_URL`, and `QDRANT_API_KEY` environment variables.
 - **Configurable Ollama** — Use the built-in Docker Ollama (default, zero config) or point to your own Ollama instance (native install -GPU access-, remote server, etc.). Configure via `OLLAMA_MODE`, `OLLAMA_URL`, `EMBEDDING_MODEL` and `EMBEDDING_DIMENSIONS` environment variables.
-- **Multi-provider embeddings** — Switch between Local Ollama (private, GPU access), Docker Ollama (zero-config), OpenAI (`text-embedding-3-small`, fastest), Google Gemini (`gemini-embedding-001`, free tier), LM Studio (local OpenAI-compatible server), or LiteLLM (proxy gateway in front of 100+ providers) with a single environment variable. No provider-specific configuration files.
+- **Multi-provider embeddings** — Switch between Local Ollama (private, GPU access), Docker Ollama (zero-config), OpenAI (`text-embedding-3-small`, fastest), Google Gemini (`gemini-embedding-001`, free tier), LM Studio (local OpenAI-compatible server), LiteLLM (proxy gateway in front of 100+ providers), or OrcaRouter (OpenAI-compatible AI gateway) with a single environment variable. No provider-specific configuration files.
 - **Private & secure** — Everything runs on your machine — your code never leaves your network. The default Docker setup includes Ollama (embeddings) and Qdrant (vector storage) with no external API calls. No API costs, no token limits. Suitable for air-gapped and on-premises environments. Optional cloud providers (OpenAI, Google Gemini, Qdrant Cloud) are available but never required.
 - **AST-aware chunking** — Files are split at function/class boundaries using AST parsing (ast-grep), not arbitrary line counts. This produces higher-quality search results. Falls back to line-based chunking for unsupported languages.
 - **Polyglot code dependency graph** — Static analysis of import/require/use/include statements using ast-grep for 18+ languages. No external tools like dependency-cruiser required. Detects circular dependencies and generates visual Mermaid diagrams.
@@ -754,6 +754,46 @@ across MCP configs), **fallback / load balancing** between embedding backends, o
 > OpenAI-compatible, lists your `EMBEDDING_MODEL` under `/v1/models`, and accepts it under its own
 > native model id (no LiteLLM `provider/` prefix).
 
+#### OrcaRouter (AI gateway)
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models
+and agents. Like OpenRouter, it exposes a provider/model namespace across many models
+(`google/gemini-embedding-001`, `openai/text-embedding-3-small`, `orcarouter/fusion`, ...), but it
+also combines adaptive routing, automatic failover, zero-markup inference, observability,
+guardrails, and agent-tool governance behind the same endpoint. Use this provider when you want a
+**single API key** for multiple embedding backends, **automatic failover** between them, or
+**provider-agnostic indexes** that survive a backend swap — without hosting a proxy yourself.
+
+```json
+{
+  "mcpServers": {
+    "socraticode": {
+      "command": "node",
+      "args": ["/absolute/path/to/socraticode/dist/index.js"],
+      "env": {
+        "EMBEDDING_PROVIDER": "orcarouter",
+        "ORCAROUTER_API_KEY": "or-...",
+        "EMBEDDING_MODEL": "google/gemini-embedding-001",
+        "EMBEDDING_DIMENSIONS": "3072"
+      }
+    }
+  }
+}
+```
+
+> **`ORCAROUTER_API_KEY`, `EMBEDDING_MODEL`, and `EMBEDDING_DIMENSIONS` are all required.**
+> OrcaRouter always authenticates; the model id and dimension come from the gateway's `/v1/models`
+> namespace. SocratiCode fails fast on any missing piece.
+>
+> Optional: `ORCAROUTER_URL` (default `https://api.orcarouter.ai/v1`) — must include the `/v1`
+> suffix; `ORCAROUTER_SEND_DIMENSIONS=true` to forward the OpenAI `dimensions` parameter
+> through the gateway (only safe for Matryoshka-aware backends like `openai/text-embedding-3-*` —
+> other backends such as `google/gemini-embedding-001` reject the request).
+>
+> It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening
+> every prompt/response and governing every tool call on a default-deny basis, with no application
+> code changes.
+
 ### Git Worktrees (shared index across directories)
 
 If you use [git worktrees](https://git-scm.com/docs/git-worktree) — or any workflow where the same repository lives in multiple directories — each path would normally get its own Qdrant index. This means redundant embedding and storage for what is essentially the same codebase.
@@ -1169,10 +1209,10 @@ The rest of this section documents the variables themselves. Pass them using whi
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `EMBEDDING_PROVIDER` | `ollama` | Embedding backend: `ollama` (local, default), `openai`, `google`, `lmstudio`, or `litellm` |
-| `EMBEDDING_MODEL` | *(per provider)* | Model name. Defaults: `nomic-embed-text` (ollama), `text-embedding-3-small` (openai), `gemini-embedding-001` (google). **Required** for `lmstudio` and `litellm` (no default). |
-| `EMBEDDING_DIMENSIONS` | *(per provider)* | Vector dimensions. Defaults: `768` (ollama), `1536` (openai), `3072` (google). **Required** for `lmstudio` and `litellm` (no default; varies per loaded model / proxy alias). |
-| `EMBEDDING_CONTEXT_LENGTH` | *(auto-detected)* | Model context window in tokens. Auto-detected for known model names (works for LiteLLM aliases that match the underlying model name). Set manually for custom LM Studio models or arbitrary LiteLLM aliases. |
+| `EMBEDDING_PROVIDER` | `ollama` | Embedding backend: `ollama` (local, default), `openai`, `google`, `lmstudio`, `litellm`, or `orcarouter` |
+| `EMBEDDING_MODEL` | *(per provider)* | Model name. Defaults: `nomic-embed-text` (ollama), `text-embedding-3-small` (openai), `gemini-embedding-001` (google). **Required** for `lmstudio`, `litellm`, and `orcarouter` (no default). |
+| `EMBEDDING_DIMENSIONS` | *(per provider)* | Vector dimensions. Defaults: `768` (ollama), `1536` (openai), `3072` (google). **Required** for `lmstudio`, `litellm`, and `orcarouter` (no default; varies per loaded model / proxy alias / gateway model id). |
+| `EMBEDDING_CONTEXT_LENGTH` | *(auto-detected)* | Model context window in tokens. Auto-detected for known model names (works for LiteLLM aliases and OrcaRouter model ids that match the underlying model name). Set manually for custom LM Studio models or arbitrary LiteLLM aliases / OrcaRouter model ids. |
 
 ### Ollama Configuration (when `EMBEDDING_PROVIDER=ollama`)
 
@@ -1205,6 +1245,14 @@ The rest of this section documents the variables themselves. Pass them using whi
 | `LITELLM_URL` | `http://localhost:4000/v1` | Full base URL of the LiteLLM proxy's OpenAI-compatible endpoint. Override for non-default ports or remote proxies (e.g. `https://litellm.internal:4001/v1`). Must include the `/v1` suffix — LiteLLM exposes `/v1/embeddings` under that prefix. |
 | `LITELLM_API_KEY` | *(none)* | **Required.** Master key (`general_settings.master_key` in the proxy's `config.yaml`) or a virtual key issued via LiteLLM's `/key/generate` endpoint. Unlike LM Studio, LiteLLM always authenticates — `/v1/models` itself is gated. |
 | `LITELLM_SEND_DIMENSIONS` | `false` | Opt-in (`true` / `1` / `yes`). Forwards the OpenAI-style `dimensions` parameter through the proxy. Safe only for Matryoshka-aware backends (`text-embedding-3-*`, `voyage-3`); other backends (BGE, `nomic-embed-text`, Cohere v3) reject the request. Leave unset unless you know your alias resolves to a Matryoshka model. |
+
+### OrcaRouter Configuration (when `EMBEDDING_PROVIDER=orcarouter`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ORCAROUTER_URL` | `https://api.orcarouter.ai/v1` | Full base URL of the OrcaRouter gateway's OpenAI-compatible endpoint. Override for custom gateways or egress-proxied setups. Must include the `/v1` suffix — OrcaRouter exposes `/v1/embeddings` under that prefix. |
+| `ORCAROUTER_API_KEY` | *(none)* | **Required.** OrcaRouter API key from the [OrcaRouter dashboard](https://www.orcarouter.ai). Unlike LM Studio, OrcaRouter always authenticates — `/v1/models` itself is gated. |
+| `ORCAROUTER_SEND_DIMENSIONS` | `false` | Opt-in (`true` / `1` / `yes`). Forwards the OpenAI-style `dimensions` parameter through the gateway. Safe only for Matryoshka-aware backends (`openai/text-embedding-3-*`); other backends (e.g. `google/gemini-embedding-001`) reject the request. Leave unset unless you know your model id resolves to a Matryoshka model. |
 
 ### Qdrant Configuration
 

--- a/src/services/embedding-config.ts
+++ b/src/services/embedding-config.ts
@@ -13,6 +13,10 @@
  *                100+ underlying providers). Requires LITELLM_API_KEY,
  *                EMBEDDING_MODEL (must match an alias in the proxy's config.yaml),
  *                and EMBEDDING_DIMENSIONS (the alias's underlying dim).
+ *   - "orcarouter": Use OrcaRouter (OpenAI-compatible AI gateway in front of many
+ *                providers, model ids like google/gemini-embedding-001). Requires
+ *                ORCAROUTER_API_KEY, EMBEDDING_MODEL (a provider/model id from the
+ *                gateway's /v1/models), and EMBEDDING_DIMENSIONS (the chosen model's dim).
  *
  * Ollama-specific:
  *   OLLAMA_MODE:
@@ -53,6 +57,17 @@
  *                              underlying models (text-embedding-3-*, voyage-3). Default off
  *                              because non-Matryoshka backends reject it.
  *
+ * OrcaRouter-specific:
+ *   ORCAROUTER_URL:            OpenAI-compatible base URL of the OrcaRouter gateway.
+ *                              Default: https://api.orcarouter.ai/v1 (the /v1 suffix is required;
+ *                              the gateway exposes /v1/embeddings under that prefix).
+ *   ORCAROUTER_API_KEY:        Required. API key issued by OrcaRouter. Unlike LM Studio, the
+ *                              gateway always authenticates.
+ *   ORCAROUTER_SEND_DIMENSIONS: Opt-in ("true" / "1" / "yes"). Forwards the OpenAI-style
+ *                              `dimensions` parameter to the gateway for Matryoshka-aware
+ *                              underlying models (openai/text-embedding-3-*). Default off
+ *                              because non-Matryoshka backends reject it.
+ *
  * Shared:
  *   EMBEDDING_MODEL:       Model name (default depends on provider; required for lmstudio).
  *   EMBEDDING_DIMENSIONS:  Vector dimensions — must match the model (default depends on
@@ -64,7 +79,7 @@ import { logger } from "./logger.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
-export type EmbeddingProvider = "ollama" | "openai" | "google" | "lmstudio" | "litellm";
+export type EmbeddingProvider = "ollama" | "openai" | "google" | "lmstudio" | "litellm" | "orcarouter";
 export type OllamaMode = "docker" | "external" | "auto";
 
 export interface EmbeddingConfig {
@@ -85,6 +100,8 @@ export interface EmbeddingConfig {
   lmstudioUrl: string;
   /** LiteLLM proxy OpenAI-compatible base URL (only relevant when embeddingProvider is "litellm"). */
   litellmUrl: string;
+  /** OrcaRouter gateway OpenAI-compatible base URL (only relevant when embeddingProvider is "orcarouter"). */
+  orcarouterUrl: string;
   embeddingModel: string;
   embeddingDimensions: number;
   /** Max context window in tokens. Used for client-side pre-truncation. */
@@ -95,10 +112,11 @@ export interface EmbeddingConfig {
 // ── Provider defaults ─────────────────────────────────────────────────────
 
 /**
- * lmstudio and litellm have empty defaults: there's no canonical model — users
- * pick one (the loaded LM Studio model, or a proxy alias from LiteLLM's
- * config.yaml). We fail-fast in loadEmbeddingConfig() when those providers are
- * selected without explicit EMBEDDING_MODEL / EMBEDDING_DIMENSIONS.
+ * lmstudio, litellm, and orcarouter have empty defaults: there's no canonical
+ * model — users pick one (the loaded LM Studio model, a proxy alias from
+ * LiteLLM's config.yaml, or a provider/model id from OrcaRouter's /v1/models).
+ * We fail-fast in loadEmbeddingConfig() when those providers are selected
+ * without explicit EMBEDDING_MODEL / EMBEDDING_DIMENSIONS.
  */
 const PROVIDER_DEFAULTS: Record<EmbeddingProvider, { model: string; dimensions: number }> = {
   ollama:   { model: "nomic-embed-text",        dimensions: 768  },
@@ -106,6 +124,7 @@ const PROVIDER_DEFAULTS: Record<EmbeddingProvider, { model: string; dimensions: 
   google:   { model: "gemini-embedding-001",    dimensions: 3072 },
   lmstudio: { model: "",                        dimensions: 0    },
   litellm:  { model: "",                        dimensions: 0    },
+  orcarouter: { model: "",                      dimensions: 0    },
 };
 
 // ── Ollama mode defaults ──────────────────────────────────────────────────
@@ -135,6 +154,13 @@ const MODEL_CONTEXT_LENGTHS: Record<string, number> = {
   "text-embedding-ada-002": 8191,
   // Google models
   "gemini-embedding-001": 2048,
+  // OrcaRouter model ids (provider/model namespace). These names match the
+  // gateway's /v1/models, so EMBEDDING_MODEL values like
+  // google/gemini-embedding-001 or openai/text-embedding-3-small auto-detect.
+  "google/gemini-embedding-001": 2048,
+  "openai/text-embedding-3-small": 8191,
+  "openai/text-embedding-3-large": 8191,
+  "openai/text-embedding-ada-002": 8191,
 };
 
 /** Guess context length from model name. Returns 0 if unknown. */
@@ -161,10 +187,11 @@ export function loadEmbeddingConfig(): EmbeddingConfig {
     rawProvider !== "openai" &&
     rawProvider !== "google" &&
     rawProvider !== "lmstudio" &&
-    rawProvider !== "litellm"
+    rawProvider !== "litellm" &&
+    rawProvider !== "orcarouter"
   ) {
     throw new Error(
-      `Invalid EMBEDDING_PROVIDER: "${rawProvider}". Must be "ollama", "openai", "google", "lmstudio", or "litellm".`,
+      `Invalid EMBEDDING_PROVIDER: "${rawProvider}". Must be "ollama", "openai", "google", "lmstudio", "litellm", or "orcarouter".`,
     );
   }
   const embeddingProvider: EmbeddingProvider = rawProvider;
@@ -222,6 +249,36 @@ export function loadEmbeddingConfig(): EmbeddingConfig {
     }
   }
 
+  // OrcaRouter model ids are provider/model names defined by the gateway — there
+  // is no canonical default model name and the dimension depends on which model
+  // id the operator chooses. Authentication is mandatory (the gateway enforces
+  // it even for read-only /v1/models). Fail fast on each missing piece so the
+  // operator gets a single, specific error rather than a generic 401 / 404 from
+  // the gateway at first embed().
+  if (embeddingProvider === "orcarouter") {
+    if (!process.env.ORCAROUTER_API_KEY) {
+      throw new Error(
+        "ORCAROUTER_API_KEY is required when EMBEDDING_PROVIDER=orcarouter. " +
+        "Set it to an OrcaRouter API key from the OrcaRouter dashboard.",
+      );
+    }
+    if (!process.env.EMBEDDING_MODEL) {
+      throw new Error(
+        "EMBEDDING_MODEL is required when EMBEDDING_PROVIDER=orcarouter. " +
+        "Set it to a provider/model id from the gateway's /v1/models (e.g. " +
+        "EMBEDDING_MODEL=google/gemini-embedding-001 or EMBEDDING_MODEL=orcarouter/fusion).",
+      );
+    }
+    if (!process.env.EMBEDDING_DIMENSIONS) {
+      throw new Error(
+        "EMBEDDING_DIMENSIONS is required when EMBEDDING_PROVIDER=orcarouter. " +
+        "The chosen model id determines the output dimension — set this to the model's " +
+        "output dim (e.g. 3072 for google/gemini-embedding-001, 1536 for " +
+        "openai/text-embedding-3-small).",
+      );
+    }
+  }
+
   // ── Ollama mode (only relevant for ollama provider) ─────────────────
   const rawMode = process.env.OLLAMA_MODE || "auto";
   if (rawMode !== "docker" && rawMode !== "external" && rawMode !== "auto") {
@@ -260,6 +317,7 @@ export function loadEmbeddingConfig(): EmbeddingConfig {
     ollamaUrl: process.env.OLLAMA_URL || modeDefaults.url,
     lmstudioUrl: process.env.LMSTUDIO_URL || "http://localhost:1234/v1",
     litellmUrl: process.env.LITELLM_URL || "http://localhost:4000/v1",
+    orcarouterUrl: process.env.ORCAROUTER_URL || "https://api.orcarouter.ai/v1",
     embeddingModel,
     embeddingDimensions,
     embeddingContextLength: contextLengthEnv
@@ -291,6 +349,10 @@ export function loadEmbeddingConfig(): EmbeddingConfig {
       litellmUrl: _config.litellmUrl,
       sendDimensions: !!process.env.LITELLM_SEND_DIMENSIONS,
     } : {}),
+    ...(embeddingProvider === "orcarouter" ? {
+      orcarouterUrl: _config.orcarouterUrl,
+      sendDimensions: !!process.env.ORCAROUTER_SEND_DIMENSIONS,
+    } : {}),
     embeddingModel: _config.embeddingModel,
     embeddingDimensions: _config.embeddingDimensions,
     embeddingContextLength: _config.embeddingContextLength || "auto",
@@ -304,7 +366,9 @@ export function loadEmbeddingConfig(): EmbeddingConfig {
             ? process.env.LMSTUDIO_API_KEY
             : embeddingProvider === "litellm"
               ? process.env.LITELLM_API_KEY
-              : undefined),
+              : embeddingProvider === "orcarouter"
+                ? process.env.ORCAROUTER_API_KEY
+                : undefined),
   });
 
   return _config;

--- a/src/services/embedding-provider.ts
+++ b/src/services/embedding-provider.ts
@@ -13,6 +13,7 @@
  *   - google   — Google Generative AI Embedding API (gemini-embedding-001, etc.)
  *   - lmstudio — local LM Studio server via OpenAI-compatible API
  *   - litellm  — LiteLLM proxy (OpenAI-compatible gateway in front of 100+ providers)
+ *   - orcarouter — OrcaRouter gateway (OpenAI-compatible AI gateway in front of many providers)
  */
 
 import type { InfraProgressCallback } from "./docker.js";
@@ -72,9 +73,14 @@ export async function getEmbeddingProvider(onProgress?: InfraProgressCallback): 
       _provider = new LiteLLMEmbeddingProvider();
       break;
     }
+    case "orcarouter": {
+      const { OrcaRouterEmbeddingProvider } = await import("./provider-orcarouter.js");
+      _provider = new OrcaRouterEmbeddingProvider();
+      break;
+    }
     default:
       throw new Error(
-        `Unknown embedding provider: "${name}". Must be "ollama", "openai", "google", "lmstudio", or "litellm".`,
+        `Unknown embedding provider: "${name}". Must be "ollama", "openai", "google", "lmstudio", "litellm", or "orcarouter".`,
       );
   }
 

--- a/src/services/provider-orcarouter.ts
+++ b/src/services/provider-orcarouter.ts
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+/**
+ * OrcaRouter embedding provider.
+ *
+ * OrcaRouter (https://www.orcarouter.ai) is an OpenAI-compatible AI gateway
+ * that exposes a provider/model namespace (google/gemini-embedding-001,
+ * orcarouter/fusion, openai/text-embedding-3-small, ...) behind a single
+ * /v1/embeddings endpoint. Model ids use the same provider/name shape as
+ * OpenRouter, and the gateway combines adaptive routing, automatic failover,
+ * zero-markup inference, observability, guardrails, and agent-tool governance.
+ *
+ * This provider is intentionally separate from `provider-litellm.ts` because:
+ *   - OrcaRouter is a managed SaaS gateway with a well-known base URL, not a
+ *     user-hosted proxy, so ORCAROUTER_URL defaults to api.orcarouter.ai.
+ *   - Model ids carry a provider/ prefix (google/...), so the /v1/models
+ *     membership check matches the operator's full model id, not a local alias.
+ *   - Whether the `dimensions` parameter is honoured depends on the underlying
+ *     provider the gateway routes to, so we make it opt-in via
+ *     ORCAROUTER_SEND_DIMENSIONS (same reasoning as LITELLM_SEND_DIMENSIONS).
+ *   - Health check messaging points at gateway-side issues (API key validity,
+ *     model id not in /v1/models) rather than at a self-hosted proxy.
+ *
+ * Required env when using this provider:
+ *   EMBEDDING_PROVIDER=orcarouter
+ *   ORCAROUTER_API_KEY=<api-key>
+ *   EMBEDDING_MODEL=<provider/model-id-from-orcarouter-v1-models>
+ *   EMBEDDING_DIMENSIONS=<dim-of-chosen-model>
+ *
+ * Optional env:
+ *   ORCAROUTER_URL=https://api.orcarouter.ai/v1   (default; must include /v1 suffix)
+ *   ORCAROUTER_SEND_DIMENSIONS=true               (opt-in; forwards `dimensions` to the
+ *                                                 gateway for Matryoshka-aware models like
+ *                                                 openai/text-embedding-3-*. Default false
+ *                                                 because non-Matryoshka backends raise on it.)
+ *   EMBEDDING_CONTEXT_LENGTH=<tokens>             (defaults to 2048 if model unknown)
+ */
+
+import OpenAI from "openai";
+import { getEmbeddingConfig } from "./embedding-config.js";
+import type { EmbeddingHealthStatus, EmbeddingProvider, EmbeddingReadinessResult } from "./embedding-types.js";
+import { logger } from "./logger.js";
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+/**
+ * Conservative batch size — OrcaRouter is a gateway in front of an arbitrary
+ * backend, so the practical batch ceiling depends on whichever provider the
+ * model id resolves to (an OpenAI id tolerates 512+, a Gemini id 100+). 256
+ * sits between the OpenAI (512) and LM Studio (64) defaults and rarely
+ * triggers gateway-level rate limiting on commercial backends.
+ */
+const ORCAROUTER_BATCH_SIZE = 256;
+
+/**
+ * Conservative chars-per-token ratio for code. Same value as provider-openai
+ * and provider-litellm; the gateway does not retokenize on the hop.
+ */
+const CHARS_PER_TOKEN_ESTIMATE = 3.0;
+
+/**
+ * Fallback context length when EMBEDDING_CONTEXT_LENGTH is unset and the model
+ * id is not in the known-models table. 2048 is a safe lower bound across the
+ * common embedding backends OrcaRouter routes to (Gemini 2048, OpenAI 8191,
+ * Voyage 16k, BGE 512). Underestimating only triggers extra client-side
+ * truncation; never a request-rejection.
+ */
+const DEFAULT_CONTEXT_LENGTH = 2048;
+
+// ── Client management ───────────────────────────────────────────────────
+
+let orcarouterClient: OpenAI | null = null;
+let orcarouterBaseUrl: string | null = null;
+let orcarouterApiKey: string | null = null;
+
+function getClient(): OpenAI {
+  const config = getEmbeddingConfig();
+  const baseUrl = config.orcarouterUrl;
+  // Read the key from the live env so test harnesses that mutate process.env
+  // between calls observe the change without an explicit reset.
+  const apiKey = process.env.ORCAROUTER_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "ORCAROUTER_API_KEY environment variable is required when using the OrcaRouter embedding provider. " +
+      "Set it in your MCP config env block.",
+    );
+  }
+  if (!orcarouterClient || orcarouterBaseUrl !== baseUrl || orcarouterApiKey !== apiKey) {
+    orcarouterClient = new OpenAI({
+      apiKey,
+      baseURL: baseUrl,
+    });
+    orcarouterBaseUrl = baseUrl;
+    orcarouterApiKey = apiKey;
+  }
+  return orcarouterClient;
+}
+
+/** Reset client (for testing or ORCAROUTER_URL / ORCAROUTER_API_KEY hot-swap). */
+export function resetOrcaRouterClient(): void {
+  orcarouterClient = null;
+  orcarouterBaseUrl = null;
+  orcarouterApiKey = null;
+}
+
+// ── Pre-truncation ──────────────────────────────────────────────────────
+
+function pretruncateTexts(texts: string[], contextLength: number): string[] {
+  if (contextLength <= 0) return texts;
+  const maxChars = Math.floor(contextLength * CHARS_PER_TOKEN_ESTIMATE);
+  return texts.map((t) => (t.length > maxChars ? t.substring(0, maxChars) : t));
+}
+
+// ── Auth-error detection ────────────────────────────────────────────────
+
+/**
+ * The OpenAI SDK surfaces 401/403 from the gateway as APIError subclasses with
+ * a `.status` field. We don't import those classes (avoids a hard dep on the
+ * SDK's private subclass exports) and instead duck-type on `.status`.
+ */
+function isAuthError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const status = (err as { status?: unknown }).status;
+  return status === 401 || status === 403;
+}
+
+// ── Provider class ──────────────────────────────────────────────────────
+
+export class OrcaRouterEmbeddingProvider implements EmbeddingProvider {
+  readonly name = "orcarouter";
+
+  async ensureReady(): Promise<EmbeddingReadinessResult> {
+    const config = getEmbeddingConfig();
+    // Fail fast with our own message before letting the SDK construct the client.
+    const client = getClient();
+
+    // Step 1 — connectivity + auth. Three failure modes share a single round trip:
+    // gateway unreachable (DNS/connection refused), bad credentials (401/403), or
+    // gateway reachable but mis-configured (500/etc.). Distinguish them so the
+    // operator gets a directly actionable hint.
+    //
+    // Iterate the SDK's auto-paginated AsyncIterable rather than reading
+    // .data directly. OrcaRouter today returns the entire model list in one
+    // page, so this is functionally a no-op; it keeps the membership check
+    // correct if the gateway ever paginates /v1/models the way the OpenAI SDK
+    // already expects.
+    const allModelIds: string[] = [];
+    try {
+      for await (const m of client.models.list()) {
+        allModelIds.push(m.id);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (isAuthError(err)) {
+        throw new Error(
+          `OrcaRouter rejected the request at ${config.orcarouterUrl} with an authentication error. ` +
+          "Check that ORCAROUTER_API_KEY is valid and has access to the embedding models. " +
+          `Underlying error: ${message}`,
+        );
+      }
+      throw new Error(
+        `OrcaRouter is not reachable at ${config.orcarouterUrl}. ` +
+        "Make sure the gateway is reachable from your network and ORCAROUTER_URL is correct " +
+        "(the URL must include the /v1 suffix). " +
+        `Underlying error: ${message}`,
+      );
+    }
+
+    // Step 2 — model id registered. OrcaRouter's /v1/models returns the full
+    // provider/model namespace; if the configured EMBEDDING_MODEL is missing the
+    // gateway will return a NotFoundError on every embed() call, which is opaque
+    // under high concurrency. Fail early with a hint that points at the model id
+    // rather than at the underlying provider.
+    const modelRegistered = allModelIds.includes(config.embeddingModel);
+    if (!modelRegistered) {
+      const known = allModelIds.slice(0, 10).join(", ");
+      throw new Error(
+        `OrcaRouter is reachable at ${config.orcarouterUrl} but the embedding model ` +
+        `"${config.embeddingModel}" is not registered on the gateway. ` +
+        "Set EMBEDDING_MODEL to a model id from OrcaRouter's /v1/models (e.g. " +
+        "google/gemini-embedding-001 or orcarouter/fusion) and retry. " +
+        (known ? `Currently registered models: ${known}.` : "The gateway currently has no registered models."),
+      );
+    }
+
+    logger.info("OrcaRouter embedding provider ready", {
+      baseUrl: config.orcarouterUrl,
+      model: config.embeddingModel,
+      sendDimensions: shouldSendDimensions(),
+    });
+    // OrcaRouter is a managed SaaS gateway — no containers, no model pulls.
+    return { modelPulled: false, containerStarted: false, imagePulled: false };
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const config = getEmbeddingConfig();
+    const client = getClient();
+    const contextLength = config.embeddingContextLength > 0
+      ? config.embeddingContextLength
+      : DEFAULT_CONTEXT_LENGTH;
+    const truncated = pretruncateTexts(texts, contextLength);
+
+    if (truncated.length <= ORCAROUTER_BATCH_SIZE) {
+      return this._embedBatch(client, truncated, config.embeddingModel, config.embeddingDimensions);
+    }
+
+    const results: number[][] = [];
+    for (let i = 0; i < truncated.length; i += ORCAROUTER_BATCH_SIZE) {
+      const batch = truncated.slice(i, i + ORCAROUTER_BATCH_SIZE);
+      const embeddings = await this._embedBatch(client, batch, config.embeddingModel, config.embeddingDimensions);
+      results.push(...embeddings);
+    }
+    return results;
+  }
+
+  async embedSingle(text: string): Promise<number[]> {
+    const results = await this.embed([text]);
+    if (results.length === 0) {
+      throw new Error("Embedding failed: no result returned");
+    }
+    return results[0];
+  }
+
+  async healthCheck(): Promise<EmbeddingHealthStatus> {
+    const config = getEmbeddingConfig();
+    const lines: string[] = [];
+    const icon = (ok: boolean) => (ok ? "[OK]" : "[MISSING]");
+
+    const hasKey = !!process.env.ORCAROUTER_API_KEY;
+    lines.push(
+      `${icon(hasKey)} OrcaRouter API key: ` +
+      (hasKey ? "Configured" : "Missing — set ORCAROUTER_API_KEY in your MCP config"),
+    );
+    if (!hasKey) {
+      return { available: false, modelReady: false, statusLines: lines };
+    }
+
+    try {
+      const client = getClient();
+      // Same auto-pagination treatment as ensureReady — see the comment there
+      // for why we iterate rather than reading .data directly.
+      const allModelIds: string[] = [];
+      for await (const m of client.models.list()) {
+        allModelIds.push(m.id);
+      }
+      lines.push(`${icon(true)} OrcaRouter: Reachable at ${config.orcarouterUrl}`);
+
+      const modelRegistered = allModelIds.includes(config.embeddingModel);
+      lines.push(
+        `${icon(modelRegistered)} Embedding model (${config.embeddingModel}): ` +
+        (modelRegistered
+          ? "Registered on the gateway"
+          : "Not registered — set EMBEDDING_MODEL to a model id from /v1/models"),
+      );
+
+      return { available: true, modelReady: modelRegistered, statusLines: lines };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (isAuthError(err)) {
+        lines.push(`${icon(false)} OrcaRouter: Auth rejected at ${config.orcarouterUrl} (${message})`);
+      } else {
+        lines.push(`${icon(false)} OrcaRouter: Not reachable at ${config.orcarouterUrl} (${message})`);
+      }
+      return { available: false, modelReady: false, statusLines: lines };
+    }
+  }
+
+  private async _embedBatch(
+    client: OpenAI,
+    texts: string[],
+    model: string,
+    dimensions: number,
+  ): Promise<number[][]> {
+    // Forwarding `dimensions` is opt-in (ORCAROUTER_SEND_DIMENSIONS=true). The
+    // gateway forwards it to the underlying provider verbatim — Matryoshka-aware
+    // models (openai/text-embedding-3-*) accept it; others (Gemini, BGE, Cohere)
+    // reject the request. Default off keeps the provider compatible with arbitrary
+    // model ids.
+    //
+    // `encoding_format: "float"` is REQUIRED. The OpenAI SDK (6.x+) defaults to
+    // `encoding_format: "base64"` and unconditionally decodes the response with
+    // toFloat32Array(). The gateway forwards the original provider's response,
+    // which for many backends (Gemini, BGE-via-TEI, custom HF wrappers) is a JSON
+    // float array. The SDK's decode path then runs `Buffer.from(<array>, 'base64')`,
+    // Node.js silently drops the encoding for array inputs and clamps each float
+    // (<1.0) to uint8 0, producing a zero buffer reinterpreted as a Float32Array
+    // of zeros. This is the same bug fixed for LM Studio in commit bb141a0 and
+    // applied to LiteLLM in provider-litellm.ts; the failure mode reproduces
+    // against any gateway alias whose backend doesn't re-encode to base64.
+    // Setting `encoding_format: "float"` makes the SDK skip the decode step.
+    const response = await client.embeddings.create({
+      model,
+      input: texts,
+      encoding_format: "float",
+      ...(shouldSendDimensions() ? { dimensions } : {}),
+    });
+    const sorted = response.data.sort((a, b) => a.index - b.index);
+    return sorted.map((d) => d.embedding);
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function shouldSendDimensions(): boolean {
+  const raw = process.env.ORCAROUTER_SEND_DIMENSIONS;
+  if (!raw) return false;
+  const v = raw.toLowerCase();
+  return v === "true" || v === "1" || v === "yes";
+}

--- a/tests/unit/embedding-config.test.ts
+++ b/tests/unit/embedding-config.test.ts
@@ -28,6 +28,9 @@ describe("embedding-config", () => {
     delete process.env.LITELLM_URL;
     delete process.env.LITELLM_API_KEY;
     delete process.env.LITELLM_SEND_DIMENSIONS;
+    delete process.env.ORCAROUTER_URL;
+    delete process.env.ORCAROUTER_API_KEY;
+    delete process.env.ORCAROUTER_SEND_DIMENSIONS;
   });
 
   afterEach(() => {
@@ -209,6 +212,7 @@ describe("embedding-config", () => {
         ollamaUrl: "http://remote-gpu:11434",
         lmstudioUrl: "http://localhost:1234/v1",
         litellmUrl: "http://localhost:4000/v1",
+        orcarouterUrl: "https://api.orcarouter.ai/v1",
         embeddingModel: "mxbai-embed-large",
         embeddingDimensions: 1024,
         embeddingContextLength: 512,
@@ -247,7 +251,7 @@ describe("embedding-config", () => {
     it("throws for invalid EMBEDDING_PROVIDER", () => {
       process.env.EMBEDDING_PROVIDER = "anthropic";
       expect(() => loadEmbeddingConfig()).toThrow(
-        'Invalid EMBEDDING_PROVIDER: "anthropic". Must be "ollama", "openai", "google", "lmstudio", or "litellm".',
+        'Invalid EMBEDDING_PROVIDER: "anthropic". Must be "ollama", "openai", "google", "lmstudio", "litellm", or "orcarouter".',
       );
     });
 
@@ -465,6 +469,132 @@ describe("embedding-config", () => {
 
       const config = loadEmbeddingConfig();
       expect(config.embeddingContextLength).toBe(8191);
+    });
+  });
+
+  describe("orcarouter provider", () => {
+    it("loads when API key, model, and dimensions are all set", () => {
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+      process.env.ORCAROUTER_API_KEY = "or_test_key";
+      process.env.EMBEDDING_MODEL = "google/gemini-embedding-001";
+      process.env.EMBEDDING_DIMENSIONS = "3072";
+
+      const config = loadEmbeddingConfig();
+      expect(config.embeddingProvider).toBe("orcarouter");
+      expect(config.embeddingModel).toBe("google/gemini-embedding-001");
+      expect(config.embeddingDimensions).toBe(3072);
+    });
+
+    it("defaults ORCAROUTER_URL to https://api.orcarouter.ai/v1", () => {
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+      process.env.ORCAROUTER_API_KEY = "or_test_key";
+      process.env.EMBEDDING_MODEL = "google/gemini-embedding-001";
+      process.env.EMBEDDING_DIMENSIONS = "3072";
+
+      const config = loadEmbeddingConfig();
+      expect(config.orcarouterUrl).toBe("https://api.orcarouter.ai/v1");
+    });
+
+    it("respects ORCAROUTER_URL override", () => {
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+      process.env.ORCAROUTER_API_KEY = "or_test_key";
+      process.env.EMBEDDING_MODEL = "openai/text-embedding-3-small";
+      process.env.EMBEDDING_DIMENSIONS = "1536";
+      process.env.ORCAROUTER_URL = "https://orcarouter.internal:443/v1";
+
+      const config = loadEmbeddingConfig();
+      expect(config.orcarouterUrl).toBe("https://orcarouter.internal:443/v1");
+    });
+
+    it("throws when ORCAROUTER_API_KEY is missing", () => {
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+      process.env.EMBEDDING_MODEL = "google/gemini-embedding-001";
+      process.env.EMBEDDING_DIMENSIONS = "3072";
+
+      expect(() => loadEmbeddingConfig()).toThrow(
+        /ORCAROUTER_API_KEY is required when EMBEDDING_PROVIDER=orcarouter/,
+      );
+    });
+
+    it("throws when EMBEDDING_MODEL is missing", () => {
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+      process.env.ORCAROUTER_API_KEY = "or_test_key";
+      process.env.EMBEDDING_DIMENSIONS = "3072";
+
+      expect(() => loadEmbeddingConfig()).toThrow(
+        /EMBEDDING_MODEL is required when EMBEDDING_PROVIDER=orcarouter/,
+      );
+    });
+
+    it("throws when EMBEDDING_DIMENSIONS is missing", () => {
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+      process.env.ORCAROUTER_API_KEY = "or_test_key";
+      process.env.EMBEDDING_MODEL = "google/gemini-embedding-001";
+
+      expect(() => loadEmbeddingConfig()).toThrow(
+        /EMBEDDING_DIMENSIONS is required when EMBEDDING_PROVIDER=orcarouter/,
+      );
+    });
+
+    it("validates the API_KEY check before model/dimension checks", () => {
+      // All three are missing — the API key error must surface first so the
+      // operator sees the most fundamental missing piece.
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+
+      expect(() => loadEmbeddingConfig()).toThrow(
+        /ORCAROUTER_API_KEY is required/,
+      );
+    });
+
+    it("includes example model ids in the model error message for discoverability", () => {
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+      process.env.ORCAROUTER_API_KEY = "or_test_key";
+      process.env.EMBEDDING_DIMENSIONS = "3072";
+
+      expect(() => loadEmbeddingConfig()).toThrow(
+        /google\/gemini-embedding-001/,
+      );
+    });
+
+    it("includes example dimensions in the error message for discoverability", () => {
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+      process.env.ORCAROUTER_API_KEY = "or_test_key";
+      process.env.EMBEDDING_MODEL = "google/gemini-embedding-001";
+
+      expect(() => loadEmbeddingConfig()).toThrow(
+        /3072 for google\/gemini-embedding-001/,
+      );
+    });
+
+    it("auto-detects context length when model id matches a well-known name", () => {
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+      process.env.ORCAROUTER_API_KEY = "or_test_key";
+      process.env.EMBEDDING_MODEL = "openai/text-embedding-3-small";
+      process.env.EMBEDDING_DIMENSIONS = "1536";
+
+      const config = loadEmbeddingConfig();
+      expect(config.embeddingContextLength).toBe(8191);
+    });
+
+    it("auto-detects context length for gemini-embedding model ids", () => {
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+      process.env.ORCAROUTER_API_KEY = "or_test_key";
+      process.env.EMBEDDING_MODEL = "google/gemini-embedding-001";
+      process.env.EMBEDDING_DIMENSIONS = "3072";
+
+      const config = loadEmbeddingConfig();
+      expect(config.embeddingContextLength).toBe(2048);
+    });
+
+    it("respects EMBEDDING_CONTEXT_LENGTH override for unknown model ids", () => {
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+      process.env.ORCAROUTER_API_KEY = "or_test_key";
+      process.env.EMBEDDING_MODEL = "orcarouter/fusion";
+      process.env.EMBEDDING_DIMENSIONS = "3072";
+      process.env.EMBEDDING_CONTEXT_LENGTH = "8192";
+
+      const config = loadEmbeddingConfig();
+      expect(config.embeddingContextLength).toBe(8192);
     });
   });
 });

--- a/tests/unit/embedding-provider.test.ts
+++ b/tests/unit/embedding-provider.test.ts
@@ -24,6 +24,9 @@ describe("embedding-provider", () => {
     delete process.env.LITELLM_URL;
     delete process.env.LITELLM_API_KEY;
     delete process.env.LITELLM_SEND_DIMENSIONS;
+    delete process.env.ORCAROUTER_URL;
+    delete process.env.ORCAROUTER_API_KEY;
+    delete process.env.ORCAROUTER_SEND_DIMENSIONS;
   });
 
   afterEach(() => {
@@ -65,6 +68,15 @@ describe("embedding-provider", () => {
       process.env.EMBEDDING_DIMENSIONS = "1536";
       const provider = await getEmbeddingProvider();
       expect(provider.name).toBe("litellm");
+    });
+
+    it("creates OrcaRouterEmbeddingProvider when configured", async () => {
+      process.env.EMBEDDING_PROVIDER = "orcarouter";
+      process.env.ORCAROUTER_API_KEY = "or_test_key";
+      process.env.EMBEDDING_MODEL = "google/gemini-embedding-001";
+      process.env.EMBEDDING_DIMENSIONS = "3072";
+      const provider = await getEmbeddingProvider();
+      expect(provider.name).toBe("orcarouter");
     });
 
     it("caches provider instance", async () => {
@@ -295,6 +307,92 @@ describe("LiteLLMEmbeddingProvider", () => {
     expect(
       health.statusLines.some(
         (l) => l.includes("LiteLLM") && l.includes("Not reachable"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("OrcaRouterEmbeddingProvider", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    resetEmbeddingConfig();
+    resetEmbeddingProvider();
+    delete process.env.EMBEDDING_PROVIDER;
+    delete process.env.EMBEDDING_MODEL;
+    delete process.env.EMBEDDING_DIMENSIONS;
+    delete process.env.EMBEDDING_CONTEXT_LENGTH;
+    delete process.env.ORCAROUTER_URL;
+    delete process.env.ORCAROUTER_API_KEY;
+    delete process.env.ORCAROUTER_SEND_DIMENSIONS;
+  });
+
+  afterEach(() => {
+    resetEmbeddingConfig();
+    resetEmbeddingProvider();
+    process.env = { ...originalEnv };
+  });
+
+  it("config validation rejects construction when ORCAROUTER_API_KEY is missing", async () => {
+    // The API key is checked at config-load time (loadEmbeddingConfig), not at
+    // factory invocation, so the throw surfaces inside getEmbeddingProvider().
+    process.env.EMBEDDING_PROVIDER = "orcarouter";
+    process.env.EMBEDDING_MODEL = "google/gemini-embedding-001";
+    process.env.EMBEDDING_DIMENSIONS = "3072";
+    // Intentionally no ORCAROUTER_API_KEY.
+
+    await expect(getEmbeddingProvider()).rejects.toThrow(/ORCAROUTER_API_KEY is required/);
+  });
+
+  it("ensureReady throws an actionable error when the gateway is unreachable", async () => {
+    process.env.EMBEDDING_PROVIDER = "orcarouter";
+    process.env.ORCAROUTER_API_KEY = "or_test_key";
+    process.env.EMBEDDING_MODEL = "google/gemini-embedding-001";
+    process.env.EMBEDDING_DIMENSIONS = "3072";
+    // Closed port → SDK fails fast with a connection error, not an auth error.
+    process.env.ORCAROUTER_URL = "http://127.0.0.1:1/v1";
+
+    const provider = await getEmbeddingProvider();
+    await expect(provider.ensureReady()).rejects.toThrow(
+      /OrcaRouter is not reachable at http:\/\/127\.0\.0\.1:1\/v1/,
+    );
+  });
+
+  it("healthCheck reports missing API key without making any network call", async () => {
+    process.env.EMBEDDING_PROVIDER = "orcarouter";
+    process.env.ORCAROUTER_API_KEY = "or_test_key";
+    process.env.EMBEDDING_MODEL = "google/gemini-embedding-001";
+    process.env.EMBEDDING_DIMENSIONS = "3072";
+    // Even with a deliberately closed port, missing-key path must short-circuit
+    // before the SDK attempts a connection, so the test stays deterministic.
+    process.env.ORCAROUTER_URL = "http://127.0.0.1:1/v1";
+
+    const provider = await getEmbeddingProvider();
+    // Now drop the key for the health-check call only — the provider re-reads
+    // process.env on each invocation (intentional, see provider-orcarouter.ts).
+    delete process.env.ORCAROUTER_API_KEY;
+
+    const health = await provider.healthCheck();
+    expect(health.available).toBe(false);
+    expect(health.modelReady).toBe(false);
+    expect(health.statusLines.some((l) => l.includes("OrcaRouter API key") && l.includes("Missing"))).toBe(true);
+  });
+
+  it("healthCheck reports unreachable gateway without throwing", async () => {
+    process.env.EMBEDDING_PROVIDER = "orcarouter";
+    process.env.ORCAROUTER_API_KEY = "or_test_key";
+    process.env.EMBEDDING_MODEL = "google/gemini-embedding-001";
+    process.env.EMBEDDING_DIMENSIONS = "3072";
+    process.env.ORCAROUTER_URL = "http://127.0.0.1:1/v1";
+
+    const provider = await getEmbeddingProvider();
+    const health = await provider.healthCheck();
+
+    expect(health.available).toBe(false);
+    expect(health.modelReady).toBe(false);
+    expect(
+      health.statusLines.some(
+        (l) => l.includes("OrcaRouter") && l.includes("Not reachable"),
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
## Summary

SocratiCode's "Multi-provider embeddings" already covers local (Ollama), SaaS (OpenAI, Google Gemini), a local OpenAI-compatible server (LM Studio), and a self-hosted gateway (LiteLLM). This PR adds [OrcaRouter](https://www.orcarouter.ai) as a first-class named provider, so users can point `EMBEDDING_PROVIDER=orcarouter` and use the OrcaRouter AI gateway directly instead of treating it as an anonymous custom base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The implementation mirrors the existing `provider-litellm.ts` pattern (an OpenAI-compatible gateway reached through the OpenAI SDK with a custom base URL), since OrcaRouter's model ids (`google/gemini-embedding-001`, `openai/text-embedding-3-small`, `orcarouter/fusion`) follow the same `provider/model` namespace shape as OpenRouter.

## Changes

- **`src/services/provider-orcarouter.ts`** — new `OrcaRouterEmbeddingProvider` implementing `EmbeddingProvider`: OpenAI-SDK client pinned to `ORCAROUTER_URL` (default `https://api.orcarouter.ai/v1`), `encoding_format: "float"` (the same base64-decode fix documented for LM Studio/LiteLLM), opt-in `dimensions` forwarding via `ORCAROUTER_SEND_DIMENSIONS`, and an `ensureReady()` that iterates `/v1/models` to fail early on an unregistered model id.
- **`src/services/embedding-config.ts`** — registers `orcarouter` in the `EmbeddingProvider` union and `PROVIDER_DEFAULTS`, adds `ORCAROUTER_URL` / `ORCAROUTER_API_KEY` / `ORCAROUTER_SEND_DIMENSIONS` with fail-fast validation (all three of key/model/dimensions required, mirroring LiteLLM), and extends the context-length table with OrcaRouter-prefixed model ids so `google/gemini-embedding-001` and `openai/text-embedding-3-*` auto-detect.
- **`src/services/embedding-provider.ts`** — factory case for `orcarouter` via dynamic import.
- **`tests/unit/embedding-config.test.ts`** / **`tests/unit/embedding-provider.test.ts`** — config validation, factory construction, unreachable-gateway, and missing-key health-check coverage, mirroring the LiteLLM test groups.
- **`README.md`** / **`DEVELOPER.md`** — new "OrcaRouter (AI gateway)" section with an MCP config example, `ORCAROUTER_*` env-var table, and provider docs, using the same wording conventions as the existing LiteLLM entries.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Test coverage improvement

## Testing

- [x] Unit tests pass (`npm run test:unit`) — 1198 passed (55 files), including the new orcarouter groups
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Lint clean (`npm run lint`) — biome check on `src/` and `tests/`
- [x] `npm run build` succeeds
- [x] New tests added for new/changed functionality
- [x] Live verification against the OrcaRouter gateway: `ensureReady()` lists `google/gemini-embedding-001` as registered, `embed(["hello world", ...])` returns 2×3072-dim vectors, `healthCheck()` reports available + modelReady; `ORCAROUTER_SEND_DIMENSIONS=true` with `openai/text-embedding-3-small` returns 256-dim vectors

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate
- [x] I have updated documentation (README.md / DEVELOPER.md) if needed
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

## Related issues

None.

---

I'm an engineer on the OrcaRouter team.
Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OrcaRouter as an OpenAI-compatible embedding provider.
  - Added configuration for OrcaRouter URLs, API keys, models, dimensions, and context lengths.
  - Added connection checks, model validation, health reporting, batching, and optional dimension forwarding.
  - Updated supported-provider documentation and configuration examples.

- **Tests**
  - Added coverage for OrcaRouter configuration, validation, connectivity, and health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->