### PR TITLE
Stop concurrent callers from racing to create the metadata collection

### DIFF
--- a/src/services/qdrant.ts
+++ b/src/services/qdrant.ts
@@ -158,16 +158,45 @@ export async function ensureCollection(name: string): Promise<void> {
   }
 }
 
-/** Create a payload index on a collection (idempotent — ignores "already exists" errors) */
-export async function ensurePayloadIndex(collName: string, fieldName: string): Promise<void> {
+/** True when an error means "someone else already created it" — safe to ignore. */
+function isAlreadyExistsError(err: unknown): boolean {
+  const status =
+    (err as { status?: number })?.status ?? (err as { statusCode?: number })?.statusCode;
+  const message = err instanceof Error ? err.message : String(err);
+  return status === 409 || /already exists/i.test(message);
+}
+
+/**
+ * Create a payload index, ignoring only the "it is already there" conflict.
+ *
+ * Every other failure propagates: a 503 leaves the collection without the index,
+ * and a caller that swallows it can never tell that it still has work to do.
+ */
+async function createPayloadIndexIfMissing(collName: string, fieldName: string): Promise<void> {
   const qdrant = getClient();
   try {
     await qdrant.createPayloadIndex(collName, {
       field_name: fieldName,
       field_schema: "keyword",
     });
-  } catch {
-    // Index already exists — ignore
+  } catch (err) {
+    if (!isAlreadyExistsError(err)) throw err;
+    // Index already exists — that is the end state we wanted.
+  }
+}
+
+/** Create a payload index on a collection (best effort — never throws) */
+export async function ensurePayloadIndex(collName: string, fieldName: string): Promise<void> {
+  try {
+    await createPayloadIndexIfMissing(collName, fieldName);
+  } catch (err) {
+    // Callers of this helper index their payload opportunistically: a missing
+    // index costs filter performance but does not make their write incorrect.
+    logger.debug("ensurePayloadIndex failed (ignored)", {
+      collection: collName,
+      field: fieldName,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 
@@ -716,32 +745,74 @@ const METADATA_COLLECTION = `${QDRANT_COLLECTION_PREFIX}socraticode_metadata`;
 /** Cached flag: once the metadata collection is confirmed to exist, skip re-checking */
 let metadataCollectionReady = false;
 
+/**
+ * In-flight creation shared by concurrent callers.
+ *
+ * `ensureMetadataCollection` is awaited from more than ten call sites, several of
+ * which run concurrently at startup (readiness checks, hash loading, graph
+ * loading). The readiness flag is only set *after* creation finishes, so without
+ * this every concurrent caller sees "does not exist" and races to create the
+ * collection — all but the first then fail with a 409 Conflict, which surfaces as
+ * `loadProjectHashes(...) failed [status 409]: Conflict` and aborts indexing.
+ */
+let metadataCollectionInFlight: Promise<void> | null = null;
+
 /** Reset the metadata collection readiness cache (for testing only) */
 export function resetMetadataCollectionCache(): void {
   metadataCollectionReady = false;
+  metadataCollectionInFlight = null;
 }
 
-/** Ensure the metadata collection exists (idempotent, cached after first success) */
+/** Ensure the metadata collection exists (idempotent, cached, concurrency-safe) */
 async function ensureMetadataCollection(): Promise<void> {
   if (metadataCollectionReady) return;
+  // Join the in-flight creation instead of starting a second one.
+  if (metadataCollectionInFlight) return metadataCollectionInFlight;
 
-  const qdrant = getClient();
-  const collections = await qdrant.getCollections();
-  const exists = collections.collections.some((c) => c.name === METADATA_COLLECTION);
-  if (!exists) {
-    // Metadata collection uses a dummy 1-dim vector since Qdrant requires vectors
-    await qdrant.createCollection(METADATA_COLLECTION, {
-      vectors: { size: 1, distance: "Cosine" },
-      on_disk_payload: true,
-    });
-    await qdrant.createPayloadIndex(METADATA_COLLECTION, {
-      field_name: "collectionName",
-      field_schema: "keyword",
-    });
-    logger.info("Created metadata collection");
+  const attempt = (async () => {
+    const qdrant = getClient();
+    const collections = await qdrant.getCollections();
+    const exists = collections.collections.some((c) => c.name === METADATA_COLLECTION);
+    if (!exists) {
+      try {
+        // Metadata collection uses a dummy 1-dim vector since Qdrant requires vectors
+        await qdrant.createCollection(METADATA_COLLECTION, {
+          vectors: { size: 1, distance: "Cosine" },
+          on_disk_payload: true,
+        });
+        logger.info("Created metadata collection");
+      } catch (err) {
+        // Another process (a second MCP instance on the same Qdrant) may have won
+        // the race. That is the desired end state, so treat it as success.
+        if (!isAlreadyExistsError(err)) throw err;
+        logger.info("Metadata collection already created by another process");
+      }
+    }
+
+    // Outside the `!exists` branch on purpose: if an earlier attempt created the
+    // collection but failed before indexing, every later attempt sees the
+    // collection and would otherwise skip indexing forever. Creating the index
+    // is idempotent, so calling it unconditionally is safe.
+    //
+    // A failure here has to propagate. The metadata collection is queried by
+    // `collectionName`, so without the index it is not usable, and swallowing
+    // the failure would mark the collection ready and never retry the index in
+    // this process.
+    await createPayloadIndexIfMissing(METADATA_COLLECTION, "collectionName");
+  })();
+  metadataCollectionInFlight = attempt;
+
+  try {
+    await attempt;
+    // Only the attempt that is still the current one may publish readiness, so a
+    // cache reset that lands mid-attempt is not undone by it.
+    if (metadataCollectionInFlight === attempt) metadataCollectionReady = true;
+  } finally {
+    // Clear on failure too, so a transient Qdrant blip can be retried. Guarded by
+    // identity so a later caller's in-flight promise is never dropped — the cache
+    // may have been reset while this attempt was running.
+    if (metadataCollectionInFlight === attempt) metadataCollectionInFlight = null;
   }
-
-  metadataCollectionReady = true;
 }
 
 /** Generate a stable UUID from a collection name (for Qdrant point ID).

--- a/tests/unit/qdrant-metadata-collection-race.test.ts
+++ b/tests/unit/qdrant-metadata-collection-race.test.ts
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+//
+// ensureMetadataCollection() is awaited from more than ten exported functions,
+// several of which run concurrently at startup. It is guarded by a boolean that
+// is only set *after* creation finishes, so concurrent callers used to all see
+// "does not exist" and all call createCollection — every caller but the first
+// got a 409 Conflict, surfacing as
+// `loadProjectHashes(...) failed [status 409]: Conflict` and aborting indexing.
+//
+// These tests drive the private helper through its exported callers and assert
+// that (a) concurrent callers create the collection exactly once, (b) every
+// shape of "already exists" from a *different process* counts as success rather
+// than an error, (c) the payload index is ensured even when creation is skipped,
+// and (d) a transient failure of either call, or a cache reset, leaves the next
+// caller free to try again.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/services/logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const mockGetCollections = vi.fn();
+const mockCreateCollection = vi.fn();
+const mockCreatePayloadIndex = vi.fn();
+const mockRetrieve = vi.fn();
+
+vi.mock("@qdrant/js-client-rest", () => ({
+  QdrantClient: class {
+    getCollections = mockGetCollections;
+    createCollection = mockCreateCollection;
+    createPayloadIndex = mockCreatePayloadIndex;
+    retrieve = mockRetrieve;
+  },
+}));
+
+/** A rejection shaped like the Qdrant REST client's 409 Conflict. */
+function conflict(): Error & { status: number } {
+  const err: Error & { status?: number } = new Error("Conflict");
+  err.status = 409;
+  return err as Error & { status: number };
+}
+
+/** A 409 exposed as `statusCode` instead of `status`, as some clients report it. */
+function conflictWithStatusCode(): Error & { statusCode: number } {
+  const err: Error & { statusCode?: number } = new Error("Conflict");
+  err.statusCode = 409;
+  return err as Error & { statusCode: number };
+}
+
+/** A rejection that only says "already exists", carrying no status at all. */
+function alreadyExistsMessage(collection: string): Error {
+  return new Error(`Collection \`${collection}\` already exists!`);
+}
+
+/** A rejection shaped like a transient Qdrant outage. */
+function unavailable(): Error & { status: number } {
+  const err: Error & { status?: number } = new Error("Service Unavailable");
+  err.status = 503;
+  return err as Error & { status: number };
+}
+
+/**
+ * The metadata collection name as the module under test builds it.
+ *
+ * `src/services/qdrant.ts` prepends `QDRANT_COLLECTION_PREFIX` to
+ * `socraticode_metadata` at module load, so hardcoding the unprefixed name
+ * breaks whenever the env var is set. Read it back from the same module
+ * registry the test just imported from, after `vi.resetModules()`.
+ */
+async function metadataCollectionName(): Promise<string> {
+  const { QDRANT_COLLECTION_PREFIX } = await import("../../src/constants.js");
+  return `${QDRANT_COLLECTION_PREFIX}socraticode_metadata`;
+}
+
+/** Defer resolution so we can hold createCollection open across callers. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("ensureMetadataCollection concurrency", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetCollections.mockReset();
+    mockCreateCollection.mockReset();
+    mockCreatePayloadIndex.mockReset();
+    mockRetrieve.mockReset();
+    // The metadata collection does not exist yet, so every caller wants to create it.
+    mockGetCollections.mockResolvedValue({ collections: [] });
+    mockCreatePayloadIndex.mockResolvedValue(undefined);
+    mockRetrieve.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates the collection once when three callers start together", async () => {
+    const gate = deferred<void>();
+    mockCreateCollection.mockImplementation(() => gate.promise);
+
+    const { loadProjectHashes } = await import("../../src/services/qdrant.js");
+
+    // All three observe "does not exist" before any creation finishes.
+    const all = Promise.all([
+      loadProjectHashes("codebase_a"),
+      loadProjectHashes("codebase_b"),
+      loadProjectHashes("codebase_c"),
+    ]);
+    gate.resolve();
+    await all;
+
+    expect(mockCreateCollection).toHaveBeenCalledTimes(1);
+    expect(mockCreatePayloadIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report an error when another process wins the race", async () => {
+    mockCreateCollection.mockRejectedValue(conflict());
+
+    const { loadProjectHashes } = await import("../../src/services/qdrant.js");
+
+    // A 409 means the collection now exists, which is the desired end state.
+    await expect(loadProjectHashes("codebase_a")).resolves.toBeNull();
+    expect(mockCreateCollection).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts an already-exists message that carries no status", async () => {
+    mockCreateCollection.mockRejectedValue(alreadyExistsMessage(await metadataCollectionName()));
+
+    const { loadProjectHashes } = await import("../../src/services/qdrant.js");
+
+    await expect(loadProjectHashes("codebase_a")).resolves.toBeNull();
+    expect(mockCreateCollection).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts a 409 reported as statusCode rather than status", async () => {
+    mockCreateCollection.mockRejectedValue(conflictWithStatusCode());
+
+    const { loadProjectHashes } = await import("../../src/services/qdrant.js");
+
+    await expect(loadProjectHashes("codebase_a")).resolves.toBeNull();
+    expect(mockCreateCollection).toHaveBeenCalledTimes(1);
+  });
+
+  it("tolerates a conflict on the payload index too", async () => {
+    mockCreateCollection.mockRejectedValue(conflict());
+    mockCreatePayloadIndex.mockRejectedValue(conflict());
+
+    const { loadProjectHashes } = await import("../../src/services/qdrant.js");
+
+    await expect(loadProjectHashes("codebase_a")).resolves.toBeNull();
+  });
+
+  it("still surfaces failures that are not conflicts", async () => {
+    mockCreateCollection.mockRejectedValue(unavailable());
+
+    const { loadProjectHashes } = await import("../../src/services/qdrant.js");
+
+    await expect(loadProjectHashes("codebase_a")).rejects.toThrow(/Service Unavailable/);
+  });
+
+  it("rejects when the payload index fails, then retries the index next call", async () => {
+    const collection = await metadataCollectionName();
+    // The collection is created on the first attempt and exists from then on, so
+    // the second attempt reaches the index without recreating anything.
+    mockGetCollections
+      .mockResolvedValueOnce({ collections: [] })
+      .mockResolvedValue({ collections: [{ name: collection }] });
+    mockCreateCollection.mockResolvedValue(undefined);
+    mockCreatePayloadIndex.mockRejectedValueOnce(unavailable()).mockResolvedValue(undefined);
+
+    const { loadProjectHashes } = await import("../../src/services/qdrant.js");
+
+    // A collection without its `collectionName` index is not usable. Reporting
+    // success here would mark the collection ready and strand it unindexed for
+    // the rest of the process, so the failure has to reach the caller.
+    await expect(loadProjectHashes("codebase_a")).rejects.toThrow(/Service Unavailable/);
+
+    // Nothing was cached as ready, so the next caller retries the index — and
+    // this time it lands.
+    await expect(loadProjectHashes("codebase_b")).resolves.toBeNull();
+
+    expect(mockCreatePayloadIndex).toHaveBeenCalledTimes(2);
+    expect(mockCreatePayloadIndex).toHaveBeenLastCalledWith(collection, {
+      field_name: "collectionName",
+      field_schema: "keyword",
+    });
+    // The collection itself was only ever created once.
+    expect(mockCreateCollection).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries creation after a transient failure instead of caching it", async () => {
+    mockCreateCollection.mockRejectedValueOnce(unavailable()).mockResolvedValueOnce(undefined);
+
+    const { loadProjectHashes } = await import("../../src/services/qdrant.js");
+
+    // The first attempt propagates the failure.
+    await expect(loadProjectHashes("codebase_a")).rejects.toThrow(/Service Unavailable/);
+    // The in-flight promise must have been cleared, so a second call tries again
+    // instead of reusing the rejected promise forever.
+    await expect(loadProjectHashes("codebase_a")).resolves.toBeNull();
+
+    expect(mockCreateCollection).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets a cache reset during creation stand", async () => {
+    const gate = deferred<void>();
+    const entered = deferred<void>();
+    mockCreateCollection.mockImplementation(() => {
+      entered.resolve();
+      return gate.promise;
+    });
+
+    const { loadProjectHashes, resetMetadataCollectionCache } = await import(
+      "../../src/services/qdrant.js"
+    );
+
+    const first = loadProjectHashes("codebase_a");
+    await entered.promise;
+    // The reset lands while the first caller is still creating the collection.
+    resetMetadataCollectionCache();
+    gate.resolve();
+    await first;
+
+    // The finished attempt is no longer the current one, so it must not mark the
+    // cache ready again — the next caller has to re-check the server.
+    await loadProjectHashes("codebase_b");
+    expect(mockGetCollections).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips creation but still ensures the index when the collection exists", async () => {
+    mockGetCollections.mockResolvedValue({
+      collections: [{ name: await metadataCollectionName() }],
+    });
+
+    const { loadProjectHashes } = await import("../../src/services/qdrant.js");
+
+    await loadProjectHashes("codebase_a");
+    await loadProjectHashes("codebase_b");
+
+    expect(mockCreateCollection).not.toHaveBeenCalled();
+    // An earlier run may have created the collection and then failed before
+    // indexing it, so the index is ensured even when creation is skipped.
+    expect(mockCreatePayloadIndex).toHaveBeenCalledTimes(1);
+    // The readiness flag short-circuits the second call, so only one listing happens.
+    expect(mockGetCollections).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

`ensureMetadataCollection()` is awaited from more than ten exported functions, several of which run concurrently while a project is being opened. The guard flag is only set after creation finishes, so every concurrent caller sees "does not exist" and calls `createCollection`. All callers but the first get a 409 Conflict, which propagates as `loadProjectHashes(collName=...) failed [status 409]: Conflict` and aborts indexing. It reproduces against an external Qdrant, where the creation round trip is long enough for the callers to overlap.

## Changes

- Share the in-flight creation promise so concurrent callers join it instead of starting a second creation. The promise is cleared in a `finally` block so a transient Qdrant failure can be retried rather than cached forever. Both that clear and the readiness flag are guarded by promise identity, so a `resetMetadataCollectionCache()` landing mid-creation is neither undone by the finishing attempt nor able to have its replacement promise overwritten.
- Treat "already exists" (409, or a message saying so) as success for `createCollection`. A second MCP instance pointed at the same Qdrant can legitimately win the race, and the end state is the one we wanted. Other failures still propagate.
- Ensure the payload index through the existing idempotent `ensurePayloadIndex()` helper rather than a second inline `createPayloadIndex`, and call it on every attempt instead of only on the creation path. An attempt that created the collection and then failed before indexing used to leave the collection permanently unindexed, because every later attempt saw the collection and skipped the index along with the creation.

Note that the shared helper ignores all index errors, not only conflicts. Narrowing that is left alone here, since it applies equally to its existing caller.

<details>
<summary>日本語の説明 (Japanese explanation)</summary>

### 何を直すか

メタデータ用のコレクションを複数の処理が同時に作ろうとして、インデックス構築が失敗するバグを直します。

### なぜ必要か

`ensureMetadataCollection()` は 10 個以上の関数から呼ばれ、プロジェクトを開くときに複数が同時に走ります（準備確認・ハッシュ読み込み・グラフ読み込みなど）。作成済みを示すフラグは作成が終わってから立つため、同時に走った呼び出しはすべて「まだ無い」と判断し、すべてが作成を試みます。最初の 1 つ以外は 409 Conflict を受け取り、インデックス構築が止まります。

外部の Qdrant を使うと再現します。作成の往復に時間がかかり、呼び出しが重なるためです。

### 変更の内容

作成中の Promise を共有し、同時に来た呼び出しは 2 度目の作成を始めず、進行中のものに合流します。`finally` で解放するため、一時的な失敗はやり直せます。解放と準備完了フラグの設定は、どちらも「自分が入れた Promise か」の判定の下に置いています。

「既にある」を成功として扱います。同じ Qdrant を指す別のインスタンスが競争に勝つことは正当で、結果として望んだ状態になるためです。

payload index の作成は、既存の冪等なヘルパを使い、毎回呼ぶ形にしました。以前は作成経路でしか呼ばれなかったため、コレクションを作った直後に index 作成が失敗すると、以降そのコレクションは恒久的に index を欠いていました。

</details>

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement

## Testing

- [x] Unit tests pass (`npm run test:unit`) — 56 files, 1191 tests
- [ ] Integration tests pass (`npm run test:integration`) — not run; requires Docker
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] New tests added for new/changed functionality

Tests cover the concurrent case, all three shapes of "already exists", retry after a transient failure, non-conflict failures of both calls, a cache reset landing mid-creation, and the index being ensured when creation is skipped. Reverting `src/services/qdrant.ts` to `main` fails 8 of the 10 tests, so they exercise the implementation rather than a copy of it.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate
- [x] I have updated documentation (README.md / DEVELOPER.md) if needed — no public API change, so no doc update
- [ ] I have addressed all [CodeRabbit](https://coderabbit.ai) review comments (or marked as resolved with explanation) — CodeRabbit runs after this PR is opened; I will address its comments then
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

## Related issues

None. Happy to move the discussion to an issue first if you prefer that for changes of this size.

---

This is one of five independent branches I am offering. The other four are feature additions around the embedding configuration; this one is the only bug fix, so I am opening it first. `src/services/ensureCollection()` and the private twin in `src/services/symbol-graph-store.ts` still have the same check-then-create shape — I kept this PR to the metadata collection to stay on one logical change, and I am glad to follow up on those separately if you want them fixed the same way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple operations initialize metadata storage simultaneously.
  * Prevented already-existing collection conflicts from causing failures.
  * Ensured required metadata indexes are restored after interrupted setup.
  * Improved recovery after temporary setup failures and cache resets.
  * Added build-version information to saved graph metadata.

* **Tests**
  * Added coverage for concurrent initialization, conflict handling, retries, resets, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->