### PR TITLE
Accept OpenAI-compatible servers without /v1/models

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,7 +706,37 @@ or when you want a Mac/Windows-friendly desktop UI for managing GGUF models).
 > fails fast if either is missing.
 >
 > Optional: `LMSTUDIO_URL` (default `http://localhost:1234/v1`) for non-default ports;
-> `LMSTUDIO_API_KEY` if you've enabled API key auth in LM Studio.
+> `LMSTUDIO_API_KEY` if you've enabled API key auth in LM Studio;
+> `LMSTUDIO_ALLOW_MISSING_MODEL_LISTING=true` for OpenAI-compatible servers that have no
+> `/v1/models` endpoint (see below).
+
+This provider also drives any other server that speaks the OpenAI embeddings API.
+Single-model servers such as [HuggingFace Text Embeddings Inference](https://github.com/huggingface/text-embeddings-inference)
+(TEI) fix the model at startup and answer `/v1/models` with a 404, so readiness needs
+`LMSTUDIO_ALLOW_MISSING_MODEL_LISTING=true` to fall back to probing `/v1/embeddings`:
+
+```json
+{
+  "mcpServers": {
+    "socraticode": {
+      "command": "node",
+      "args": ["/absolute/path/to/socraticode/dist/index.js"],
+      "env": {
+        "EMBEDDING_PROVIDER": "lmstudio",
+        "LMSTUDIO_URL": "http://localhost:8080/v1",
+        "EMBEDDING_MODEL": "BAAI/bge-m3",
+        "EMBEDDING_DIMENSIONS": "1024",
+        "LMSTUDIO_ALLOW_MISSING_MODEL_LISTING": "true"
+      }
+    }
+  }
+}
+```
+
+> `EMBEDDING_MODEL` is whatever the server was started with (TEI's `--model-id`) and
+> `EMBEDDING_DIMENSIONS` must match that model's output width — the probe checks it and
+> fails fast on a mismatch, since without `/v1/models` there is nothing else to verify
+> against.
 
 #### LiteLLM (proxy gateway, 100+ providers)
 
@@ -1207,6 +1237,7 @@ The rest of this section documents the variables themselves. Pass them using whi
 |----------|---------|-------------|
 | `LMSTUDIO_URL` | `http://localhost:1234/v1` | Full base URL of LM Studio's OpenAI-compatible Local Server. Override when the server runs on a non-default port or a remote machine (e.g. `http://gpu-rig.local:5678/v1`). Must include the `/v1` suffix. |
 | `LMSTUDIO_API_KEY` | *(none)* | Optional. LM Studio's Local Server has no auth by default; set this only if you've enabled API key auth in the LM Studio UI. |
+| `LMSTUDIO_ALLOW_MISSING_MODEL_LISTING` | `false` | Accept an OpenAI-compatible server that has no `/v1/models` endpoint. Single-model servers such as HuggingFace Text Embeddings Inference (TEI) fix the model at startup and return 404 for the listing, while `/v1/embeddings` works normally. When enabled (`true` / `1` / `yes`), readiness and health checks fall back to probing `/v1/embeddings` with one throwaway input, and the probe's vector width is checked against `EMBEDDING_DIMENSIONS`. Only a 404 or 405 from the listing triggers the fallback — a refused connection, a 401, or a 5xx still reports the LM Studio diagnostics. Accepts `false` / `0` / `no` as well; any other non-empty value is rejected at startup rather than silently read as `false`. |
 
 ### LiteLLM Configuration (when `EMBEDDING_PROVIDER=litellm`)
 

--- a/src/services/embedding-config.ts
+++ b/src/services/embedding-config.ts
@@ -40,6 +40,11 @@
  *                          Default: http://localhost:1234/v1
  *   LMSTUDIO_API_KEY:      Optional API key. LM Studio's Local Server has no auth by default;
  *                          set this only if you've enabled an API key in LM Studio.
+ *   LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: Opt-in ("true" / "1" / "yes"). Accepts an
+ *                          OpenAI-compatible server whose /v1/models endpoint is absent
+ *                          (404/405) — e.g. HuggingFace Text Embeddings Inference — by
+ *                          falling back to an /v1/embeddings probe. Default off.
+ *                          Any other non-empty value is rejected with an error.
  *
  * LiteLLM-specific:
  *   LITELLM_URL:               OpenAI-compatible base URL of the LiteLLM proxy.
@@ -88,6 +93,11 @@ export interface EmbeddingConfig {
   lmstudioUrl: string;
   /** LiteLLM proxy OpenAI-compatible base URL (only relevant when embeddingProvider is "litellm"). */
   litellmUrl: string;
+  /**
+   * Accept an OpenAI-compatible server with no /v1/models endpoint (only relevant when
+   * embeddingProvider is "lmstudio"). See LMSTUDIO_ALLOW_MISSING_MODEL_LISTING above.
+   */
+  allowMissingModelListing: boolean;
   embeddingModel: string;
   embeddingDimensions: number;
   /** Max context window in tokens. Used for client-side pre-truncation. */
@@ -183,6 +193,31 @@ export function queryPrefix(): string {
  */
 export function documentPrefix(): string {
   return process.env.EMBEDDING_DOCUMENT_PREFIX ?? DEFAULT_DOCUMENT_PREFIX;
+}
+
+// ── Boolean env vars ──────────────────────────────────────────────────────
+
+/**
+ * Parse a boolean env var: case-insensitive and whitespace-tolerant, with
+ * "true" / "1" / "yes" enabling and "false" / "0" / "no" disabling. Unset,
+ * empty, and whitespace-only all mean "not configured", so the caller's
+ * default applies.
+ *
+ * Anything else throws, naming the variable and the value. A typo such as
+ * "ture" is a request for the flag to be on, and silently treating it as off
+ * would leave the operator debugging the behaviour they thought they had
+ * disabled the flag out of.
+ */
+function parseBooleanEnv(name: string, raw: string | undefined, defaultValue: boolean): boolean {
+  if (!raw) return defaultValue;
+  const v = raw.trim().toLowerCase();
+  if (v === "") return defaultValue;
+  if (v === "true" || v === "1" || v === "yes") return true;
+  if (v === "false" || v === "0" || v === "no") return false;
+  throw new Error(
+    `Invalid ${name}: "${raw}". Must be "true", "1", "yes", "false", "0", or "no" ` +
+    `(case-insensitive), or left unset.`,
+  );
 }
 
 // ── Singleton ─────────────────────────────────────────────────────────────
@@ -311,6 +346,11 @@ export function loadEmbeddingConfig(): EmbeddingConfig {
     ollamaUrl: process.env.OLLAMA_URL || modeDefaults.url,
     lmstudioUrl: process.env.LMSTUDIO_URL || "http://localhost:1234/v1",
     litellmUrl: process.env.LITELLM_URL || "http://localhost:4000/v1",
+    allowMissingModelListing: parseBooleanEnv(
+      "LMSTUDIO_ALLOW_MISSING_MODEL_LISTING",
+      process.env.LMSTUDIO_ALLOW_MISSING_MODEL_LISTING,
+      false,
+    ),
     embeddingModel,
     embeddingDimensions,
     embeddingContextLength: contextLengthEnv
@@ -337,6 +377,7 @@ export function loadEmbeddingConfig(): EmbeddingConfig {
     } : {}),
     ...(embeddingProvider === "lmstudio" ? {
       lmstudioUrl: _config.lmstudioUrl,
+      allowMissingModelListing: _config.allowMissingModelListing,
     } : {}),
     ...(embeddingProvider === "litellm" ? {
       litellmUrl: _config.litellmUrl,

--- a/src/services/provider-lmstudio.ts
+++ b/src/services/provider-lmstudio.ts
@@ -19,6 +19,8 @@
  *   LMSTUDIO_URL=http://localhost:1234/v1   (default)
  *   LMSTUDIO_API_KEY=<key>                  (only if you've enabled API key auth in LM Studio)
  *   EMBEDDING_CONTEXT_LENGTH=<tokens>       (defaults to 2048 if model unknown)
+ *   LMSTUDIO_ALLOW_MISSING_MODEL_LISTING=true  (accept servers without /v1/models, e.g. TEI;
+ *                                           resolved in embedding-config.ts)
  */
 
 import OpenAI from "openai";
@@ -84,6 +86,26 @@ function pretruncateTexts(texts: string[], contextLength: number): string[] {
   return texts.map((t) => (t.length > maxChars ? t.substring(0, maxChars) : t));
 }
 
+// ── Missing-endpoint detection ──────────────────────────────────────────
+
+/**
+ * Whether a `models.list()` failure means the endpoint itself is absent.
+ *
+ * Only 404 (no such route) and 405 (route exists for other verbs) say "this
+ * server has no model listing". A refused connection, a 401, or a 5xx say
+ * something else is wrong, and the LM Studio-specific guidance is then the more
+ * useful answer — so those must not be mistaken for a single-model server.
+ *
+ * The OpenAI SDK surfaces HTTP failures as APIError subclasses carrying a
+ * `.status` field. We duck-type on it rather than importing those classes, the
+ * same way `provider-litellm.ts` detects auth errors.
+ */
+function isMissingEndpointError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const status = (err as { status?: unknown }).status;
+  return status === 404 || status === 405;
+}
+
 // ── Provider class ──────────────────────────────────────────────────────
 
 export class LMStudioEmbeddingProvider implements EmbeddingProvider {
@@ -96,18 +118,70 @@ export class LMStudioEmbeddingProvider implements EmbeddingProvider {
     // Step 1 — connectivity. The Local Server might be off, the port might be wrong,
     // or LM Studio itself might not be running. Surface those as a single actionable
     // message before checking model load state.
+    //
+    // Not every OpenAI-compatible server implements /v1/models. Single-model servers
+    // such as HuggingFace Text Embeddings Inference (TEI) fix the model at startup
+    // via --model-id and return 404 for the listing endpoint, even though
+    // /v1/embeddings works normally. Only that case — an absent endpoint, opted into
+    // via LMSTUDIO_ALLOW_MISSING_MODEL_LISTING — falls back to probing
+    // /v1/embeddings with one throwaway input. Every other failure keeps the LM
+    // Studio guidance below, which is what an operator who forgot to start the
+    // Local Server needs to read.
     let modelList: Awaited<ReturnType<typeof client.models.list>>;
     try {
       modelList = await client.models.list();
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new Error(
-        `LM Studio is not reachable at ${config.lmstudioUrl}. ` +
-        "Make sure LM Studio is running and the Local Server is started " +
-        "(Local Server tab > Start Server). " +
-        "If you've changed the port, set LMSTUDIO_URL accordingly (e.g. http://localhost:5678/v1). " +
-        `Underlying error: ${message}`,
-      );
+      const listingMessage = err instanceof Error ? err.message : String(err);
+
+      if (!(config.allowMissingModelListing && isMissingEndpointError(err))) {
+        throw new Error(
+          `LM Studio is not reachable at ${config.lmstudioUrl}. ` +
+          "Make sure LM Studio is running and the Local Server is started " +
+          "(Local Server tab > Start Server). " +
+          "If you've changed the port, set LMSTUDIO_URL accordingly (e.g. http://localhost:5678/v1). " +
+          (config.allowMissingModelListing
+            ? ""
+            : "If your server is OpenAI-compatible but has no /v1/models endpoint (e.g. TEI), " +
+              "set LMSTUDIO_ALLOW_MISSING_MODEL_LISTING=true to probe /v1/embeddings instead. ") +
+          `Underlying error: ${listingMessage}`,
+        );
+      }
+
+      // Fall back to an embedding probe. A single short input is enough: if it
+      // succeeds, both the server and the configured model are usable.
+      let probe: number[];
+      try {
+        probe = await this.embedSingle("probe");
+      } catch (probeErr) {
+        const probeMessage =
+          probeErr instanceof Error ? probeErr.message : String(probeErr);
+        throw new Error(
+          `The embedding server at ${config.lmstudioUrl} has no /v1/models endpoint and its ` +
+          "/v1/embeddings endpoint did not answer either. Check that the server is running and " +
+          "that LMSTUDIO_URL points at its OpenAI-compatible base URL (it must include the /v1 " +
+          `suffix). Model listing error: ${listingMessage}. Embedding probe error: ${probeMessage}`,
+        );
+      }
+
+      // Without /v1/models this probe is the only chance to catch a wrong
+      // EMBEDDING_DIMENSIONS. The value sizes the Qdrant collection, so a mismatch
+      // resurfaces later as an opaque vector-dimension error from the database.
+      if (probe.length !== config.embeddingDimensions) {
+        throw new Error(
+          `The embedding server at ${config.lmstudioUrl} returns ${probe.length}-dimensional ` +
+          `vectors for model "${config.embeddingModel}", but EMBEDDING_DIMENSIONS is set to ` +
+          `${config.embeddingDimensions}. Set EMBEDDING_DIMENSIONS=${probe.length} to match the ` +
+          "model, or point EMBEDDING_MODEL at a model of the expected width.",
+        );
+      }
+
+      logger.info("Embedding provider ready via embedding probe", {
+        baseUrl: config.lmstudioUrl,
+        model: config.embeddingModel,
+        dimensions: probe.length,
+        note: "/v1/models unavailable — model load state not verified",
+      });
+      return { modelPulled: false, containerStarted: false, imagePulled: false };
     }
 
     // Step 2 — model loaded. LM Studio's /v1/models lists the currently-loaded
@@ -168,8 +242,12 @@ export class LMStudioEmbeddingProvider implements EmbeddingProvider {
     const lines: string[] = [];
     const icon = (ok: boolean) => (ok ? "[OK]" : "[MISSING]");
 
+    // Outside the try: a client that cannot even be constructed is a configuration
+    // fault, not a reachability one, and must not be reported as an unreachable
+    // server (nor retried through the probe, which would fail identically).
+    const client = getClient();
+
     try {
-      const client = getClient();
       const models = await client.models.list();
       lines.push(`${icon(true)} LM Studio: Reachable at ${config.lmstudioUrl}`);
 
@@ -186,6 +264,43 @@ export class LMStudioEmbeddingProvider implements EmbeddingProvider {
       return { available: true, modelReady: modelLoaded, statusLines: lines };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+
+      // A server whose /v1/models endpoint is absent is not necessarily down — see
+      // LMSTUDIO_ALLOW_MISSING_MODEL_LISTING. Probe /v1/embeddings before reporting a
+      // failure, otherwise codebase_health misreports a working TEI server as
+      // unreachable. Same failure-kind test as ensureReady: anything other than a
+      // missing endpoint is reported as-is.
+      if (config.allowMissingModelListing && isMissingEndpointError(err)) {
+        try {
+          // Keep the probe's width: without /v1/models this is the only check on
+          // EMBEDDING_DIMENSIONS, and ensureReady() refuses a mismatch. Reporting
+          // the model ready here would contradict it for the same configuration.
+          const probe = await this.embedSingle("probe");
+          const dimensionsMatch = probe.length === config.embeddingDimensions;
+          lines.push(
+            `${icon(true)} Embedding server: Reachable at ${config.lmstudioUrl} ` +
+            "(/v1/models unavailable — verified via /v1/embeddings)",
+          );
+          lines.push(
+            `${icon(dimensionsMatch)} Embedding model (${config.embeddingModel}): ` +
+            (dimensionsMatch
+              ? "Responding (load state not verifiable without /v1/models)"
+              : `Returns ${probe.length}-dimensional vectors, but EMBEDDING_DIMENSIONS ` +
+                `is set to ${config.embeddingDimensions}. Set EMBEDDING_DIMENSIONS=` +
+                `${probe.length} to match the model`),
+          );
+          return { available: true, modelReady: dimensionsMatch, statusLines: lines };
+        } catch (probeErr) {
+          const probeMessage =
+            probeErr instanceof Error ? probeErr.message : String(probeErr);
+          lines.push(
+            `${icon(false)} Embedding server: Not reachable at ${config.lmstudioUrl} ` +
+            `(model listing: ${message}; embedding probe: ${probeMessage})`,
+          );
+          return { available: false, modelReady: false, statusLines: lines };
+        }
+      }
+
       lines.push(`${icon(false)} LM Studio: Not reachable at ${config.lmstudioUrl} (${message})`);
       return { available: false, modelReady: false, statusLines: lines };
     }

--- a/tests/unit/embedding-config.test.ts
+++ b/tests/unit/embedding-config.test.ts
@@ -25,6 +25,7 @@ describe("embedding-config", () => {
     delete process.env.GOOGLE_API_KEY;
     delete process.env.LMSTUDIO_URL;
     delete process.env.LMSTUDIO_API_KEY;
+    delete process.env.LMSTUDIO_ALLOW_MISSING_MODEL_LISTING;
     delete process.env.LITELLM_URL;
     delete process.env.LITELLM_API_KEY;
     delete process.env.LITELLM_SEND_DIMENSIONS;
@@ -211,6 +212,7 @@ describe("embedding-config", () => {
         ollamaUrl: "http://remote-gpu:11434",
         lmstudioUrl: "http://localhost:1234/v1",
         litellmUrl: "http://localhost:4000/v1",
+        allowMissingModelListing: false,
         embeddingModel: "mxbai-embed-large",
         embeddingDimensions: 1024,
         embeddingContextLength: 512,
@@ -358,6 +360,68 @@ describe("embedding-config", () => {
 
       const config = loadEmbeddingConfig();
       expect(config.embeddingContextLength).toBe(32768);
+    });
+  });
+
+  describe("LMSTUDIO_ALLOW_MISSING_MODEL_LISTING", () => {
+    /** The lmstudio provider needs a model and a dimension before anything else loads. */
+    function lmstudioEnv(): void {
+      process.env.EMBEDDING_PROVIDER = "lmstudio";
+      process.env.EMBEDDING_MODEL = "nomic-embed-text-v1.5";
+      process.env.EMBEDDING_DIMENSIONS = "768";
+    }
+
+    it("defaults to false when unset", () => {
+      lmstudioEnv();
+      expect(loadEmbeddingConfig().allowMissingModelListing).toBe(false);
+    });
+
+    it.each(["true", "TRUE", "True", " true ", "1", "yes"])(
+      "reads %j as enabled",
+      (value) => {
+        lmstudioEnv();
+        process.env.LMSTUDIO_ALLOW_MISSING_MODEL_LISTING = value;
+        expect(loadEmbeddingConfig().allowMissingModelListing).toBe(true);
+      },
+    );
+
+    it.each(["false", "FALSE", "0", "no", "", "  "])(
+      "reads %j as disabled",
+      (value) => {
+        lmstudioEnv();
+        process.env.LMSTUDIO_ALLOW_MISSING_MODEL_LISTING = value;
+        expect(loadEmbeddingConfig().allowMissingModelListing).toBe(false);
+      },
+    );
+
+    // A typo is a request for the flag to be on. Reading it as off used to leave the
+    // operator debugging the behaviour they believed they had turned on.
+    it.each(["ture", "tru", "on", "off", "enabled", "y", "n", "2"])(
+      "rejects %j instead of reading it as disabled",
+      (value) => {
+        lmstudioEnv();
+        process.env.LMSTUDIO_ALLOW_MISSING_MODEL_LISTING = value;
+        expect(() => loadEmbeddingConfig()).toThrow(
+          /Invalid LMSTUDIO_ALLOW_MISSING_MODEL_LISTING/,
+        );
+      },
+    );
+
+    it("names both the variable and the offending value in the error", () => {
+      lmstudioEnv();
+      process.env.LMSTUDIO_ALLOW_MISSING_MODEL_LISTING = "ture";
+      expect(() => loadEmbeddingConfig()).toThrow(
+        /Invalid LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "ture"/,
+      );
+    });
+
+    // The flag belongs to the lmstudio provider, but it is read unconditionally,
+    // so a stray value must not pass unnoticed under another provider either.
+    it("rejects an unrecognised value under a provider that ignores the flag", () => {
+      process.env.LMSTUDIO_ALLOW_MISSING_MODEL_LISTING = "ture";
+      expect(() => loadEmbeddingConfig()).toThrow(
+        /Invalid LMSTUDIO_ALLOW_MISSING_MODEL_LISTING/,
+      );
     });
   });
 

--- a/tests/unit/lmstudio-missing-model-listing.test.ts
+++ b/tests/unit/lmstudio-missing-model-listing.test.ts
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetEmbeddingConfig } from "../../src/services/embedding-config.js";
+import { LMStudioEmbeddingProvider, resetLMStudioClient } from "../../src/services/provider-lmstudio.js";
+
+/**
+ * A fake OpenAI client stands in for the server. The axis that matters is how
+ * /v1/models fails: a 404 or 405 means the endpoint is absent — the shape of
+ * HuggingFace Text Embeddings Inference (TEI) — whereas a refused connection or a
+ * 401 means something else is wrong and must keep the LM Studio guidance.
+ *
+ * LMSTUDIO_ALLOW_MISSING_MODEL_LISTING is resolved by getEmbeddingConfig() on every
+ * call, so each case only needs vi.stubEnv plus a config reset — no module reloading.
+ */
+const fake = vi.hoisted(() => ({
+  behaviour: {
+    /** HTTP status models.list() fails with. undefined means it succeeds. */
+    listStatus: undefined as number | undefined,
+    /** Fail models.list() with a transport error, which carries no status. */
+    listTransportError: false,
+    /** Model ids returned when models.list() succeeds. */
+    listedModels: [] as string[],
+    /** Fail embeddings.create() to simulate a dead server. */
+    embedFails: false,
+    /** Width of the vectors embeddings.create() returns. */
+    embeddingLength: 0,
+  },
+  calls: { list: 0, embed: 0 },
+}));
+
+vi.mock("openai", () => {
+  class FakeOpenAI {
+    models = {
+      list: async () => {
+        fake.calls.list++;
+        if (fake.behaviour.listTransportError) {
+          throw new Error("connect ECONNREFUSED 127.0.0.1:18080");
+        }
+        if (fake.behaviour.listStatus !== undefined) {
+          const err = new Error(
+            `${fake.behaviour.listStatus} status code (no body)`,
+          ) as Error & { status: number };
+          err.status = fake.behaviour.listStatus;
+          throw err;
+        }
+        return { data: fake.behaviour.listedModels.map((id) => ({ id })) };
+      },
+    };
+    embeddings = {
+      create: async ({ input }: { input: string[] }) => {
+        fake.calls.embed++;
+        if (fake.behaviour.embedFails) throw new Error("connection refused");
+        const embedding = Array.from({ length: fake.behaviour.embeddingLength }, () => 0.1);
+        return { data: input.map((_, index) => ({ index, embedding })) };
+      },
+    };
+  }
+  return { default: FakeOpenAI, OpenAI: FakeOpenAI };
+});
+
+const MODEL = "BAAI/bge-m3";
+const DIMENSIONS = 1024;
+
+/** Apply the lmstudio env, plus overrides, and drop the cached config. */
+function setEnv(overrides: Record<string, string | undefined> = {}): void {
+  const env: Record<string, string | undefined> = {
+    EMBEDDING_PROVIDER: "lmstudio",
+    LMSTUDIO_URL: "http://localhost:18080/v1",
+    EMBEDDING_MODEL: MODEL,
+    EMBEDDING_DIMENSIONS: String(DIMENSIONS),
+    EMBEDDING_CONTEXT_LENGTH: undefined,
+    LMSTUDIO_API_KEY: undefined,
+    // Explicitly unset so an exported flag in the developer's shell cannot leak in.
+    LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: undefined,
+    ...overrides,
+  };
+  for (const [key, value] of Object.entries(env)) {
+    vi.stubEnv(key, value);
+  }
+  resetEmbeddingConfig();
+}
+
+beforeEach(() => {
+  fake.behaviour.listStatus = undefined;
+  fake.behaviour.listTransportError = false;
+  fake.behaviour.listedModels = [MODEL];
+  fake.behaviour.embedFails = false;
+  fake.behaviour.embeddingLength = DIMENSIONS;
+  fake.calls.list = 0;
+  fake.calls.embed = 0;
+  resetEmbeddingConfig();
+  resetLMStudioClient();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  resetEmbeddingConfig();
+  resetLMStudioClient();
+});
+
+describe("ensureReady — default behaviour is unchanged", () => {
+  it("succeeds when /v1/models lists the configured model", async () => {
+    setEnv();
+    await expect(
+      new LMStudioEmbeddingProvider().ensureReady(),
+    ).resolves.toMatchObject({ modelPulled: false });
+    expect(fake.calls.list).toBe(1);
+    // The default path must not spend an embedding call on probing.
+    expect(fake.calls.embed).toBe(0);
+  });
+
+  it("fails with the LM Studio message when /v1/models is missing and the flag is unset", async () => {
+    setEnv();
+    fake.behaviour.listStatus = 404;
+    await expect(
+      new LMStudioEmbeddingProvider().ensureReady(),
+    ).rejects.toThrow(/LMSTUDIO_ALLOW_MISSING_MODEL_LISTING/);
+    expect(fake.calls.embed).toBe(0);
+  });
+
+  it("still fails when the model is absent from a working listing", async () => {
+    setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "true" });
+    fake.behaviour.listedModels = ["some-other-model"];
+    await expect(
+      new LMStudioEmbeddingProvider().ensureReady(),
+    ).rejects.toThrow(/is not loaded/);
+  });
+});
+
+describe("ensureReady — LMSTUDIO_ALLOW_MISSING_MODEL_LISTING=true", () => {
+  it("falls back to an embedding probe when the listing returns 404", async () => {
+    setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "true" });
+    fake.behaviour.listStatus = 404;
+    await expect(
+      new LMStudioEmbeddingProvider().ensureReady(),
+    ).resolves.toMatchObject({ modelPulled: false });
+    expect(fake.calls.list).toBe(1);
+    expect(fake.calls.embed).toBe(1);
+  });
+
+  it("falls back to an embedding probe when the listing returns 405", async () => {
+    setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "true" });
+    fake.behaviour.listStatus = 405;
+    await expect(
+      new LMStudioEmbeddingProvider().ensureReady(),
+    ).resolves.toMatchObject({ modelPulled: false });
+    expect(fake.calls.embed).toBe(1);
+  });
+
+  it("does not probe when the server refuses the connection", async () => {
+    setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "true" });
+    fake.behaviour.listTransportError = true;
+    await expect(
+      new LMStudioEmbeddingProvider().ensureReady(),
+    ).rejects.toThrow(/Local Server tab > Start Server/);
+    expect(fake.calls.embed).toBe(0);
+  });
+
+  it("does not probe when the listing is rejected with 401", async () => {
+    setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "true" });
+    fake.behaviour.listStatus = 401;
+    await expect(
+      new LMStudioEmbeddingProvider().ensureReady(),
+    ).rejects.toThrow(/LM Studio is not reachable/);
+    expect(fake.calls.embed).toBe(0);
+  });
+
+  it("reports both errors when the probe also fails", async () => {
+    setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "true" });
+    fake.behaviour.listStatus = 404;
+    fake.behaviour.embedFails = true;
+    const err = await new LMStudioEmbeddingProvider()
+      .ensureReady()
+      .catch((e: unknown) => e as Error);
+    expect(err.message).toContain("Model listing error");
+    expect(err.message).toContain("Embedding probe error");
+  });
+
+  it("fails when the probe's vector width disagrees with EMBEDDING_DIMENSIONS", async () => {
+    setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "true" });
+    fake.behaviour.listStatus = 404;
+    fake.behaviour.embeddingLength = 768;
+    const err = await new LMStudioEmbeddingProvider()
+      .ensureReady()
+      .catch((e: unknown) => e as Error);
+    // Both the expected and the observed width belong in the message.
+    expect(err.message).toContain("768");
+    expect(err.message).toContain("1024");
+  });
+
+  it.each(["true", "TRUE", "True", " true ", "1", "yes"])(
+    "treats %j as enabled",
+    async (value) => {
+      setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: value });
+      fake.behaviour.listStatus = 404;
+      await expect(
+        new LMStudioEmbeddingProvider().ensureReady(),
+      ).resolves.toMatchObject({ modelPulled: false });
+      expect(fake.calls.embed).toBe(1);
+    },
+  );
+
+  it.each(["false", "FALSE", "0", "no", "", "  "])(
+    "treats %j as disabled",
+    async (value) => {
+      setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: value });
+      fake.behaviour.listStatus = 404;
+      await expect(
+        new LMStudioEmbeddingProvider().ensureReady(),
+      ).rejects.toThrow(/LMSTUDIO_ALLOW_MISSING_MODEL_LISTING/);
+      expect(fake.calls.embed).toBe(0);
+    },
+  );
+
+  // A misspelling used to be read as "disabled", so the operator saw the
+  // missing-listing failure they thought they had opted out of.
+  it.each(["ture", "on", "enabled"])(
+    "refuses to start on the unrecognised value %j",
+    async (value) => {
+      setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: value });
+      fake.behaviour.listStatus = 404;
+      await expect(
+        new LMStudioEmbeddingProvider().ensureReady(),
+      ).rejects.toThrow(
+        new RegExp(`Invalid LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "${value}"`),
+      );
+      expect(fake.calls.list).toBe(0);
+      expect(fake.calls.embed).toBe(0);
+    },
+  );
+});
+
+describe("healthCheck — a server without /v1/models is not reported as down", () => {
+  it("reports the loaded model when /v1/models answers and the flag is unset", async () => {
+    setEnv();
+    const status = await new LMStudioEmbeddingProvider().healthCheck();
+    expect(status.available).toBe(true);
+    expect(status.modelReady).toBe(true);
+    expect(status.statusLines.join("\n")).toContain("LM Studio: Reachable");
+    expect(fake.calls.embed).toBe(0);
+  });
+
+  it("reports the loaded model when /v1/models answers and the flag is set", async () => {
+    setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "true" });
+    const status = await new LMStudioEmbeddingProvider().healthCheck();
+    expect(status.available).toBe(true);
+    expect(status.modelReady).toBe(true);
+    expect(status.statusLines.join("\n")).toContain("LM Studio: Reachable");
+    // A working listing needs no probe even with the flag on.
+    expect(fake.calls.embed).toBe(0);
+  });
+
+  it("reports available via the embedding probe when the flag is set", async () => {
+    setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "true" });
+    fake.behaviour.listStatus = 404;
+    const status = await new LMStudioEmbeddingProvider().healthCheck();
+    expect(status.available).toBe(true);
+    expect(status.modelReady).toBe(true);
+    expect(status.statusLines.join("\n")).toContain("/v1/embeddings");
+  });
+
+  // ensureReady() refuses a probe whose width disagrees with EMBEDDING_DIMENSIONS,
+  // so healthCheck must not call the same configuration ready.
+  it("reports the model as not ready when the probe width disagrees", async () => {
+    setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "true" });
+    fake.behaviour.listStatus = 404;
+    fake.behaviour.embeddingLength = 768;
+    const status = await new LMStudioEmbeddingProvider().healthCheck();
+    expect(status.available).toBe(true);
+    expect(status.modelReady).toBe(false);
+    const text = status.statusLines.join("\n");
+    expect(text).toContain("768-dimensional");
+    expect(text).toContain("EMBEDDING_DIMENSIONS");
+  });
+
+  it("reports unavailable when neither endpoint answers", async () => {
+    setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "true" });
+    fake.behaviour.listStatus = 404;
+    fake.behaviour.embedFails = true;
+    const status = await new LMStudioEmbeddingProvider().healthCheck();
+    expect(status.available).toBe(false);
+    expect(status.modelReady).toBe(false);
+  });
+
+  it("keeps the original message when the flag is unset", async () => {
+    setEnv();
+    fake.behaviour.listStatus = 404;
+    const status = await new LMStudioEmbeddingProvider().healthCheck();
+    expect(status.available).toBe(false);
+    expect(status.statusLines.join("\n")).toContain("LM Studio: Not reachable");
+  });
+
+  it("keeps the original message when the server refuses the connection", async () => {
+    setEnv({ LMSTUDIO_ALLOW_MISSING_MODEL_LISTING: "true" });
+    fake.behaviour.listTransportError = true;
+    const status = await new LMStudioEmbeddingProvider().healthCheck();
+    expect(status.available).toBe(false);
+    expect(status.statusLines.join("\n")).toContain("LM Studio: Not reachable");
+    expect(fake.calls.embed).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

The `lmstudio` provider gates readiness and health on `models.list()`. Servers that host exactly one model — HuggingFace Text Embeddings Inference (TEI) being the common case — fix the model at startup and have no `/v1/models` route, so the listing returns 404 even though `/v1/embeddings` works. `ensureReady()` then fails with an "LM Studio is not reachable" message and the server is unusable.

## Changes

- Add `LMSTUDIO_ALLOW_MISSING_MODEL_LISTING` (default `false`, so existing behaviour is unchanged). The name carries the `LMSTUDIO_` prefix because the flag only affects that provider, alongside `LMSTUDIO_URL` and `LMSTUDIO_API_KEY`. It is resolved in `embedding-config.ts` on every `getEmbeddingConfig()` call.
- When the flag is on, **only a 404 or 405** from the listing falls back to probing `/v1/embeddings` with a single throwaway input. A refused connection, a 401, or a 5xx keeps the LM Studio diagnostics, which are what an operator who forgot to start the Local Server needs to read. `healthCheck()` applies the same rule.
- Without `/v1/models` the probe is also the only chance to validate `EMBEDDING_DIMENSIONS`, which sizes the Qdrant collection. Compare the probe's vector width against the configured value and fail fast on a mismatch, naming both numbers, rather than letting it resurface as an opaque database error.
- Accept `true` / `1` / `yes` and `false` / `0` / `no`, case-insensitively and ignoring surrounding whitespace. A non-empty value that is none of those throws, naming the variable and the value: a typo such as `ture` is a request to turn the flag on, and reading it as "off" would send the operator to debug the missing-listing failure they believed they had opted out of. Unset, empty, and whitespace-only still mean "not configured" and keep the default.
- Document the flag in the README's LM Studio section, with a TEI env example.

A model that is absent from a working listing still fails, so the flag only relaxes the missing-endpoint case. Nothing outside the `lmstudio` provider changes; `provider-litellm.ts` is untouched.

<details>
<summary>日本語の説明 (Japanese explanation)</summary>

### 何を直すか

モデル一覧の API を持たない OpenAI 互換の推論サーバを使えるようにします。

### なぜ必要か

起動前の確認で、推論サーバへ「載っているモデルの一覧」（`/v1/models`）を問い合わせています。ところがモデルを 1 つだけ載せるサーバは、起動時にモデルを固定する設計のため、この口を持ちません。HuggingFace の TEI（text-embeddings-inference）が代表例で、`/v1/models` は 404 を返します。埋め込み本体（`/v1/embeddings`）は正常に動くのに、事前確認で落ちます。しかも「LM Studio に到達できない」という、実態と食い違うエラーが出ます。

### 誰が得をするか

- GGUF 版が配布されていないモデルを使いたい人。Ollama は GGUF を求めますが、Safetensors だけで配布されるモデルは少なくありません（例: `cl-nagoya/ruri-v3-*`）。こうしたモデルは TEI なら動きます
- 手元の GGUF ファイルを直接読ませたい人。`llama-server` はファイルを指定して起動できます
- 推論サーバを選びたい人。同一マシンの実測で、TEI は Ollama の 1.76 倍の速さでした

### 変更の内容

有効にすると、一覧の取得が **404 か 405 で失敗したときだけ** `/v1/embeddings` へ捨て試行を 1 回投げます。これが通れば準備完了とみなします。接続拒否・401・5xx は従来どおりの案内を保ちます。サーバの起動を忘れた利用者に必要なのはその案内だからです。

一覧が無い環境では、この捨て試行が `EMBEDDING_DIMENSIONS` を検証できる唯一の機会です。返ってきたベクトルの次元数を設定値と比べ、食い違えば両方の数値を挙げて即座に失敗します。放置すると、あとで Qdrant の分かりにくいエラーとして表面化します。

綴りを誤った値は、既定値に落とさず例外にします。`ture` と書いた人は有効にしたかったはずで、黙って「無効」と読むと、切ったはずの失敗を延々と調べることになるからです。

</details>

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement

## Testing

- [x] Unit tests pass (`npm run test:unit`) — 60 files, 1312 tests
- [ ] Integration tests pass (`npm run test:integration`) — not run; requires Docker
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] New tests added for new/changed functionality

Also verified against a stub server that answers 404 on `/v1/models` and serves `/v1/embeddings`, and against a closed port, to confirm the diagnostics stay correct in both directions. `LMSTUDIO_ALLOW_MISSING_MODEL_LISTING=true npm run test:unit` passes too, so the suite does not depend on the variable being unset.

To check the strict parsing is actually load-bearing, I mutated the parser to fall back to the default instead of throwing: 13 tests fail. Restoring the throw makes them pass again.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate
- [x] I have updated documentation (README.md / DEVELOPER.md) if needed
- [x] I have addressed all [CodeRabbit](https://coderabbit.ai) review comments (or marked as resolved with explanation)
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

## Related issues

None. Happy to move the discussion to an issue first if you prefer that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for LM Studio-compatible embedding servers without a `/v1/models` endpoint.
  * Added configuration to enable readiness and health checks through embedding probes.
  * Added validation for the configured embedding vector dimensions.

* **Bug Fixes**
  * Improved health and readiness reporting for unavailable models, authentication failures, and dimension mismatches.

* **Documentation**
  * Documented TEI configuration, readiness checks, model requirements, and the new environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->