### PR TITLE
fix(graph): exact symbol impact traversal and declaration extraction for non-function exports (#132)

### DIFF
--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -390,7 +390,7 @@ async function persistSymbolGraph(
     fileCount: symbolsByFile.size,
     unresolvedEdgePct: computeUnresolvedPct(outgoingCallsByFile),
     builtAt: Date.now(),
-    schemaVersion: 1,
+    schemaVersion: 2,
   };
   await saveSymbolGraphMeta(projectId, meta);
 

--- a/src/services/graph-impact.ts
+++ b/src/services/graph-impact.ts
@@ -16,6 +16,14 @@ import {
 
 // ── Impact (blast radius) ────────────────────────────────────────────────
 
+// ── Impact (blast radius) ────────────────────────────────────────────────
+
+export type ImpactStatus =
+  | "ok"
+  | "not_found"
+  | "ambiguous"
+  | "unsupported_or_incomplete";
+
 export interface ImpactResult {
   target: string;
   targetKind: "file" | "symbol";
@@ -24,9 +32,12 @@ export interface ImpactResult {
   filesByDepth: Map<number, string[]>;
   totalFiles: number;
   truncated: boolean;
+  status: ImpactStatus;
+  message?: string;
+  candidates?: SymbolNode[];
 }
 
-/** BFS over the in-memory `reverseFileIndex`. Polymorphic on target type. */
+/** BFS over symbol call/reference graph or reverseFileIndex. Polymorphic on target type. */
 export async function getImpactRadius(
   cache: SymbolGraphCache,
   target: string,
@@ -39,46 +50,167 @@ export async function getImpactRadius(
     ? "file"
     : "symbol";
 
-  // Resolve to one or more "seed" files
-  let seedFiles: Set<string>;
   if (targetKind === "file") {
-    seedFiles = new Set([target]);
-  } else {
-    seedFiles = new Set();
-    const nameIndex = await cache.getNameIndex();
-    const refs = nameIndex.get(target) ?? [];
-    for (const r of refs) seedFiles.add(r.file);
-  }
-
-  const visited = new Set<string>();
-  const filesByDepth = new Map<number, string[]>();
-  let frontier = new Set(seedFiles);
-  for (const f of seedFiles) visited.add(f);
-
-  let truncated = false;
-  for (let hop = 1; hop <= safeDepth; hop++) {
-    const next = new Set<string>();
-    for (const calleeFile of frontier) {
-      const callers = reverseIndex.get(calleeFile);
-      if (!callers) continue;
-      for (const callerFile of callers) {
-        if (visited.has(callerFile)) continue;
-        next.add(callerFile);
-        visited.add(callerFile);
-      }
+    const normTarget = toForwardSlash(target);
+    const targetPayload = await cache.getFilePayload(normTarget);
+    if (!targetPayload) {
+      return {
+        target,
+        targetKind,
+        depth: safeDepth,
+        filesByDepth: new Map(),
+        totalFiles: 0,
+        truncated: false,
+        status: "not_found",
+        message: `File '${target}' was not found in the index.`,
+      };
     }
-    if (next.size === 0) break;
-    filesByDepth.set(hop, Array.from(next).sort());
-    frontier = next;
-    // After reaching the depth limit, check if more callers exist beyond it.
-    if (hop === safeDepth) {
+
+    const visited = new Set<string>([normTarget]);
+    const filesByDepth = new Map<number, string[]>();
+    let frontier = new Set<string>([normTarget]);
+    let truncated = false;
+
+    for (let hop = 1; hop <= safeDepth; hop++) {
+      const next = new Set<string>();
       for (const calleeFile of frontier) {
         const callers = reverseIndex.get(calleeFile);
         if (!callers) continue;
         for (const callerFile of callers) {
-          if (!visited.has(callerFile)) {
-            truncated = true;
-            break;
+          if (visited.has(callerFile)) continue;
+          next.add(callerFile);
+          visited.add(callerFile);
+        }
+      }
+      if (next.size === 0) break;
+      filesByDepth.set(hop, Array.from(next).sort());
+      frontier = next;
+
+      if (hop === safeDepth) {
+        for (const calleeFile of frontier) {
+          const callers = reverseIndex.get(calleeFile);
+          if (!callers) continue;
+          for (const callerFile of callers) {
+            if (!visited.has(callerFile)) {
+              truncated = true;
+              break;
+            }
+          }
+          if (truncated) break;
+        }
+      }
+    }
+
+    let totalFiles = 0;
+    for (const arr of filesByDepth.values()) totalFiles += arr.length;
+    return {
+      target,
+      targetKind,
+      depth: safeDepth,
+      filesByDepth,
+      totalFiles,
+      truncated,
+      status: "ok",
+    };
+  }
+
+  // Symbol mode: exact symbol resolution and traversal
+  const nameIndex = await cache.getNameIndex();
+  const refs = nameIndex.get(target) ?? [];
+
+  if (refs.length === 0) {
+    return {
+      target,
+      targetKind,
+      depth: safeDepth,
+      filesByDepth: new Map(),
+      totalFiles: 0,
+      truncated: false,
+      status: "not_found",
+      message: `Symbol '${target}' was not found in the symbol graph.`,
+    };
+  }
+
+  const distinctFiles = Array.from(new Set(refs.map((r) => r.file)));
+  if (distinctFiles.length > 1) {
+    const candidates: SymbolNode[] = [];
+    for (const ref of refs) {
+      const payload = await cache.getFilePayload(ref.file);
+      const sym = payload?.symbols.find((s) => s.id === ref.id);
+      if (sym) candidates.push(sym);
+    }
+    return {
+      target,
+      targetKind,
+      depth: safeDepth,
+      filesByDepth: new Map(),
+      totalFiles: 0,
+      truncated: false,
+      status: "ambiguous",
+      message: `Symbol '${target}' is ambiguous (defined in ${distinctFiles.length} files: ${distinctFiles.slice(0, 5).join(", ")}${distinctFiles.length > 5 ? "..." : ""}). Specify the file path or qualified name to disambiguate.`,
+      candidates,
+    };
+  }
+
+  const targetSymbolIds = new Set(refs.map((r) => r.id));
+  const visitedFiles = new Set<string>(distinctFiles);
+  const filesByDepth = new Map<number, string[]>();
+
+  let frontierSymbolIds = new Set(targetSymbolIds);
+  let frontierFiles = new Set<string>(distinctFiles);
+  let truncated = false;
+
+  for (let hop = 1; hop <= safeDepth; hop++) {
+    const nextHopFiles = new Set<string>();
+    const nextSymbolIds = new Set<string>();
+    const nextFiles = new Set<string>();
+
+    // For all files that could call into our current frontier files
+    for (const calleeFile of frontierFiles) {
+      const potentialCallerFiles = reverseIndex.get(calleeFile);
+      if (!potentialCallerFiles) continue;
+
+      for (const callerFile of potentialCallerFiles) {
+        const callerPayload = await cache.getFilePayload(callerFile);
+        if (!callerPayload) continue;
+
+        let matched = false;
+        for (const edge of callerPayload.outgoingCalls) {
+          const callsTarget = edge.calleeCandidates.some((candId) =>
+            frontierSymbolIds.has(candId),
+          );
+          if (callsTarget) {
+            matched = true;
+            nextSymbolIds.add(edge.callerId);
+          }
+        }
+
+        if (matched) {
+          if (!visitedFiles.has(callerFile)) {
+            nextHopFiles.add(callerFile);
+            visitedFiles.add(callerFile);
+          }
+          nextFiles.add(callerFile);
+        }
+      }
+    }
+
+    if (nextHopFiles.size === 0) break;
+    filesByDepth.set(hop, Array.from(nextHopFiles).sort());
+    frontierSymbolIds = nextSymbolIds;
+    frontierFiles = nextFiles;
+
+    if (hop === safeDepth) {
+      for (const calleeFile of frontierFiles) {
+        const potentialCallerFiles = reverseIndex.get(calleeFile);
+        if (!potentialCallerFiles) continue;
+        for (const callerFile of potentialCallerFiles) {
+          if (!visitedFiles.has(callerFile)) {
+            const cp = await cache.getFilePayload(callerFile);
+            if (cp?.outgoingCalls.some((e) => e.calleeCandidates.some((c) => frontierSymbolIds.has(c)))) {
+              truncated = true;
+              break;
+            }
           }
         }
         if (truncated) break;
@@ -88,9 +220,15 @@ export async function getImpactRadius(
 
   let totalFiles = 0;
   for (const arr of filesByDepth.values()) totalFiles += arr.length;
+
   return {
-    target, targetKind, depth: safeDepth, filesByDepth, totalFiles,
+    target,
+    targetKind,
+    depth: safeDepth,
+    filesByDepth,
+    totalFiles,
     truncated,
+    status: "ok",
   };
 }
 

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -754,12 +754,6 @@ function extractFromTsLike(
 
   // Class declarations
   for (const node of safeFindAll(root, "class_declaration")) {
-    // The name FIELD, not a subtree search: safeFind's recursive DFS reaches a
-    // decorator's identifier before the class's own name, so `@sealed class X`
-    // would extract as a class named `sealed` and collide with the real
-    // decorator function at resolution time. The field is grammar-precise on
-    // JS (identifier) and TS/TSX (type_identifier) alike; the searches remain
-    // only as a belt for grammars without the field.
     const nameNode = node.field("name")
       ?? safeFind(node, "type_identifier")
       ?? safeFind(node, "identifier");
@@ -775,11 +769,6 @@ function extractFromTsLike(
     symbols.push(sym);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
 
-    // Methods inside the class — DIRECT children of the class body only. A
-    // recursive scan fabricates phantom methods: an object-literal shorthand
-    // handler inside a field initializer or a call argument, or a nested
-    // class's methods, would all be stamped onto THIS class and persisted into
-    // the name index, corrupting name-based resolution and impact seeds.
     const body = node.field("body");
     // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
     let members: any[] = [];
@@ -790,9 +779,6 @@ function extractFromTsLike(
       members = [];
     }
     for (const m of members) {
-      // Name from the field, accepting only a literal property name: a
-      // computed name like `[Symbol.iterator]` has no static identity, and
-      // searching inside it used to persist a method that does not exist.
       const mNameNode = m.field("name");
       const mName = mNameNode?.kind() === "property_identifier" ? mNameNode.text() : null;
       if (!mName) continue;
@@ -843,30 +829,96 @@ function extractFromTsLike(
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
   }
 
-  // Named arrow functions: `const foo = (...) => {...}` or `const foo = function(...) {...}`
-  for (const node of safeFindAll(root, "lexical_declaration")) {
-    for (const decl of safeFindAll(node, "variable_declarator")) {
-      const idNode = safeFind(decl, "identifier");
-      if (!idNode) continue;
-      const name = idNode.text();
-      const arrow = safeFind(decl, "arrow_function");
-      const fnExpr = safeFind(decl, "function_expression");
-      const fn = arrow ?? fnExpr;
-      if (!fn) continue;
-      const r = fn.range();
-      const startLine = r.start.line + 1;
-      const endLine = r.end.line + 1;
-      const sym: SymbolNode = {
-        id: makeId(file, name, startLine),
-        name, qualifiedName: name, kind: "function", file, line: startLine, endLine, language,
-      };
-      symbols.push(sym);
-      scopes.push({ name, startLine, endLine, symbolId: sym.id });
+  // Interface declarations (TS / TSX)
+  for (const node of safeFindAll(root, "interface_declaration")) {
+    const nameNode = node.field("name")
+      ?? safeFind(node, "type_identifier")
+      ?? safeFind(node, "identifier");
+    if (!nameNode) continue;
+    const name = nameNode.text();
+    const r = node.range();
+    const startLine = r.start.line + 1;
+    const endLine = r.end.line + 1;
+    const sym: SymbolNode = {
+      id: makeId(file, name, startLine),
+      name, qualifiedName: name, kind: "interface", file, line: startLine, endLine, language,
+    };
+    symbols.push(sym);
+    scopes.push({ name, startLine, endLine, symbolId: sym.id });
+  }
+
+  // Type alias declarations (TS / TSX)
+  for (const node of safeFindAll(root, "type_alias_declaration")) {
+    const nameNode = node.field("name")
+      ?? safeFind(node, "type_identifier")
+      ?? safeFind(node, "identifier");
+    if (!nameNode) continue;
+    const name = nameNode.text();
+    const r = node.range();
+    const startLine = r.start.line + 1;
+    const endLine = r.end.line + 1;
+    const sym: SymbolNode = {
+      id: makeId(file, name, startLine),
+      name, qualifiedName: name, kind: "type", file, line: startLine, endLine, language,
+    };
+    symbols.push(sym);
+    scopes.push({ name, startLine, endLine, symbolId: sym.id });
+  }
+
+  // Enum declarations (TS / TSX)
+  for (const node of safeFindAll(root, "enum_declaration")) {
+    const nameNode = node.field("name")
+      ?? safeFind(node, "identifier");
+    if (!nameNode) continue;
+    const name = nameNode.text();
+    const r = node.range();
+    const startLine = r.start.line + 1;
+    const endLine = r.end.line + 1;
+    const sym: SymbolNode = {
+      id: makeId(file, name, startLine),
+      name, qualifiedName: name, kind: "enum", file, line: startLine, endLine, language,
+    };
+    symbols.push(sym);
+    scopes.push({ name, startLine, endLine, symbolId: sym.id });
+  }
+
+  // Lexical and variable declarations: const, let, var (including arrow functions and plain constants)
+  const declKinds = ["lexical_declaration", "variable_declaration"];
+  for (const declKind of declKinds) {
+    for (const node of safeFindAll(root, declKind)) {
+      for (const decl of safeFindAll(node, "variable_declarator")) {
+        const idNode = decl.field("name") ?? safeFind(decl, "identifier");
+        if (!idNode) continue;
+        const name = idNode.text();
+        const arrow = safeFind(decl, "arrow_function");
+        const fnExpr = safeFind(decl, "function_expression");
+        const fn = arrow ?? fnExpr;
+        const r = (fn ?? decl).range();
+        const startLine = r.start.line + 1;
+        const endLine = r.end.line + 1;
+        const symKind: SymbolKind = fn ? "function" : "variable";
+        const sym: SymbolNode = {
+          id: makeId(file, name, startLine),
+          name, qualifiedName: name, kind: symKind, file, line: startLine, endLine, language,
+        };
+        symbols.push(sym);
+        scopes.push({ name, startLine, endLine, symbolId: sym.id });
+      }
     }
   }
 
-  // Call sites
+  // Track declaration names and lines to avoid self-referencing declaration identifiers
+  const declaredNamesAndLines = new Set<string>();
+  for (const s of symbols) {
+    if (s.name !== "<module>") {
+      declaredNamesAndLines.add(`${s.name}#${s.line}`);
+    }
+  }
+
   const rawCalls: ExtractedSymbols["rawCalls"] = [];
+  const importedNames = new Set<string>();
+
+  // 1. Call sites
   for (const node of safeFindAll(root, "call_expression")) {
     const calleeName = extractCalleeNameJs(node.text());
     if (!calleeName) continue;
@@ -878,6 +930,109 @@ function extractFromTsLike(
       callSite: { file, line: callLine },
     });
   }
+
+  // 2. Import statements: named imports (`import { X, Y as Z }`), type imports (`import type { T }`), default imports (`import D from ...`)
+  for (const imp of safeFindAll(root, "import_statement")) {
+    const r = imp.range();
+    const line = r.start.line + 1;
+
+    for (const spec of safeFindAll(imp, "import_specifier")) {
+      const nameNode = spec.field("name") ?? safeFind(spec, "identifier");
+      if (!nameNode) continue;
+      const importedName = nameNode.text();
+      importedNames.add(importedName);
+      rawCalls.push({
+        callerId: moduleSym.id,
+        calleeName: importedName,
+        callSite: { file, line },
+      });
+    }
+
+    const clause = safeFind(imp, "import_clause");
+    if (clause) {
+      // Direct identifier in import_clause is default import
+      // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+      const kids = (clause as any).children?.() ?? [];
+      for (const k of kids) {
+        if (k.kind() === "identifier") {
+          const defaultName = k.text();
+          importedNames.add(defaultName);
+          rawCalls.push({
+            callerId: moduleSym.id,
+            calleeName: defaultName,
+            callSite: { file, line },
+          });
+        }
+      }
+    }
+  }
+
+  // 3. Re-export statements (`export { X, Y } from '...'` and `export { X }`)
+  for (const exp of safeFindAll(root, "export_statement")) {
+    const r = exp.range();
+    const line = r.start.line + 1;
+    for (const spec of safeFindAll(exp, "export_specifier")) {
+      const nameNode = spec.field("name") ?? safeFind(spec, "identifier");
+      if (!nameNode) continue;
+      const expName = nameNode.text();
+      importedNames.add(expName);
+      rawCalls.push({
+        callerId: moduleSym.id,
+        calleeName: expName,
+        callSite: { file, line },
+      });
+    }
+  }
+
+  // 4. Type references (type annotations, type arguments, implements, extends)
+  const TS_BUILTIN_TYPES = new Set([
+    "string", "number", "boolean", "any", "unknown", "never", "void", "null", "undefined",
+    "symbol", "bigint", "object", "Function", "true", "false",
+    "Array", "Record", "Promise", "Partial", "Required", "Readonly", "Pick", "Omit",
+    "Exclude", "Extract", "NonNullable", "ReturnType", "InstanceType", "Parameters",
+    "ConstructorParameters", "Awaited", "Map", "Set", "WeakMap", "WeakSet", "Error",
+    "RegExp", "Date", "Uint8Array", "Int8Array", "Uint16Array", "Int16Array",
+    "Uint32Array", "Int32Array", "Float32Array", "Float64Array", "BigInt64Array", "BigUint64Array",
+    "ArrayBuffer", "DataView", "Iterable", "AsyncIterable", "Iterator", "AsyncIterator",
+    "Generator", "AsyncGenerator", "TemplateStringsArray", "PropertyKey",
+    "T", "K", "V", "U", "R", "P",
+  ]);
+
+  for (const node of safeFindAll(root, "type_identifier")) {
+    const name = node.text();
+    if (TS_BUILTIN_TYPES.has(name)) continue;
+    const r = node.range();
+    const line = r.start.line + 1;
+    if (declaredNamesAndLines.has(`${name}#${line}`)) continue;
+    const callerId = findCallerId(scopes, line, moduleSym.id);
+    rawCalls.push({
+      callerId,
+      calleeName: name,
+      callSite: { file, line },
+    });
+  }
+
+  // 5. Value references to imported identifiers in expressions / statements
+  if (importedNames.size > 0) {
+    for (const idNode of safeFindAll(root, "identifier")) {
+      const name = idNode.text();
+      if (!importedNames.has(name)) continue;
+      const r = idNode.range();
+      const line = r.start.line + 1;
+      const parentKind = idNode.parent()?.kind?.();
+      // Skip import_specifier / export_specifier definition sites themselves
+      if (parentKind === "import_specifier" || parentKind === "import_clause" || parentKind === "export_specifier") {
+        continue;
+      }
+      const callerId = findCallerId(scopes, line, moduleSym.id);
+      rawCalls.push({
+        callerId,
+        calleeName: name,
+        callSite: { file, line },
+      });
+    }
+  }
+
   return { symbols, rawCalls };
 }
 

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -270,16 +270,17 @@ async function dispatchGraphTool(
       // the real loader state. Idempotent and cheap after the first call.
       ensureDynamicLanguages();
       const grammarStatus = getDynamicLanguageStatus();
+      const BUILTIN_AST_LANGUAGES = [
+        "csharp", "go", "java", "javascript", "kotlin", "python", "rust", "tsx", "typescript",
+      ];
       const renderGrammarBlock = (): string[] => {
-        if (grammarStatus.loaded.length === 0 && grammarStatus.failed.length === 0) {
-          return [];
-        }
         const block: string[] = ["", "AST grammars:"];
+        block.push(`  Built-in (ast-grep, ${BUILTIN_AST_LANGUAGES.length}): ${BUILTIN_AST_LANGUAGES.join(", ")}`);
         if (grammarStatus.loaded.length > 0) {
-          block.push(`  Loaded (${grammarStatus.loaded.length}): ${grammarStatus.loaded.join(", ")}`);
+          block.push(`  Dynamic loaded (${grammarStatus.loaded.length}): ${grammarStatus.loaded.join(", ")}`);
         }
         if (grammarStatus.failed.length > 0) {
-          block.push(`  Failed (${grammarStatus.failed.length}):`);
+          block.push(`  Dynamic failed (${grammarStatus.failed.length}):`);
           for (const f of grammarStatus.failed) {
             block.push(`    - ${f.name}: ${f.error}`);
           }
@@ -413,13 +414,35 @@ async function dispatchGraphTool(
         return "No symbol graph found. Run codebase_graph_build (or codebase_index) first.";
       }
       const result = await getImpactRadius(cache, target, depth);
+
+      if (result.status === "not_found") {
+        return result.message ?? `Target '${target}' was not found in the graph.`;
+      }
+      if (result.status === "ambiguous") {
+        const lines = [
+          `Target '${target}' is ambiguous:`,
+          result.message ?? "",
+        ];
+        if (result.candidates && result.candidates.length > 0) {
+          lines.push("");
+          lines.push("Candidates:");
+          for (const c of result.candidates) {
+            lines.push(`  - [${c.kind}] ${c.qualifiedName} in ${c.file}:${c.line}`);
+          }
+        }
+        return lines.join("\n").trimEnd();
+      }
+      if (result.status === "unsupported_or_incomplete") {
+        return result.message ?? `Graph analysis for '${target}' is incomplete.`;
+      }
+
       const lines = [
         `Blast radius for ${result.targetKind}: ${result.target}`,
         `Depth: ${result.depth}    Total impacted files: ${result.totalFiles}`,
         "",
       ];
       if (result.totalFiles === 0) {
-        lines.push("No callers found — nothing else depends on this.");
+        lines.push("No callers or references found — nothing else depends on this.");
       } else {
         for (const [hop, files] of result.filesByDepth.entries()) {
           lines.push(`Hop ${hop} (${files.length} files):`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export type SymbolKind =
   | "enum"
   | "module"
   | "struct"
+  | "type"
   | "variable";
 
 /** A single symbol (definition) extracted from source code */
@@ -167,7 +168,7 @@ export interface SymbolGraphMeta {
   fileCount: number;
   unresolvedEdgePct: number;
   builtAt: number;
-  schemaVersion: 1;
+  schemaVersion: 1 | 2;
 }
 
 /** Per-file payload stored in `_symgraph_file` */

--- a/tests/integration/tools.test.ts
+++ b/tests/integration/tools.test.ts
@@ -363,15 +363,35 @@ describe.skipIf(!dockerAvailable)(
         expect(result).toContain("Missing required argument");
       });
 
-      it("returns a blast-radius report for a known symbol", async () => {
+      it("returns a blast-radius report for a known function symbol", async () => {
         const result = await handleGraphTool("codebase_impact", {
           projectPath: fixture.root,
-          target: "main",
+          target: "greet",
           depth: 3,
         });
         expect(typeof result).toBe("string");
-        // Either "Blast radius for ..." (found) or graceful empty/no-graph message.
-        expect(result.length).toBeGreaterThan(0);
+        expect(result).toContain("Blast radius for symbol: greet");
+        expect(result).toContain("src/index.ts");
+      });
+
+      it("returns a blast-radius report for an interface export (issue #132)", async () => {
+        const result = await handleGraphTool("codebase_impact", {
+          projectPath: fixture.root,
+          target: "UserConfig",
+          depth: 3,
+        });
+        expect(typeof result).toBe("string");
+        expect(result).toContain("Blast radius for symbol: UserConfig");
+        expect(result).toContain("src/index.ts");
+      });
+
+      it("returns informative not found error for non-existent symbol", async () => {
+        const result = await handleGraphTool("codebase_impact", {
+          projectPath: fixture.root,
+          target: "NonExistentSymbolXYZ",
+          depth: 3,
+        });
+        expect(result).toContain("not found");
       });
     });
 

--- a/tests/unit/graph-impact.test.ts
+++ b/tests/unit/graph-impact.test.ts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+import { describe, expect, it } from "vitest";
+import { getImpactRadius } from "../../src/services/graph-impact.js";
+import { SymbolGraphCache } from "../../src/services/symbol-graph-cache.js";
+import type { SymbolGraphFilePayload, SymbolGraphMeta, SymbolNode } from "../../src/types.js";
+
+function createMockCache(opts: {
+  symbols: SymbolNode[];
+  reverseFileIndex: Map<string, Set<string>>;
+  filePayloads: Map<string, SymbolGraphFilePayload>;
+}): SymbolGraphCache {
+  const meta: SymbolGraphMeta = {
+    projectId: "test-proj",
+    symbolCount: opts.symbols.length,
+    edgeCount: 0,
+    fileCount: opts.filePayloads.size,
+    unresolvedEdgePct: 0,
+    builtAt: Date.now(),
+    schemaVersion: 2,
+  };
+
+  const cache = new SymbolGraphCache("test-proj", meta);
+
+  // Pre-seed cache fields directly
+  const nameIndex = new Map<string, Array<{ file: string; id: string }>>();
+  for (const s of opts.symbols) {
+    if (s.name === "<module>") continue;
+    const list = nameIndex.get(s.name) ?? [];
+    list.push({ file: s.file, id: s.id });
+    nameIndex.set(s.name, list);
+  }
+
+  // @ts-expect-error accessing private field for unit testing
+  cache.nameIndex = nameIndex;
+  // @ts-expect-error accessing private field for unit testing
+  cache.reverseFileIndex = opts.reverseFileIndex;
+
+  for (const [f, payload] of opts.filePayloads) {
+    cache.fileDataLru.set(f, payload);
+  }
+
+  return cache;
+}
+
+describe("graph-impact exact symbol traversal and fail-closed", () => {
+  it("returns not_found status when symbol is not in index", async () => {
+    const cache = createMockCache({
+      symbols: [],
+      reverseFileIndex: new Map(),
+      filePayloads: new Map(),
+    });
+
+    const result = await getImpactRadius(cache, "NonExistentSymbol");
+    expect(result.status).toBe("not_found");
+    expect(result.totalFiles).toBe(0);
+    expect(result.message).toContain("not found");
+  });
+
+  it("returns ambiguous status when symbol is defined in multiple files", async () => {
+    const sym1: SymbolNode = {
+      id: "src/a.ts::Config#1",
+      name: "Config",
+      qualifiedName: "Config",
+      kind: "interface",
+      file: "src/a.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+    const sym2: SymbolNode = {
+      id: "src/b.ts::Config#1",
+      name: "Config",
+      qualifiedName: "Config",
+      kind: "interface",
+      file: "src/b.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+
+    const cache = createMockCache({
+      symbols: [sym1, sym2],
+      reverseFileIndex: new Map(),
+      filePayloads: new Map([
+        ["src/a.ts", { file: "src/a.ts", language: "typescript", contentHash: "h1", symbols: [sym1], outgoingCalls: [] }],
+        ["src/b.ts", { file: "src/b.ts", language: "typescript", contentHash: "h2", symbols: [sym2], outgoingCalls: [] }],
+      ]),
+    });
+
+    const result = await getImpactRadius(cache, "Config");
+    expect(result.status).toBe("ambiguous");
+    expect(result.totalFiles).toBe(0);
+    expect(result.message).toContain("ambiguous");
+    expect(result.candidates).toHaveLength(2);
+  });
+
+  it("isolates blast radius between different symbols in the same file (issue #132)", async () => {
+    // Defining file with two symbols: JobOfferSnapshot (type) and UnrelatedConstant (const)
+    const symType: SymbolNode = {
+      id: "src/domain/snapshot.ts::JobOfferSnapshot#10",
+      name: "JobOfferSnapshot",
+      qualifiedName: "JobOfferSnapshot",
+      kind: "type",
+      file: "src/domain/snapshot.ts",
+      line: 10,
+      endLine: 15,
+      language: "typescript",
+    };
+    const symConst: SymbolNode = {
+      id: "src/domain/snapshot.ts::UnrelatedConstant#20",
+      name: "UnrelatedConstant",
+      qualifiedName: "UnrelatedConstant",
+      kind: "variable",
+      file: "src/domain/snapshot.ts",
+      line: 20,
+      endLine: 20,
+      language: "typescript",
+    };
+
+    // Caller 1 references JobOfferSnapshot
+    const caller1: SymbolGraphFilePayload = {
+      file: "src/services/evaluator.ts",
+      language: "typescript",
+      contentHash: "h_eval",
+      symbols: [],
+      outgoingCalls: [
+        {
+          callerId: "src/services/evaluator.ts::eval#5",
+          calleeName: "JobOfferSnapshot",
+          calleeCandidates: ["src/domain/snapshot.ts::JobOfferSnapshot#10"],
+          confidence: "unique",
+          callSite: { file: "src/services/evaluator.ts", line: 6 },
+        },
+      ],
+    };
+
+    // Caller 2 references UnrelatedConstant only
+    const caller2: SymbolGraphFilePayload = {
+      file: "src/services/other.ts",
+      language: "typescript",
+      contentHash: "h_other",
+      symbols: [],
+      outgoingCalls: [
+        {
+          callerId: "src/services/other.ts::doOther#2",
+          calleeName: "UnrelatedConstant",
+          calleeCandidates: ["src/domain/snapshot.ts::UnrelatedConstant#20"],
+          confidence: "unique",
+          callSite: { file: "src/services/other.ts", line: 3 },
+        },
+      ],
+    };
+
+    const cache = createMockCache({
+      symbols: [symType, symConst],
+      reverseFileIndex: new Map([
+        ["src/domain/snapshot.ts", new Set(["src/services/evaluator.ts", "src/services/other.ts"])],
+      ]),
+      filePayloads: new Map([
+        ["src/domain/snapshot.ts", {
+          file: "src/domain/snapshot.ts",
+          language: "typescript",
+          contentHash: "h_snap",
+          symbols: [symType, symConst],
+          outgoingCalls: [],
+        }],
+        ["src/services/evaluator.ts", caller1],
+        ["src/services/other.ts", caller2],
+      ]),
+    });
+
+    // Querying JobOfferSnapshot must ONLY return evaluator.ts, NOT other.ts!
+    const resultSnapshot = await getImpactRadius(cache, "JobOfferSnapshot");
+    expect(resultSnapshot.status).toBe("ok");
+    expect(resultSnapshot.totalFiles).toBe(1);
+    expect(resultSnapshot.filesByDepth.get(1)).toEqual(["src/services/evaluator.ts"]);
+
+    // Querying UnrelatedConstant must ONLY return other.ts, NOT evaluator.ts!
+    const resultConst = await getImpactRadius(cache, "UnrelatedConstant");
+    expect(resultConst.status).toBe("ok");
+    expect(resultConst.totalFiles).toBe(1);
+    expect(resultConst.filesByDepth.get(1)).toEqual(["src/services/other.ts"]);
+  });
+
+  it("returns status ok and totalFiles 0 for a genuine zero-dependent symbol", async () => {
+    const symUnused: SymbolNode = {
+      id: "src/unused.ts::UNUSED_SYMBOL#1",
+      name: "UNUSED_SYMBOL",
+      qualifiedName: "UNUSED_SYMBOL",
+      kind: "variable",
+      file: "src/unused.ts",
+      line: 1,
+      endLine: 1,
+      language: "typescript",
+    };
+
+    const cache = createMockCache({
+      symbols: [symUnused],
+      reverseFileIndex: new Map(),
+      filePayloads: new Map([
+        ["src/unused.ts", { file: "src/unused.ts", language: "typescript", contentHash: "h_u", symbols: [symUnused], outgoingCalls: [] }],
+      ]),
+    });
+
+    const result = await getImpactRadius(cache, "UNUSED_SYMBOL");
+    expect(result.status).toBe("ok");
+    expect(result.totalFiles).toBe(0);
+  });
+
+  it("file mode traverses all dependents of a target file", async () => {
+    const cache = createMockCache({
+      symbols: [],
+      reverseFileIndex: new Map([
+        ["src/domain/snapshot.ts", new Set(["src/services/evaluator.ts", "src/services/other.ts"])],
+      ]),
+      filePayloads: new Map([
+        ["src/domain/snapshot.ts", { file: "src/domain/snapshot.ts", language: "typescript", contentHash: "h1", symbols: [], outgoingCalls: [] }],
+      ]),
+    });
+
+    const result = await getImpactRadius(cache, "src/domain/snapshot.ts");
+    expect(result.targetKind).toBe("file");
+    expect(result.status).toBe("ok");
+    expect(result.totalFiles).toBe(2);
+    expect(result.filesByDepth.get(1)).toEqual(["src/services/evaluator.ts", "src/services/other.ts"]);
+  });
+});

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -65,6 +65,49 @@ const helper = function () { return 42; };
       expect(names).toContain("validate");
       expect(names).toContain("helper");
     });
+
+    it("extracts interfaces, type aliases, enums, and plain constants (issue #132)", () => {
+      const src = `
+export interface UserProfile { id: string; name: string; }
+export type JobOfferSnapshot = { id: string; score: number; };
+export enum OfferStatus { Active, Expired }
+export const STALE_EVALUATION_WHERE = "status = 'stale'";
+export let retryCount = 3;
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/types.ts");
+      const syms = new Map(out.symbols.map((s) => [s.name, s]));
+      expect(syms.get("UserProfile")?.kind).toBe("interface");
+      expect(syms.get("JobOfferSnapshot")?.kind).toBe("type");
+      expect(syms.get("OfferStatus")?.kind).toBe("enum");
+      expect(syms.get("STALE_EVALUATION_WHERE")?.kind).toBe("variable");
+      expect(syms.get("retryCount")?.kind).toBe("variable");
+    });
+
+    it("extracts import, re-export, and type reference edges (issue #132)", () => {
+      const src = `
+import { JobOfferSnapshot, STALE_EVALUATION_WHERE } from "./types";
+import type { UserProfile } from "./user";
+import DefaultService from "./service";
+export { OfferStatus } from "./enums";
+
+export function processOffer(offer: JobOfferSnapshot): UserProfile {
+  const query = STALE_EVALUATION_WHERE;
+  return { id: "1", name: query };
+}
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/worker.ts");
+      const calleeNames = out.rawCalls.map((c) => c.calleeName);
+      expect(calleeNames).toContain("JobOfferSnapshot");
+      expect(calleeNames).toContain("STALE_EVALUATION_WHERE");
+      expect(calleeNames).toContain("UserProfile");
+      expect(calleeNames).toContain("DefaultService");
+      expect(calleeNames).toContain("OfferStatus");
+
+      const processOfferCall = out.rawCalls.find(
+        (c) => c.calleeName === "JobOfferSnapshot" && c.callerId.includes("::processOffer#"),
+      );
+      expect(processOfferCall).toBeDefined();
+    });
   });
 
   describe("Python", () => {


### PR DESCRIPTION
Fixes #132

### 1. Problem Identified

When running `codebase_impact` on non-function TypeScript/JavaScript exports (such as `const`, `type`, `interface`, and `enum`), the tool consistently reported:
```
Blast radius for symbol: <symbol>
Depth: 3    Total impacted files: 0

No callers found — nothing else depends on this.
```
even when those symbols were imported and used across multiple files in the project.

This defect stemmed from three core architectural issues:
1. **Declaration Extraction Gap**: The TypeScript/JavaScript AST extractor in `graph-symbols.ts` only extracted classes, function declarations, and function-valued constants. Plain `const`, `let`, `var`, `interface_declaration`, `type_alias_declaration`, and `enum_declaration` were completely ignored during symbol extraction.
2. **Missing Reference Model**: Only `call_expression` nodes created outgoing edges. Type references (`type_identifier`, generics, annotations), value references, imports (`import_specifier`, `import type`, default imports), and re-exports (`export_specifier`) did not generate reference edges.
3. **File-Level Reverse Index Traversal**: When resolving a symbol's blast radius, `getImpactRadius` converted the target symbol name into its defining file(s) and traversed a file-level reverse call index (`calleeFile -> callerFiles`). Consequently:
   - If a symbol was not in the index, it produced an empty seed set and returned `0` impacted files without indicating that the symbol was unknown or unsupported.
   - All symbols in the same file shared the same aggregate blast radius.
   - Any `0` result was formatted as *"No callers found — nothing else depends on this"*, creating a false sense of safety before refactoring or removing code.
4. **Misleading Grammar Status**: `codebase_graph_status` labeled dynamically registered grammars as "AST grammars", omitting ast-grep built-in grammars (JS/TS/TSX/Python/etc.), which caused confusion regarding whether TS grammar was loaded.

---

### 2. Solution Implemented

1. **Complete Declaration and Reference Extraction in TS/JS (`src/services/graph-symbols.ts`)**:
   - Added first-class `"type"` symbol kind to `SymbolKind` in `src/types.ts`.
   - Enhanced `extractFromTsLike` to extract `interface_declaration`, `type_alias_declaration`, `enum_declaration`, and plain `variable_declarator` (`const`, `let`, `var`).
   - Added extraction of reference edges from:
     - `import_statement` (`import { X, Y as Z }`, `import type { T }`, and default imports).
     - `export_statement` (re-exports `export { X }`).
     - `type_identifier` (type annotations, type arguments, `implements`, `extends`), filtering out TS built-in primitive types and declaration site identifiers.
     - Value references to imported identifiers in expressions.

2. **Exact Symbol-Level Traversal & Fail-Closed Status (`src/services/graph-impact.ts`)**:
   - Updated `getImpactRadius` to track exact symbol identities:
     - In symbol mode, candidate caller files from `reverseIndex.get(calleeFile)` are inspected for outgoing edges that specifically target `sym.id` (`edge.calleeCandidates.includes(sym.id)`).
     - Hop-by-hop traversal propagates only through the actual calling symbols / calling files.
   - Formalized `ImpactStatus` (`ok`, `not_found`, `ambiguous`, `unsupported_or_incomplete`):
     - `not_found`: returned when the symbol/file does not exist in the index.
     - `ambiguous`: returned when an unqualified symbol name is defined in multiple files, providing candidate locations.
     - `ok`: returned when the target is resolved unambiguously, clearly distinguishing 0 verified dependents from missing symbols.

3. **Tool Output & Status Diagnostics (`src/tools/graph-tools.ts`)**:
   - Updated `codebase_impact` to return descriptive diagnostics for `not_found` and `ambiguous` targets.
   - Updated `codebase_graph_status` grammar rendering to separate built-in ast-grep grammars (`csharp`, `go`, `java`, `javascript`, `kotlin`, `python`, `rust`, `tsx`, `typescript`) from dynamically loaded grammars.

4. **Schema Versioning (`src/types.ts`, `src/services/code-graph.ts`)**:
   - Updated `SymbolGraphMeta.schemaVersion` to `schemaVersion: 1 | 2`, setting `schemaVersion: 2` for newly built graphs.

5. **Comprehensive Test Suite**:
   - Added unit tests in `tests/unit/graph-symbols.test.ts` asserting extraction of `type`, `interface`, `enum`, `const`, `import type`, re-exports, and type references.
   - Added unit tests in `tests/unit/graph-impact.test.ts` verifying exact symbol blast radius isolation between distinct symbols in the same file, ambiguous symbol handling, not-found symbol handling, and genuine zero-dependent symbols.
   - Added integration tests in `tests/integration/tools.test.ts` for `codebase_impact` with interface exports (`UserConfig`).

---

### 3. Rationale and Design Decisions

- **Exact Symbol Identity vs File-Level Traversal**: A blast radius tool is fundamentally used to answer *"What breaks if I change or delete symbol X?"*. Unioning all callers of a file or confusing two symbols defined in the same file undermines the safety guarantee of the tool. Traversing exact symbol candidate IDs restores the correctness contract.
- **Fail-Closed by Default**: Phrasing unknown or unsupported symbols as "0 callers found / safe to delete" is dangerous in refactoring workflows. Differentiating `not_found`, `ambiguous`, and `resolved_zero` ensures agents and human developers receive actionable and truthful feedback.
- **Built-in Type Filtering**: Filtering out TypeScript primitives (`string`, `number`, `boolean`, `Promise`, `Record`, etc.) prevents millions of unresolvable edges from inflating memory consumption and skewing the unresolved edge percentage.
- **Zero-Breakage Backward Compatibility**: Existing `reverseFileIndex` sharding is retained and used as a fast coarse filter, after which file payloads are loaded lazily to check exact edge targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Impact analysis now distinguishes successful, unavailable, ambiguous, and unsupported results.
  * Ambiguous symbol matches include candidate definitions to help identify the intended target.
  * Code graphs now recognize interfaces, type aliases, enums, variables, imports, re-exports, and type references.
  * Impact analysis supports both symbol and file targets with clearer caller and reference results.

* **Bug Fixes**
  * Improved blast-radius accuracy when multiple symbols share a file.
  * Added clearer messages for missing symbols and genuinely unused symbols.

* **Improvements**
  * Graph status reporting now clearly separates built-in and dynamically loaded grammars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->