### PR TITLE
fix(graph): exact symbol impact traversal and declaration extraction for non-function exports (#132)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -330,7 +330,9 @@ server.tool(
   "Impact Analysis — return the BLAST RADIUS for a file or symbol. Lists every file (and, where helpful, function) that could break if you change the target. Polymorphic on target: a path-like string ('src/foo.ts') triggers file-mode; a name-like string ('validateUser') triggers symbol-mode. Use this BEFORE refactoring, renaming, or deleting code to know what depends on it.",
   {
     projectPath: z.string().describe("Absolute path to the project directory.").optional(),
-    target: z.string().describe("Target file path (relative) OR symbol name."),
+    target: z.string().describe("Target file path (relative) OR symbol name.").optional(),
+    file: z.string().describe("Optional file path to disambiguate the target symbol.").optional(),
+    symbolId: z.string().describe("Exact symbol ID (e.g. 'src/foo.ts::validateUser#10') to disambiguate.").optional(),
     depth: z.number().describe("How many hops back to walk (default 3, max 10).").optional(),
   },
   async (args) => ({

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -390,7 +390,7 @@ async function persistSymbolGraph(
     fileCount: symbolsByFile.size,
     unresolvedEdgePct: computeUnresolvedPct(outgoingCallsByFile),
     builtAt: Date.now(),
-    schemaVersion: 1,
+    schemaVersion: 2,
   };
   await saveSymbolGraphMeta(projectId, meta);
 

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -360,24 +360,33 @@ async function persistSymbolGraph(
     const newGeneration = randomUUID();
     registerStagingGeneration(projectId, newGeneration);
 
-    const reverseShards = new Map<number, Record<string, string[]>>();
+    const reverseShardSets = new Map<number, Map<string, Set<string>>>();
     for (const edges of outgoingCallsByFile.values()) {
       for (const e of edges) {
         for (const calleeId of e.calleeCandidates) {
           const bucket = reverseShardKeyForCallee(calleeId);
-          let shard = reverseShards.get(bucket);
+          let shard = reverseShardSets.get(bucket);
           if (!shard) {
-            shard = {};
-            reverseShards.set(bucket, shard);
+            shard = new Map();
+            reverseShardSets.set(bucket, shard);
           }
-          const existing = shard[calleeId];
-          if (existing) {
-            if (!existing.includes(e.callerId)) existing.push(e.callerId);
-          } else {
-            shard[calleeId] = [e.callerId];
+          let callers = shard.get(calleeId);
+          if (!callers) {
+            callers = new Set();
+            shard.set(calleeId, callers);
           }
+          callers.add(e.callerId);
         }
       }
+    }
+
+    const reverseShards = new Map<number, Record<string, string[]>>();
+    for (const [bucket, shardSets] of reverseShardSets.entries()) {
+      const shard: Record<string, string[]> = {};
+      for (const [calleeId, callers] of shardSets.entries()) {
+        shard[calleeId] = Array.from(callers);
+      }
+      reverseShards.set(bucket, shard);
     }
 
     try {

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -31,6 +31,7 @@ import {
   allNameShardKeys,
   cleanStaleGenerations,
   contentHashOf,
+  coordinateProject,
   deleteGeneration,
   deleteSymbolGraphData,
   ensureSymbolGraphCollections,
@@ -310,125 +311,127 @@ async function persistSymbolGraph(
   symbolsByFile: Map<string, SymbolNode[]>,
   outgoingCallsByFile: Map<string, SymbolEdge[]>,
 ): Promise<void> {
-  await ensureSymbolGraphCollections(projectId);
+  return coordinateProject(projectId, async () => {
+    await ensureSymbolGraphCollections(projectId);
 
-  // Build per-file payloads (need source bytes for contentHash).
-  const payloads: SymbolGraphFilePayload[] = [];
-  let totalSymbols = 0;
-  let totalEdges = 0;
-  for (const [relPath, symbols] of symbolsByFile.entries()) {
-    const outgoingCalls = outgoingCallsByFile.get(relPath) ?? [];
-    let language = "plaintext";
-    const firstNonModule = symbols.find((s) => s.name !== "<module>");
-    if (firstNonModule) language = firstNonModule.language;
-    else language = symbols[0]?.language ?? language;
+    // Build per-file payloads (need source bytes for contentHash).
+    const payloads: SymbolGraphFilePayload[] = [];
+    let totalSymbols = 0;
+    let totalEdges = 0;
+    for (const [relPath, symbols] of symbolsByFile.entries()) {
+      const outgoingCalls = outgoingCallsByFile.get(relPath) ?? [];
+      let language = "plaintext";
+      const firstNonModule = symbols.find((s) => s.name !== "<module>");
+      if (firstNonModule) language = firstNonModule.language;
+      else language = symbols[0]?.language ?? language;
 
-    let contentHash = "";
-    try {
-      const src = await fs.readFile(path.join(resolvedPath, relPath), "utf-8");
-      contentHash = contentHashOf(src);
-    } catch {
-      // ignore
+      let contentHash = "";
+      try {
+        const src = await fs.readFile(path.join(resolvedPath, relPath), "utf-8");
+        contentHash = contentHashOf(src);
+      } catch {
+        // ignore
+      }
+      payloads.push({
+        file: relPath, language, contentHash, symbols, outgoingCalls,
+      });
+      totalSymbols += symbols.filter((s) => s.name !== "<module>").length;
+      totalEdges += outgoingCalls.length;
     }
-    payloads.push({
-      file: relPath, language, contentHash, symbols, outgoingCalls,
-    });
-    totalSymbols += symbols.filter((s) => s.name !== "<module>").length;
-    totalEdges += outgoingCalls.length;
-  }
 
-  // Build sharded indices
-  const nameShards = new Map<string, Record<string, SymbolRef[]>>();
-  for (const key of allNameShardKeys()) nameShards.set(key, {});
-  for (const [file, symbols] of symbolsByFile.entries()) {
-    for (const sym of symbols) {
-      if (sym.name === "<module>") continue;
-      const shardKey = nameShardKey(sym.name);
-      const shard = nameShards.get(shardKey);
-      if (!shard) continue;
-      const ref: SymbolRef = { file, id: sym.id };
-      // Use hasOwn — `shard[sym.name]` would return Object.prototype.constructor
-      // (a function) for symbol names like "constructor" / "toString" / "hasOwnProperty".
-      const existing = Object.hasOwn(shard, sym.name) ? shard[sym.name] : undefined;
-      if (existing) existing.push(ref);
-      else shard[sym.name] = [ref];
+    // Build sharded indices
+    const nameShards = new Map<string, Record<string, SymbolRef[]>>();
+    for (const key of allNameShardKeys()) nameShards.set(key, {});
+    for (const [file, symbols] of symbolsByFile.entries()) {
+      for (const sym of symbols) {
+        if (sym.name === "<module>") continue;
+        const shardKey = nameShardKey(sym.name);
+        const shard = nameShards.get(shardKey);
+        if (!shard) continue;
+        const ref: SymbolRef = { file, id: sym.id };
+        // Use hasOwn — `shard[sym.name]` would return Object.prototype.constructor
+        // (a function) for symbol names like "constructor" / "toString" / "hasOwnProperty".
+        const existing = Object.hasOwn(shard, sym.name) ? shard[sym.name] : undefined;
+        if (existing) existing.push(ref);
+        else shard[sym.name] = [ref];
+      }
     }
-  }
 
-  const newGeneration = randomUUID();
-  registerStagingGeneration(newGeneration);
+    const newGeneration = randomUUID();
+    registerStagingGeneration(projectId, newGeneration);
 
-  const reverseShards = new Map<number, Record<string, string[]>>();
-  for (const edges of outgoingCallsByFile.values()) {
-    for (const e of edges) {
-      for (const calleeId of e.calleeCandidates) {
-        const bucket = reverseShardKeyForCallee(calleeId);
-        let shard = reverseShards.get(bucket);
-        if (!shard) {
-          shard = {};
-          reverseShards.set(bucket, shard);
-        }
-        const existing = shard[calleeId];
-        if (existing) {
-          if (!existing.includes(e.callerId)) existing.push(e.callerId);
-        } else {
-          shard[calleeId] = [e.callerId];
+    const reverseShards = new Map<number, Record<string, string[]>>();
+    for (const edges of outgoingCallsByFile.values()) {
+      for (const e of edges) {
+        for (const calleeId of e.calleeCandidates) {
+          const bucket = reverseShardKeyForCallee(calleeId);
+          let shard = reverseShards.get(bucket);
+          if (!shard) {
+            shard = {};
+            reverseShards.set(bucket, shard);
+          }
+          const existing = shard[calleeId];
+          if (existing) {
+            if (!existing.includes(e.callerId)) existing.push(e.callerId);
+          } else {
+            shard[calleeId] = [e.callerId];
+          }
         }
       }
     }
-  }
 
-  try {
-    // Persist all payloads and shards into the staged generation first
-    await saveFilePayloads(projectId, payloads, newGeneration);
-    for (const [shardKey, shard] of nameShards.entries()) {
-      if (Object.keys(shard).length === 0) continue;
-      await saveNameShard(projectId, shardKey, shard, newGeneration);
-    }
-    for (const [bucket, shard] of reverseShards.entries()) {
-      if (Object.keys(shard).length === 0) continue;
-      await saveReverseShard(projectId, bucket, shard, newGeneration);
-    }
+    try {
+      // Persist all payloads and shards into the staged generation first
+      await saveFilePayloads(projectId, payloads, newGeneration);
+      for (const [shardKey, shard] of nameShards.entries()) {
+        if (Object.keys(shard).length === 0) continue;
+        await saveNameShard(projectId, shardKey, shard, newGeneration);
+      }
+      for (const [bucket, shard] of reverseShards.entries()) {
+        if (Object.keys(shard).length === 0) continue;
+        await saveReverseShard(projectId, bucket, shard, newGeneration);
+      }
 
-    // Activate that generation with one metadata-pointer write only after every staged write succeeds
-    const meta: SymbolGraphMeta = {
-      projectId,
-      symbolCount: totalSymbols,
-      edgeCount: totalEdges,
-      fileCount: symbolsByFile.size,
-      unresolvedEdgePct: computeUnresolvedPct(outgoingCallsByFile),
-      builtAt: Date.now(),
-      schemaVersion: 2,
-      generation: newGeneration,
-    };
-    await saveSymbolGraphMeta(projectId, meta);
-
-    // Replace cache entry
-    const cache = new SymbolGraphCache(projectId, meta);
-    setSymbolGraphCache(cache);
-
-    // Safely retire superseded generations and clean abandoned staged generations
-    await cleanStaleGenerations(projectId, newGeneration).catch((err) => {
-      logger.warn("Failed to clean stale symbol-graph generations", {
+      // Activate that generation with one metadata-pointer write only after every staged write succeeds
+      const meta: SymbolGraphMeta = {
         projectId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    });
+        symbolCount: totalSymbols,
+        edgeCount: totalEdges,
+        fileCount: symbolsByFile.size,
+        unresolvedEdgePct: computeUnresolvedPct(outgoingCallsByFile),
+        builtAt: Date.now(),
+        schemaVersion: 2,
+        generation: newGeneration,
+      };
+      await saveSymbolGraphMeta(projectId, meta);
 
-    logger.info("Symbol graph persisted", {
-      projectId,
-      files: meta.fileCount,
-      symbols: meta.symbolCount,
-      edges: meta.edgeCount,
-      unresolvedPct: meta.unresolvedEdgePct.toFixed(1),
-    });
-  } catch (err) {
-    // Staging failed: clean up the incomplete staged generation immediately
-    await deleteGeneration(projectId, newGeneration).catch(() => {});
-    throw err;
-  } finally {
-    unregisterStagingGeneration(newGeneration);
-  }
+      // Replace cache entry
+      const cache = new SymbolGraphCache(projectId, meta);
+      setSymbolGraphCache(cache);
+
+      // Safely retire superseded generations and clean abandoned staged generations
+      await cleanStaleGenerations(projectId, newGeneration).catch((err) => {
+        logger.warn("Failed to clean stale symbol-graph generations", {
+          projectId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+
+      logger.info("Symbol graph persisted", {
+        projectId,
+        files: meta.fileCount,
+        symbols: meta.symbolCount,
+        edges: meta.edgeCount,
+        unresolvedPct: meta.unresolvedEdgePct.toFixed(1),
+      });
+    } catch (err) {
+      // Staging failed: clean up the incomplete staged generation immediately
+      await deleteGeneration(projectId, newGeneration).catch(() => {});
+      throw err;
+    } finally {
+      unregisterStagingGeneration(projectId, newGeneration);
+    }
+  });
 }
 
 /**

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -32,7 +33,7 @@ import {
   deleteSymbolGraphData,
   ensureSymbolGraphCollections,
   nameShardKey,
-  reverseShardKey,
+  reverseShardKeyForCallee,
   saveFilePayloads,
   saveNameShard,
   saveReverseShard,
@@ -350,13 +351,13 @@ async function persistSymbolGraph(
     }
   }
 
+  const newGeneration = randomUUID();
+
   const reverseShards = new Map<number, Record<string, string[]>>();
   for (const edges of outgoingCallsByFile.values()) {
     for (const e of edges) {
       for (const calleeId of e.calleeCandidates) {
-        const calleeFile = calleeId.split("::")[0];
-        if (!calleeFile) continue;
-        const bucket = reverseShardKey(calleeFile);
+        const bucket = reverseShardKeyForCallee(calleeId);
         let shard = reverseShards.get(bucket);
         if (!shard) {
           shard = {};
@@ -372,17 +373,18 @@ async function persistSymbolGraph(
     }
   }
 
-  // Persist
-  await saveFilePayloads(projectId, payloads);
+  // Persist all payloads and shards into the staged generation first
+  await saveFilePayloads(projectId, payloads, newGeneration);
   for (const [shardKey, shard] of nameShards.entries()) {
     if (Object.keys(shard).length === 0) continue;
-    await saveNameShard(projectId, shardKey, shard);
+    await saveNameShard(projectId, shardKey, shard, newGeneration);
   }
   for (const [bucket, shard] of reverseShards.entries()) {
     if (Object.keys(shard).length === 0) continue;
-    await saveReverseShard(projectId, bucket, shard);
+    await saveReverseShard(projectId, bucket, shard, newGeneration);
   }
 
+  // Activate that generation with one metadata-pointer write only after every staged write succeeds
   const meta: SymbolGraphMeta = {
     projectId,
     symbolCount: totalSymbols,
@@ -391,6 +393,7 @@ async function persistSymbolGraph(
     unresolvedEdgePct: computeUnresolvedPct(outgoingCallsByFile),
     builtAt: Date.now(),
     schemaVersion: 2,
+    generation: newGeneration,
   };
   await saveSymbolGraphMeta(projectId, meta);
 

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -351,22 +351,22 @@ async function persistSymbolGraph(
   }
 
   const reverseShards = new Map<number, Record<string, string[]>>();
-  for (const [callerFile, edges] of outgoingCallsByFile.entries()) {
+  for (const edges of outgoingCallsByFile.values()) {
     for (const e of edges) {
       for (const calleeId of e.calleeCandidates) {
         const calleeFile = calleeId.split("::")[0];
-        if (!calleeFile || calleeFile === callerFile) continue;
+        if (!calleeFile) continue;
         const bucket = reverseShardKey(calleeFile);
         let shard = reverseShards.get(bucket);
         if (!shard) {
           shard = {};
           reverseShards.set(bucket, shard);
         }
-        const existing = shard[calleeFile];
+        const existing = shard[calleeId];
         if (existing) {
-          if (!existing.includes(callerFile)) existing.push(callerFile);
+          if (!existing.includes(e.callerId)) existing.push(e.callerId);
         } else {
-          shard[calleeFile] = [callerFile];
+          shard[calleeId] = [e.callerId];
         }
       }
     }

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -35,11 +35,13 @@ import {
   deleteSymbolGraphData,
   ensureSymbolGraphCollections,
   nameShardKey,
+  registerStagingGeneration,
   reverseShardKeyForCallee,
   saveFilePayloads,
   saveNameShard,
   saveReverseShard,
   saveSymbolGraphMeta,
+  unregisterStagingGeneration,
 } from "./symbol-graph-store.js";
 
 // Re-export analysis functions for external consumers
@@ -354,6 +356,7 @@ async function persistSymbolGraph(
   }
 
   const newGeneration = randomUUID();
+  registerStagingGeneration(newGeneration);
 
   const reverseShards = new Map<number, Record<string, string[]>>();
   for (const edges of outgoingCallsByFile.values()) {
@@ -423,6 +426,8 @@ async function persistSymbolGraph(
     // Staging failed: clean up the incomplete staged generation immediately
     await deleteGeneration(projectId, newGeneration).catch(() => {});
     throw err;
+  } finally {
+    unregisterStagingGeneration(newGeneration);
   }
 }
 

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -29,7 +29,9 @@ import {
 } from "./symbol-graph-cache.js";
 import {
   allNameShardKeys,
+  cleanStaleGenerations,
   contentHashOf,
+  deleteGeneration,
   deleteSymbolGraphData,
   ensureSymbolGraphCollections,
   nameShardKey,
@@ -373,41 +375,55 @@ async function persistSymbolGraph(
     }
   }
 
-  // Persist all payloads and shards into the staged generation first
-  await saveFilePayloads(projectId, payloads, newGeneration);
-  for (const [shardKey, shard] of nameShards.entries()) {
-    if (Object.keys(shard).length === 0) continue;
-    await saveNameShard(projectId, shardKey, shard, newGeneration);
+  try {
+    // Persist all payloads and shards into the staged generation first
+    await saveFilePayloads(projectId, payloads, newGeneration);
+    for (const [shardKey, shard] of nameShards.entries()) {
+      if (Object.keys(shard).length === 0) continue;
+      await saveNameShard(projectId, shardKey, shard, newGeneration);
+    }
+    for (const [bucket, shard] of reverseShards.entries()) {
+      if (Object.keys(shard).length === 0) continue;
+      await saveReverseShard(projectId, bucket, shard, newGeneration);
+    }
+
+    // Activate that generation with one metadata-pointer write only after every staged write succeeds
+    const meta: SymbolGraphMeta = {
+      projectId,
+      symbolCount: totalSymbols,
+      edgeCount: totalEdges,
+      fileCount: symbolsByFile.size,
+      unresolvedEdgePct: computeUnresolvedPct(outgoingCallsByFile),
+      builtAt: Date.now(),
+      schemaVersion: 2,
+      generation: newGeneration,
+    };
+    await saveSymbolGraphMeta(projectId, meta);
+
+    // Replace cache entry
+    const cache = new SymbolGraphCache(projectId, meta);
+    setSymbolGraphCache(cache);
+
+    // Safely retire superseded generations and clean abandoned staged generations
+    await cleanStaleGenerations(projectId, newGeneration).catch((err) => {
+      logger.warn("Failed to clean stale symbol-graph generations", {
+        projectId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+
+    logger.info("Symbol graph persisted", {
+      projectId,
+      files: meta.fileCount,
+      symbols: meta.symbolCount,
+      edges: meta.edgeCount,
+      unresolvedPct: meta.unresolvedEdgePct.toFixed(1),
+    });
+  } catch (err) {
+    // Staging failed: clean up the incomplete staged generation immediately
+    await deleteGeneration(projectId, newGeneration).catch(() => {});
+    throw err;
   }
-  for (const [bucket, shard] of reverseShards.entries()) {
-    if (Object.keys(shard).length === 0) continue;
-    await saveReverseShard(projectId, bucket, shard, newGeneration);
-  }
-
-  // Activate that generation with one metadata-pointer write only after every staged write succeeds
-  const meta: SymbolGraphMeta = {
-    projectId,
-    symbolCount: totalSymbols,
-    edgeCount: totalEdges,
-    fileCount: symbolsByFile.size,
-    unresolvedEdgePct: computeUnresolvedPct(outgoingCallsByFile),
-    builtAt: Date.now(),
-    schemaVersion: 2,
-    generation: newGeneration,
-  };
-  await saveSymbolGraphMeta(projectId, meta);
-
-  // Replace cache entry
-  const cache = new SymbolGraphCache(projectId, meta);
-  setSymbolGraphCache(cache);
-
-  logger.info("Symbol graph persisted", {
-    projectId,
-    files: meta.fileCount,
-    symbols: meta.symbolCount,
-    edges: meta.edgeCount,
-    unresolvedPct: meta.unresolvedEdgePct.toFixed(1),
-  });
 }
 
 /**

--- a/src/services/graph-impact.ts
+++ b/src/services/graph-impact.ts
@@ -331,7 +331,7 @@ export async function getImpactRadius(
     const reverseSymbolIndex = await cache.getReverseSymbolIndex();
     const targetSymbolIds = new Set(selectedRefs.map((r) => r.id));
     const visitedSymbols = new Set<string>(targetSymbolIds);
-    const visitedFiles = new Set<string>();
+    const visitedFiles = new Set<string>(selectedRefs.map((r) => r.file));
     const filesByDepth = new Map<number, string[]>();
 
     let frontierSymbolIds = new Set(targetSymbolIds);

--- a/src/services/graph-impact.ts
+++ b/src/services/graph-impact.ts
@@ -51,6 +51,7 @@ export async function getImpactRadius(
   depth: number = 3,
   options?: ImpactOptions,
 ): Promise<ImpactResult> {
+  const release = cache.acquireReader();
   const safeDepth = Math.max(1, Math.min(depth, MAX_IMPACT_DEPTH));
   const isIncomplete = options?.isIncomplete ?? (cache.meta.schemaVersion < 2);
 
@@ -59,7 +60,6 @@ export async function getImpactRadius(
     : looksLikeFilePath(target)
       ? "file"
       : "symbol";
-
 
   try {
     if (targetKind === "file") {
@@ -226,6 +226,7 @@ export async function getImpactRadius(
     if (cache.meta.schemaVersion < 2) {
       const reverseIndex = await cache.getReverseFileIndex();
       const targetSymbolIds = new Set(selectedRefs.map((r) => r.id));
+      const visitedSymbols = new Set<string>(targetSymbolIds);
       const distinctFiles = Array.from(new Set(selectedRefs.map((r) => r.file)));
       const visitedFiles = new Set<string>(distinctFiles);
       const filesByDepth = new Map<number, string[]>();
@@ -254,7 +255,10 @@ export async function getImpactRadius(
               );
               if (callsTarget) {
                 matched = true;
-                nextSymbolIds.add(edge.callerId);
+                if (!visitedSymbols.has(edge.callerId)) {
+                  visitedSymbols.add(edge.callerId);
+                  nextSymbolIds.add(edge.callerId);
+                }
               }
             }
 
@@ -268,8 +272,10 @@ export async function getImpactRadius(
           }
         }
 
-        if (nextHopFiles.size === 0) break;
-        filesByDepth.set(hop, Array.from(nextHopFiles).sort());
+        if (nextSymbolIds.size === 0) break;
+        if (nextHopFiles.size > 0) {
+          filesByDepth.set(hop, Array.from(nextHopFiles).sort());
+        }
         frontierSymbolIds = nextSymbolIds;
         frontierFiles = nextFiles;
 
@@ -278,12 +284,16 @@ export async function getImpactRadius(
             const potentialCallerFiles = new Set(reverseIndex.get(calleeFile) ?? []);
             potentialCallerFiles.add(calleeFile);
             for (const callerFile of potentialCallerFiles) {
-              if (!visitedFiles.has(callerFile)) {
-                const cp = await cache.getFilePayload(callerFile);
-                if (cp?.outgoingCalls.some((e) => e.calleeCandidates.some((c) => frontierSymbolIds.has(c)))) {
-                  truncated = true;
-                  break;
-                }
+              const cp = await cache.getFilePayload(callerFile);
+              if (!cp) continue;
+              const hasMoreCalls = cp.outgoingCalls.some(
+                (e) =>
+                  !visitedSymbols.has(e.callerId) &&
+                  e.calleeCandidates.some((c) => frontierSymbolIds.has(c)),
+              );
+              if (hasMoreCalls) {
+                truncated = true;
+                break;
               }
             }
             if (truncated) break;
@@ -408,6 +418,8 @@ export async function getImpactRadius(
       };
     }
     throw err;
+  } finally {
+    release();
   }
 }
 
@@ -429,16 +441,21 @@ export async function getCallFlow(
   entrypointId: string,
   depth: number = 5,
 ): Promise<FlowNode | null> {
-  const safeDepth = Math.max(1, Math.min(depth, MAX_FLOW_DEPTH));
-  const file = symbolIdToFile(entrypointId);
-  if (!file) return null;
-  const payload = await cache.getFilePayload(file);
-  if (!payload) return null;
-  const sym = payload.symbols.find((s) => s.id === entrypointId);
-  if (!sym) return null;
+  const release = cache.acquireReader();
+  try {
+    const safeDepth = Math.max(1, Math.min(depth, MAX_FLOW_DEPTH));
+    const file = symbolIdToFile(entrypointId);
+    if (!file) return null;
+    const payload = await cache.getFilePayload(file);
+    if (!payload) return null;
+    const sym = payload.symbols.find((s) => s.id === entrypointId);
+    if (!sym) return null;
 
-  const visited = new Set<string>();
-  return await walk(cache, sym, 0, safeDepth, visited);
+    const visited = new Set<string>();
+    return await walk(cache, sym, 0, safeDepth, visited);
+  } finally {
+    release();
+  }
 }
 
 async function walk(
@@ -513,87 +530,92 @@ export async function getSymbolContext(
   name: string,
   fileHint?: string,
 ): Promise<SymbolContext[]> {
-  const nameIndex = await cache.getNameIndex();
-  let refs = nameIndex.get(name) ?? [];
-  if (fileHint) {
-    const normalizedHint = toForwardSlash(fileHint);
-    refs = refs.filter((r) => r.file === normalizedHint || r.file.endsWith(`/${normalizedHint}`));
-  }
-  if (refs.length === 0) return [];
-
-  const reverseSymbolIndex = await cache.getReverseSymbolIndex();
-  const out: SymbolContext[] = [];
-
-  for (const ref of refs) {
-    const payload = await cache.getFilePayload(ref.file);
-    if (!payload) continue;
-    const sym = payload.symbols.find((s) => s.id === ref.id);
-    if (!sym) continue;
-
-    // Callees: outgoing calls from this symbol
-    const callees: SymbolContextCallee[] = payload.outgoingCalls
-      .filter((e) => e.callerId === sym.id)
-      .map((e) => ({
-        name: e.calleeName,
-        resolved: e.calleeCandidates,
-        confidence: e.confidence,
-        kind: e.kind,
-      }));
-
-    // Callers: query reverse symbol index for callers of this symbol (schema v2)
-    // or scan callerFiles from reverse file index (schema v1)
-    const callers: SymbolContextCaller[] = [];
-
-    if (cache.meta.schemaVersion >= 2) {
-      const callerIds = reverseSymbolIndex.get(sym.id) ?? new Set();
-
-      // Group callerIds by file so we fetch each payload at most once
-      const callerIdsByFile = new Map<string, string[]>();
-      for (const cId of callerIds) {
-        const cFile = symbolIdToFile(cId);
-        if (!cFile) continue;
-        const list = callerIdsByFile.get(cFile);
-        if (list) list.push(cId);
-        else callerIdsByFile.set(cFile, [cId]);
-      }
-
-      for (const [cFile, cIds] of callerIdsByFile.entries()) {
-        const cp = await cache.getFilePayload(cFile);
-        if (!cp) continue;
-        for (const e of cp.outgoingCalls) {
-          if (e.calleeCandidates.includes(sym.id) && cIds.includes(e.callerId)) {
-            callers.push({
-              file: e.callSite.file,
-              line: e.callSite.line,
-              symbolId: e.callerId,
-              kind: e.kind,
-            });
-          }
-        }
-      }
-    } else {
-      const reverseIndex = await cache.getReverseFileIndex();
-      const callerFiles = new Set(reverseIndex.get(ref.file) ?? []);
-      callerFiles.add(ref.file);
-      for (const cf of callerFiles) {
-        const cp = await cache.getFilePayload(cf);
-        if (!cp) continue;
-        for (const e of cp.outgoingCalls) {
-          if (e.calleeCandidates.includes(sym.id)) {
-            callers.push({
-              file: e.callSite.file,
-              line: e.callSite.line,
-              symbolId: e.callerId,
-              kind: e.kind,
-            });
-          }
-        }
-      }
+  const release = cache.acquireReader();
+  try {
+    const nameIndex = await cache.getNameIndex();
+    let refs = nameIndex.get(name) ?? [];
+    if (fileHint) {
+      const normalizedHint = toForwardSlash(fileHint);
+      refs = refs.filter((r) => r.file === normalizedHint || r.file.endsWith(`/${normalizedHint}`));
     }
+    if (refs.length === 0) return [];
 
-    out.push({ symbol: sym, callers, callees });
+    const reverseSymbolIndex = await cache.getReverseSymbolIndex();
+    const out: SymbolContext[] = [];
+
+    for (const ref of refs) {
+      const payload = await cache.getFilePayload(ref.file);
+      if (!payload) continue;
+      const sym = payload.symbols.find((s) => s.id === ref.id);
+      if (!sym) continue;
+
+      // Callees: outgoing calls from this symbol
+      const callees: SymbolContextCallee[] = payload.outgoingCalls
+        .filter((e) => e.callerId === sym.id)
+        .map((e) => ({
+          name: e.calleeName,
+          resolved: e.calleeCandidates,
+          confidence: e.confidence,
+          kind: e.kind,
+        }));
+
+      // Callers: query reverse symbol index for callers of this symbol (schema v2)
+      // or scan callerFiles from reverse file index (schema v1)
+      const callers: SymbolContextCaller[] = [];
+
+      if (cache.meta.schemaVersion >= 2) {
+        const callerIds = reverseSymbolIndex.get(sym.id) ?? new Set();
+
+        // Group callerIds by file so we fetch each payload at most once
+        const callerIdsByFile = new Map<string, string[]>();
+        for (const cId of callerIds) {
+          const cFile = symbolIdToFile(cId);
+          if (!cFile) continue;
+          const list = callerIdsByFile.get(cFile);
+          if (list) list.push(cId);
+          else callerIdsByFile.set(cFile, [cId]);
+        }
+
+        for (const [cFile, cIds] of callerIdsByFile.entries()) {
+          const cp = await cache.getFilePayload(cFile);
+          if (!cp) continue;
+          for (const e of cp.outgoingCalls) {
+            if (e.calleeCandidates.includes(sym.id) && cIds.includes(e.callerId)) {
+              callers.push({
+                file: e.callSite.file,
+                line: e.callSite.line,
+                symbolId: e.callerId,
+                kind: e.kind,
+              });
+            }
+          }
+        }
+      } else {
+        const reverseIndex = await cache.getReverseFileIndex();
+        const callerFiles = new Set(reverseIndex.get(ref.file) ?? []);
+        callerFiles.add(ref.file);
+        for (const cf of callerFiles) {
+          const cp = await cache.getFilePayload(cf);
+          if (!cp) continue;
+          for (const e of cp.outgoingCalls) {
+            if (e.calleeCandidates.includes(sym.id)) {
+              callers.push({
+                file: e.callSite.file,
+                line: e.callSite.line,
+                symbolId: e.callerId,
+                kind: e.kind,
+              });
+            }
+          }
+        }
+      }
+
+      out.push({ symbol: sym, callers, callees });
+    }
+    return out;
+  } finally {
+    release();
   }
-  return out;
 }
 
 // ── List symbols ─────────────────────────────────────────────────────────
@@ -602,33 +624,38 @@ export async function listSymbols(
   cache: SymbolGraphCache,
   opts: { file?: string; query?: string; limit?: number },
 ): Promise<SymbolNode[]> {
-  const limit = opts.limit ?? 200;
-  const out: SymbolNode[] = [];
+  const release = cache.acquireReader();
+  try {
+    const limit = opts.limit ?? 200;
+    const out: SymbolNode[] = [];
 
-  if (opts.file) {
-    const payload = await cache.getFilePayload(toForwardSlash(opts.file));
-    if (!payload) return [];
-    for (const s of payload.symbols) {
-      if (s.name === "<module>") continue;
-      out.push(s);
-      if (out.length >= limit) break;
+    if (opts.file) {
+      const payload = await cache.getFilePayload(toForwardSlash(opts.file));
+      if (!payload) return [];
+      for (const s of payload.symbols) {
+        if (s.name === "<module>") continue;
+        out.push(s);
+        if (out.length >= limit) break;
+      }
+      return out;
+    }
+
+    const nameIndex = await cache.getNameIndex();
+    const q = opts.query?.toLowerCase() ?? "";
+    for (const [name, refs] of nameIndex.entries()) {
+      if (q && !name.toLowerCase().includes(q)) continue;
+      for (const r of refs) {
+        const payload = await cache.getFilePayload(r.file);
+        if (!payload) continue;
+        const sym = payload.symbols.find((s) => s.id === r.id);
+        if (sym) out.push(sym);
+        if (out.length >= limit) return out;
+      }
     }
     return out;
+  } finally {
+    release();
   }
-
-  const nameIndex = await cache.getNameIndex();
-  const q = opts.query?.toLowerCase() ?? "";
-  for (const [name, refs] of nameIndex.entries()) {
-    if (q && !name.toLowerCase().includes(q)) continue;
-    for (const r of refs) {
-      const payload = await cache.getFilePayload(r.file);
-      if (!payload) continue;
-      const sym = payload.symbols.find((s) => s.id === r.id);
-      if (sym) out.push(sym);
-      if (out.length >= limit) return out;
-    }
-  }
-  return out;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────

--- a/src/services/graph-impact.ts
+++ b/src/services/graph-impact.ts
@@ -42,8 +42,10 @@ export async function getImpactRadius(
   cache: SymbolGraphCache,
   target: string,
   depth: number = 3,
+  options?: { isIncomplete?: boolean },
 ): Promise<ImpactResult> {
   const safeDepth = Math.max(1, Math.min(depth, MAX_IMPACT_DEPTH));
+  const isIncomplete = options?.isIncomplete ?? (cache.meta.schemaVersion < 2);
   const reverseIndex = await cache.getReverseFileIndex();
 
   const targetKind: "file" | "symbol" = looksLikeFilePath(target)
@@ -103,6 +105,20 @@ export async function getImpactRadius(
 
     let totalFiles = 0;
     for (const arr of filesByDepth.values()) totalFiles += arr.length;
+
+    if (totalFiles === 0 && isIncomplete) {
+      return {
+        target,
+        targetKind,
+        depth: safeDepth,
+        filesByDepth,
+        totalFiles: 0,
+        truncated: false,
+        status: "unsupported_or_incomplete",
+        message: `The symbol graph is incomplete (schema v${cache.meta.schemaVersion ?? 1} or incomplete language parser support). Rebuild with codebase_graph_build before relying on zero-dependent verification.`,
+      };
+    }
+
     return {
       target,
       targetKind,
@@ -131,14 +147,19 @@ export async function getImpactRadius(
     };
   }
 
-  const distinctFiles = Array.from(new Set(refs.map((r) => r.file)));
-  if (distinctFiles.length > 1) {
+  const distinctIds = Array.from(new Set(refs.map((r) => r.id)));
+  if (distinctIds.length > 1) {
     const candidates: SymbolNode[] = [];
     for (const ref of refs) {
       const payload = await cache.getFilePayload(ref.file);
       const sym = payload?.symbols.find((s) => s.id === ref.id);
       if (sym) candidates.push(sym);
     }
+    const distinctFiles = Array.from(new Set(refs.map((r) => r.file)));
+    const locDesc = distinctFiles.length === 1
+      ? `in file ${distinctFiles[0]}`
+      : `across ${distinctFiles.length} files (${distinctFiles.slice(0, 5).join(", ")}${distinctFiles.length > 5 ? "..." : ""})`;
+
     return {
       target,
       targetKind,
@@ -147,12 +168,13 @@ export async function getImpactRadius(
       totalFiles: 0,
       truncated: false,
       status: "ambiguous",
-      message: `Symbol '${target}' is ambiguous (defined in ${distinctFiles.length} files: ${distinctFiles.slice(0, 5).join(", ")}${distinctFiles.length > 5 ? "..." : ""}). Specify the file path or qualified name to disambiguate.`,
+      message: `Symbol '${target}' is ambiguous (matches ${distinctIds.length} symbols ${locDesc}). Specify the file path or qualified name to disambiguate.`,
       candidates,
     };
   }
 
   const targetSymbolIds = new Set(refs.map((r) => r.id));
+  const distinctFiles = Array.from(new Set(refs.map((r) => r.file)));
   const visitedFiles = new Set<string>(distinctFiles);
   const filesByDepth = new Map<number, string[]>();
 
@@ -220,6 +242,19 @@ export async function getImpactRadius(
 
   let totalFiles = 0;
   for (const arr of filesByDepth.values()) totalFiles += arr.length;
+
+  if (totalFiles === 0 && isIncomplete) {
+    return {
+      target,
+      targetKind,
+      depth: safeDepth,
+      filesByDepth,
+      totalFiles: 0,
+      truncated: false,
+      status: "unsupported_or_incomplete",
+      message: `The symbol graph is incomplete (schema v${cache.meta.schemaVersion ?? 1} or incomplete language parser support). Rebuild with codebase_graph_build before relying on zero-dependent verification.`,
+    };
+  }
 
   return {
     target,

--- a/src/services/graph-impact.ts
+++ b/src/services/graph-impact.ts
@@ -60,18 +60,6 @@ export async function getImpactRadius(
       ? "file"
       : "symbol";
 
-  if (cache.meta.schemaVersion < 2) {
-    return {
-      target,
-      targetKind,
-      depth: safeDepth,
-      filesByDepth: new Map(),
-      totalFiles: 0,
-      truncated: false,
-      status: "graph_upgrade_required",
-      message: `The symbol graph is schema v${cache.meta.schemaVersion ?? 1} (legacy / incomplete). Rebuild with codebase_graph_build before querying impact analysis.`,
-    };
-  }
 
   try {
     if (targetKind === "file") {
@@ -233,6 +221,101 @@ export async function getImpactRadius(
         };
       }
       selectedRefs = refs;
+    }
+
+    if (cache.meta.schemaVersion < 2) {
+      const reverseIndex = await cache.getReverseFileIndex();
+      const targetSymbolIds = new Set(selectedRefs.map((r) => r.id));
+      const distinctFiles = Array.from(new Set(selectedRefs.map((r) => r.file)));
+      const visitedFiles = new Set<string>(distinctFiles);
+      const filesByDepth = new Map<number, string[]>();
+
+      let frontierSymbolIds = new Set(targetSymbolIds);
+      let frontierFiles = new Set<string>(distinctFiles);
+      let truncated = false;
+
+      for (let hop = 1; hop <= safeDepth; hop++) {
+        const nextHopFiles = new Set<string>();
+        const nextSymbolIds = new Set<string>();
+        const nextFiles = new Set<string>();
+
+        for (const calleeFile of frontierFiles) {
+          const potentialCallerFiles = reverseIndex.get(calleeFile);
+          if (!potentialCallerFiles) continue;
+
+          for (const callerFile of potentialCallerFiles) {
+            const callerPayload = await cache.getFilePayload(callerFile);
+            if (!callerPayload) continue;
+
+            let matched = false;
+            for (const edge of callerPayload.outgoingCalls) {
+              const callsTarget = edge.calleeCandidates.some((candId) =>
+                frontierSymbolIds.has(candId),
+              );
+              if (callsTarget) {
+                matched = true;
+                nextSymbolIds.add(edge.callerId);
+              }
+            }
+
+            if (matched) {
+              if (!visitedFiles.has(callerFile)) {
+                nextHopFiles.add(callerFile);
+                visitedFiles.add(callerFile);
+              }
+              nextFiles.add(callerFile);
+            }
+          }
+        }
+
+        if (nextHopFiles.size === 0) break;
+        filesByDepth.set(hop, Array.from(nextHopFiles).sort());
+        frontierSymbolIds = nextSymbolIds;
+        frontierFiles = nextFiles;
+
+        if (hop === safeDepth) {
+          for (const calleeFile of frontierFiles) {
+            const potentialCallerFiles = reverseIndex.get(calleeFile);
+            if (!potentialCallerFiles) continue;
+            for (const callerFile of potentialCallerFiles) {
+              if (!visitedFiles.has(callerFile)) {
+                const cp = await cache.getFilePayload(callerFile);
+                if (cp?.outgoingCalls.some((e) => e.calleeCandidates.some((c) => frontierSymbolIds.has(c)))) {
+                  truncated = true;
+                  break;
+                }
+              }
+            }
+            if (truncated) break;
+          }
+        }
+      }
+
+      let totalFiles = 0;
+      for (const arr of filesByDepth.values()) totalFiles += arr.length;
+
+      if (totalFiles === 0 && isIncomplete) {
+        return {
+          target,
+          targetKind,
+          depth: safeDepth,
+          filesByDepth,
+          totalFiles: 0,
+          truncated: false,
+          status: "unsupported_or_incomplete",
+          message: `The symbol graph is incomplete (schema v${cache.meta.schemaVersion ?? 1} or incomplete language parser support). Rebuild with codebase_graph_build before relying on zero-dependent verification.`,
+        };
+      }
+
+      return {
+        target,
+        targetKind,
+        depth: safeDepth,
+        filesByDepth,
+        totalFiles,
+        truncated,
+        status: "ok",
+      };
     }
 
     const reverseSymbolIndex = await cache.getReverseSymbolIndex();
@@ -457,31 +540,52 @@ export async function getSymbolContext(
         kind: e.kind,
       }));
 
-    // Callers: query reverse symbol index for callers of this symbol
-    const callerIds = reverseSymbolIndex.get(sym.id) ?? new Set();
+    // Callers: query reverse symbol index for callers of this symbol (schema v2)
+    // or scan callerFiles from reverse file index (schema v1)
     const callers: SymbolContextCaller[] = [];
 
-    // Group callerIds by file so we fetch each payload at most once
-    const callerIdsByFile = new Map<string, string[]>();
-    for (const cId of callerIds) {
-      const cFile = symbolIdToFile(cId);
-      if (!cFile) continue;
-      const list = callerIdsByFile.get(cFile);
-      if (list) list.push(cId);
-      else callerIdsByFile.set(cFile, [cId]);
-    }
+    if (cache.meta.schemaVersion >= 2) {
+      const callerIds = reverseSymbolIndex.get(sym.id) ?? new Set();
 
-    for (const [cFile, cIds] of callerIdsByFile.entries()) {
-      const cp = await cache.getFilePayload(cFile);
-      if (!cp) continue;
-      for (const e of cp.outgoingCalls) {
-        if (e.calleeCandidates.includes(sym.id) && cIds.includes(e.callerId)) {
-          callers.push({
-            file: e.callSite.file,
-            line: e.callSite.line,
-            symbolId: e.callerId,
-            kind: e.kind,
-          });
+      // Group callerIds by file so we fetch each payload at most once
+      const callerIdsByFile = new Map<string, string[]>();
+      for (const cId of callerIds) {
+        const cFile = symbolIdToFile(cId);
+        if (!cFile) continue;
+        const list = callerIdsByFile.get(cFile);
+        if (list) list.push(cId);
+        else callerIdsByFile.set(cFile, [cId]);
+      }
+
+      for (const [cFile, cIds] of callerIdsByFile.entries()) {
+        const cp = await cache.getFilePayload(cFile);
+        if (!cp) continue;
+        for (const e of cp.outgoingCalls) {
+          if (e.calleeCandidates.includes(sym.id) && cIds.includes(e.callerId)) {
+            callers.push({
+              file: e.callSite.file,
+              line: e.callSite.line,
+              symbolId: e.callerId,
+              kind: e.kind,
+            });
+          }
+        }
+      }
+    } else {
+      const reverseIndex = await cache.getReverseFileIndex();
+      const callerFiles = reverseIndex.get(ref.file) ?? new Set();
+      for (const cf of callerFiles) {
+        const cp = await cache.getFilePayload(cf);
+        if (!cp) continue;
+        for (const e of cp.outgoingCalls) {
+          if (e.calleeCandidates.includes(sym.id)) {
+            callers.push({
+              file: e.callSite.file,
+              line: e.callSite.line,
+              symbolId: e.callerId,
+              kind: e.kind,
+            });
+          }
         }
       }
     }

--- a/src/services/graph-impact.ts
+++ b/src/services/graph-impact.ts
@@ -11,6 +11,7 @@ import { MAX_FLOW_DEPTH, MAX_IMPACT_DEPTH, toForwardSlash } from "../constants.j
 import type { SymbolNode } from "../types.js";
 import {
   type SymbolGraphCache,
+  type SymbolGraphReaderToken,
   symbolIdToFile,
 } from "./symbol-graph-cache.js";
 import { StorageReadError } from "./symbol-graph-store.js";
@@ -52,6 +53,7 @@ export async function getImpactRadius(
   options?: ImpactOptions,
 ): Promise<ImpactResult> {
   const release = cache.acquireReader();
+  const readerToken = release.token;
   const safeDepth = Math.max(1, Math.min(depth, MAX_IMPACT_DEPTH));
   const isIncomplete = options?.isIncomplete ?? (cache.meta.schemaVersion < 2);
 
@@ -63,9 +65,9 @@ export async function getImpactRadius(
 
   try {
     if (targetKind === "file") {
-      const reverseIndex = await cache.getReverseFileIndex();
+      const reverseIndex = await cache.getReverseFileIndex(readerToken);
       const normTarget = toForwardSlash(target);
-      const targetPayload = await cache.getFilePayload(normTarget);
+      const targetPayload = await cache.getFilePayload(normTarget, readerToken);
       if (!targetPayload) {
         return {
           target,
@@ -158,7 +160,7 @@ export async function getImpactRadius(
           message: `Invalid symbolId '${options.symbolId}'.`,
         };
       }
-      const payload = await cache.getFilePayload(sFile);
+      const payload = await cache.getFilePayload(sFile, readerToken);
       const sym = payload?.symbols.find((s) => s.id === options.symbolId);
       if (!sym) {
         return {
@@ -174,7 +176,7 @@ export async function getImpactRadius(
       }
       selectedRefs = [{ file: sFile, id: options.symbolId }];
     } else {
-      const nameIndex = await cache.getNameIndex();
+      const nameIndex = await cache.getNameIndex(readerToken);
       let refs = nameIndex.get(target) ?? [];
 
       if (options?.file) {
@@ -199,7 +201,7 @@ export async function getImpactRadius(
       if (distinctIds.length > 1) {
         const candidates: SymbolNode[] = [];
         for (const ref of refs) {
-          const payload = await cache.getFilePayload(ref.file);
+          const payload = await cache.getFilePayload(ref.file, readerToken);
           const sym = payload?.symbols.find((s) => s.id === ref.id);
           if (sym) candidates.push(sym);
         }
@@ -224,7 +226,7 @@ export async function getImpactRadius(
     }
 
     if (cache.meta.schemaVersion < 2) {
-      const reverseIndex = await cache.getReverseFileIndex();
+      const reverseIndex = await cache.getReverseFileIndex(readerToken);
       const targetSymbolIds = new Set(selectedRefs.map((r) => r.id));
       const visitedSymbols = new Set<string>(targetSymbolIds);
       const distinctFiles = Array.from(new Set(selectedRefs.map((r) => r.file)));
@@ -245,7 +247,7 @@ export async function getImpactRadius(
           potentialCallerFiles.add(calleeFile);
 
           for (const callerFile of potentialCallerFiles) {
-            const callerPayload = await cache.getFilePayload(callerFile);
+            const callerPayload = await cache.getFilePayload(callerFile, readerToken);
             if (!callerPayload) continue;
 
             let matched = false;
@@ -284,7 +286,7 @@ export async function getImpactRadius(
             const potentialCallerFiles = new Set(reverseIndex.get(calleeFile) ?? []);
             potentialCallerFiles.add(calleeFile);
             for (const callerFile of potentialCallerFiles) {
-              const cp = await cache.getFilePayload(callerFile);
+              const cp = await cache.getFilePayload(callerFile, readerToken);
               if (!cp) continue;
               const hasMoreCalls = cp.outgoingCalls.some(
                 (e) =>
@@ -328,7 +330,7 @@ export async function getImpactRadius(
       };
     }
 
-    const reverseSymbolIndex = await cache.getReverseSymbolIndex();
+    const reverseSymbolIndex = await cache.getReverseSymbolIndex(readerToken);
     const targetSymbolIds = new Set(selectedRefs.map((r) => r.id));
     const visitedSymbols = new Set<string>(targetSymbolIds);
     const visitedFiles = new Set<string>(selectedRefs.map((r) => r.file));
@@ -440,19 +442,21 @@ export async function getCallFlow(
   cache: SymbolGraphCache,
   entrypointId: string,
   depth: number = 5,
+  operationToken?: SymbolGraphReaderToken,
 ): Promise<FlowNode | null> {
-  const release = cache.acquireReader();
+  const release = cache.acquireReader(operationToken);
+  const readerToken = release.token;
   try {
     const safeDepth = Math.max(1, Math.min(depth, MAX_FLOW_DEPTH));
     const file = symbolIdToFile(entrypointId);
     if (!file) return null;
-    const payload = await cache.getFilePayload(file);
+    const payload = await cache.getFilePayload(file, readerToken);
     if (!payload) return null;
     const sym = payload.symbols.find((s) => s.id === entrypointId);
     if (!sym) return null;
 
     const visited = new Set<string>();
-    return await walk(cache, sym, 0, safeDepth, visited);
+    return await walk(cache, sym, 0, safeDepth, visited, readerToken);
   } finally {
     release();
   }
@@ -464,6 +468,7 @@ async function walk(
   hop: number,
   maxDepth: number,
   visited: Set<string>,
+  readerToken: SymbolGraphReaderToken,
 ): Promise<FlowNode> {
   const node: FlowNode = {
     symbolId: sym.id,
@@ -482,7 +487,7 @@ async function walk(
     return node;
   }
 
-  const payload = await cache.getFilePayload(sym.file);
+  const payload = await cache.getFilePayload(sym.file, readerToken);
   if (!payload) return node;
 
   const calls = payload.outgoingCalls.filter(
@@ -493,11 +498,18 @@ async function walk(
     for (const calleeId of e.calleeCandidates) {
       const calleeFile = symbolIdToFile(calleeId);
       if (!calleeFile) continue;
-      const calleePayload = await cache.getFilePayload(calleeFile);
+      const calleePayload = await cache.getFilePayload(calleeFile, readerToken);
       if (!calleePayload) continue;
       const calleeSym = calleePayload.symbols.find((s) => s.id === calleeId);
       if (!calleeSym) continue;
-      node.children.push(await walk(cache, calleeSym, hop + 1, maxDepth, visited));
+      node.children.push(await walk(
+        cache,
+        calleeSym,
+        hop + 1,
+        maxDepth,
+        visited,
+        readerToken,
+      ));
     }
   }
   return node;
@@ -531,8 +543,9 @@ export async function getSymbolContext(
   fileHint?: string,
 ): Promise<SymbolContext[]> {
   const release = cache.acquireReader();
+  const readerToken = release.token;
   try {
-    const nameIndex = await cache.getNameIndex();
+    const nameIndex = await cache.getNameIndex(readerToken);
     let refs = nameIndex.get(name) ?? [];
     if (fileHint) {
       const normalizedHint = toForwardSlash(fileHint);
@@ -540,11 +553,11 @@ export async function getSymbolContext(
     }
     if (refs.length === 0) return [];
 
-    const reverseSymbolIndex = await cache.getReverseSymbolIndex();
+    const reverseSymbolIndex = await cache.getReverseSymbolIndex(readerToken);
     const out: SymbolContext[] = [];
 
     for (const ref of refs) {
-      const payload = await cache.getFilePayload(ref.file);
+      const payload = await cache.getFilePayload(ref.file, readerToken);
       if (!payload) continue;
       const sym = payload.symbols.find((s) => s.id === ref.id);
       if (!sym) continue;
@@ -577,7 +590,7 @@ export async function getSymbolContext(
         }
 
         for (const [cFile, cIds] of callerIdsByFile.entries()) {
-          const cp = await cache.getFilePayload(cFile);
+          const cp = await cache.getFilePayload(cFile, readerToken);
           if (!cp) continue;
           for (const e of cp.outgoingCalls) {
             if (e.calleeCandidates.includes(sym.id) && cIds.includes(e.callerId)) {
@@ -591,11 +604,11 @@ export async function getSymbolContext(
           }
         }
       } else {
-        const reverseIndex = await cache.getReverseFileIndex();
+        const reverseIndex = await cache.getReverseFileIndex(readerToken);
         const callerFiles = new Set(reverseIndex.get(ref.file) ?? []);
         callerFiles.add(ref.file);
         for (const cf of callerFiles) {
-          const cp = await cache.getFilePayload(cf);
+          const cp = await cache.getFilePayload(cf, readerToken);
           if (!cp) continue;
           for (const e of cp.outgoingCalls) {
             if (e.calleeCandidates.includes(sym.id)) {
@@ -625,12 +638,13 @@ export async function listSymbols(
   opts: { file?: string; query?: string; limit?: number },
 ): Promise<SymbolNode[]> {
   const release = cache.acquireReader();
+  const readerToken = release.token;
   try {
     const limit = opts.limit ?? 200;
     const out: SymbolNode[] = [];
 
     if (opts.file) {
-      const payload = await cache.getFilePayload(toForwardSlash(opts.file));
+      const payload = await cache.getFilePayload(toForwardSlash(opts.file), readerToken);
       if (!payload) return [];
       for (const s of payload.symbols) {
         if (s.name === "<module>") continue;
@@ -640,12 +654,12 @@ export async function listSymbols(
       return out;
     }
 
-    const nameIndex = await cache.getNameIndex();
+    const nameIndex = await cache.getNameIndex(readerToken);
     const q = opts.query?.toLowerCase() ?? "";
     for (const [name, refs] of nameIndex.entries()) {
       if (q && !name.toLowerCase().includes(q)) continue;
       for (const r of refs) {
-        const payload = await cache.getFilePayload(r.file);
+        const payload = await cache.getFilePayload(r.file, readerToken);
         if (!payload) continue;
         const sym = payload.symbols.find((s) => s.id === r.id);
         if (sym) out.push(sym);

--- a/src/services/graph-impact.ts
+++ b/src/services/graph-impact.ts
@@ -16,6 +16,14 @@ import {
 
 // ── Impact (blast radius) ────────────────────────────────────────────────
 
+// ── Impact (blast radius) ────────────────────────────────────────────────
+
+export type ImpactStatus =
+  | "ok"
+  | "not_found"
+  | "ambiguous"
+  | "unsupported_or_incomplete";
+
 export interface ImpactResult {
   target: string;
   targetKind: "file" | "symbol";
@@ -24,9 +32,12 @@ export interface ImpactResult {
   filesByDepth: Map<number, string[]>;
   totalFiles: number;
   truncated: boolean;
+  status: ImpactStatus;
+  message?: string;
+  candidates?: SymbolNode[];
 }
 
-/** BFS over the in-memory `reverseFileIndex`. Polymorphic on target type. */
+/** BFS over symbol call/reference graph or reverseFileIndex. Polymorphic on target type. */
 export async function getImpactRadius(
   cache: SymbolGraphCache,
   target: string,
@@ -39,46 +50,167 @@ export async function getImpactRadius(
     ? "file"
     : "symbol";
 
-  // Resolve to one or more "seed" files
-  let seedFiles: Set<string>;
   if (targetKind === "file") {
-    seedFiles = new Set([target]);
-  } else {
-    seedFiles = new Set();
-    const nameIndex = await cache.getNameIndex();
-    const refs = nameIndex.get(target) ?? [];
-    for (const r of refs) seedFiles.add(r.file);
-  }
-
-  const visited = new Set<string>();
-  const filesByDepth = new Map<number, string[]>();
-  let frontier = new Set(seedFiles);
-  for (const f of seedFiles) visited.add(f);
-
-  let truncated = false;
-  for (let hop = 1; hop <= safeDepth; hop++) {
-    const next = new Set<string>();
-    for (const calleeFile of frontier) {
-      const callers = reverseIndex.get(calleeFile);
-      if (!callers) continue;
-      for (const callerFile of callers) {
-        if (visited.has(callerFile)) continue;
-        next.add(callerFile);
-        visited.add(callerFile);
-      }
+    const normTarget = toForwardSlash(target);
+    const targetPayload = await cache.getFilePayload(normTarget);
+    if (!targetPayload) {
+      return {
+        target,
+        targetKind,
+        depth: safeDepth,
+        filesByDepth: new Map(),
+        totalFiles: 0,
+        truncated: false,
+        status: "not_found",
+        message: `File '${target}' was not found in the index.`,
+      };
     }
-    if (next.size === 0) break;
-    filesByDepth.set(hop, Array.from(next).sort());
-    frontier = next;
-    // After reaching the depth limit, check if more callers exist beyond it.
-    if (hop === safeDepth) {
+
+    const visited = new Set<string>([normTarget]);
+    const filesByDepth = new Map<number, string[]>();
+    let frontier = new Set<string>([normTarget]);
+    let truncated = false;
+
+    for (let hop = 1; hop <= safeDepth; hop++) {
+      const next = new Set<string>();
       for (const calleeFile of frontier) {
         const callers = reverseIndex.get(calleeFile);
         if (!callers) continue;
         for (const callerFile of callers) {
-          if (!visited.has(callerFile)) {
-            truncated = true;
-            break;
+          if (visited.has(callerFile)) continue;
+          next.add(callerFile);
+          visited.add(callerFile);
+        }
+      }
+      if (next.size === 0) break;
+      filesByDepth.set(hop, Array.from(next).sort());
+      frontier = next;
+
+      if (hop === safeDepth) {
+        for (const calleeFile of frontier) {
+          const callers = reverseIndex.get(calleeFile);
+          if (!callers) continue;
+          for (const callerFile of callers) {
+            if (!visited.has(callerFile)) {
+              truncated = true;
+              break;
+            }
+          }
+          if (truncated) break;
+        }
+      }
+    }
+
+    let totalFiles = 0;
+    for (const arr of filesByDepth.values()) totalFiles += arr.length;
+    return {
+      target,
+      targetKind,
+      depth: safeDepth,
+      filesByDepth,
+      totalFiles,
+      truncated,
+      status: "ok",
+    };
+  }
+
+  // Symbol mode: exact symbol resolution and traversal
+  const nameIndex = await cache.getNameIndex();
+  const refs = nameIndex.get(target) ?? [];
+
+  if (refs.length === 0) {
+    return {
+      target,
+      targetKind,
+      depth: safeDepth,
+      filesByDepth: new Map(),
+      totalFiles: 0,
+      truncated: false,
+      status: "not_found",
+      message: `Symbol '${target}' was not found in the symbol graph.`,
+    };
+  }
+
+  const distinctFiles = Array.from(new Set(refs.map((r) => r.file)));
+  if (distinctFiles.length > 1) {
+    const candidates: SymbolNode[] = [];
+    for (const ref of refs) {
+      const payload = await cache.getFilePayload(ref.file);
+      const sym = payload?.symbols.find((s) => s.id === ref.id);
+      if (sym) candidates.push(sym);
+    }
+    return {
+      target,
+      targetKind,
+      depth: safeDepth,
+      filesByDepth: new Map(),
+      totalFiles: 0,
+      truncated: false,
+      status: "ambiguous",
+      message: `Symbol '${target}' is ambiguous (defined in ${distinctFiles.length} files: ${distinctFiles.slice(0, 5).join(", ")}${distinctFiles.length > 5 ? "..." : ""}). Specify the file path or qualified name to disambiguate.`,
+      candidates,
+    };
+  }
+
+  const targetSymbolIds = new Set(refs.map((r) => r.id));
+  const visitedFiles = new Set<string>(distinctFiles);
+  const filesByDepth = new Map<number, string[]>();
+
+  let frontierSymbolIds = new Set(targetSymbolIds);
+  let frontierFiles = new Set<string>(distinctFiles);
+  let truncated = false;
+
+  for (let hop = 1; hop <= safeDepth; hop++) {
+    const nextHopFiles = new Set<string>();
+    const nextSymbolIds = new Set<string>();
+    const nextFiles = new Set<string>();
+
+    // For all files that could call into our current frontier files
+    for (const calleeFile of frontierFiles) {
+      const potentialCallerFiles = reverseIndex.get(calleeFile);
+      if (!potentialCallerFiles) continue;
+
+      for (const callerFile of potentialCallerFiles) {
+        const callerPayload = await cache.getFilePayload(callerFile);
+        if (!callerPayload) continue;
+
+        let matched = false;
+        for (const edge of callerPayload.outgoingCalls) {
+          const callsTarget = edge.calleeCandidates.some((candId) =>
+            frontierSymbolIds.has(candId),
+          );
+          if (callsTarget) {
+            matched = true;
+            nextSymbolIds.add(edge.callerId);
+          }
+        }
+
+        if (matched) {
+          if (!visitedFiles.has(callerFile)) {
+            nextHopFiles.add(callerFile);
+            visitedFiles.add(callerFile);
+          }
+          nextFiles.add(callerFile);
+        }
+      }
+    }
+
+    if (nextHopFiles.size === 0) break;
+    filesByDepth.set(hop, Array.from(nextHopFiles).sort());
+    frontierSymbolIds = nextSymbolIds;
+    frontierFiles = nextFiles;
+
+    if (hop === safeDepth) {
+      for (const calleeFile of frontierFiles) {
+        const potentialCallerFiles = reverseIndex.get(calleeFile);
+        if (!potentialCallerFiles) continue;
+        for (const callerFile of potentialCallerFiles) {
+          if (!visitedFiles.has(callerFile)) {
+            const cp = await cache.getFilePayload(callerFile);
+            if (cp?.outgoingCalls.some((e) => e.calleeCandidates.some((c) => frontierSymbolIds.has(c)))) {
+              truncated = true;
+              break;
+            }
           }
         }
         if (truncated) break;
@@ -88,9 +220,15 @@ export async function getImpactRadius(
 
   let totalFiles = 0;
   for (const arr of filesByDepth.values()) totalFiles += arr.length;
+
   return {
-    target, targetKind, depth: safeDepth, filesByDepth, totalFiles,
+    target,
+    targetKind,
+    depth: safeDepth,
+    filesByDepth,
+    totalFiles,
     truncated,
+    status: "ok",
   };
 }
 

--- a/src/services/graph-impact.ts
+++ b/src/services/graph-impact.ts
@@ -240,8 +240,8 @@ export async function getImpactRadius(
         const nextFiles = new Set<string>();
 
         for (const calleeFile of frontierFiles) {
-          const potentialCallerFiles = reverseIndex.get(calleeFile);
-          if (!potentialCallerFiles) continue;
+          const potentialCallerFiles = new Set(reverseIndex.get(calleeFile) ?? []);
+          potentialCallerFiles.add(calleeFile);
 
           for (const callerFile of potentialCallerFiles) {
             const callerPayload = await cache.getFilePayload(callerFile);
@@ -275,8 +275,8 @@ export async function getImpactRadius(
 
         if (hop === safeDepth) {
           for (const calleeFile of frontierFiles) {
-            const potentialCallerFiles = reverseIndex.get(calleeFile);
-            if (!potentialCallerFiles) continue;
+            const potentialCallerFiles = new Set(reverseIndex.get(calleeFile) ?? []);
+            potentialCallerFiles.add(calleeFile);
             for (const callerFile of potentialCallerFiles) {
               if (!visitedFiles.has(callerFile)) {
                 const cp = await cache.getFilePayload(callerFile);
@@ -573,7 +573,8 @@ export async function getSymbolContext(
       }
     } else {
       const reverseIndex = await cache.getReverseFileIndex();
-      const callerFiles = reverseIndex.get(ref.file) ?? new Set();
+      const callerFiles = new Set(reverseIndex.get(ref.file) ?? []);
+      callerFiles.add(ref.file);
       for (const cf of callerFiles) {
         const cp = await cache.getFilePayload(cf);
         if (!cp) continue;

--- a/src/services/graph-impact.ts
+++ b/src/services/graph-impact.ts
@@ -13,8 +13,7 @@ import {
   type SymbolGraphCache,
   symbolIdToFile,
 } from "./symbol-graph-cache.js";
-
-// ── Impact (blast radius) ────────────────────────────────────────────────
+import { StorageReadError } from "./symbol-graph-store.js";
 
 // ── Impact (blast radius) ────────────────────────────────────────────────
 
@@ -22,7 +21,15 @@ export type ImpactStatus =
   | "ok"
   | "not_found"
   | "ambiguous"
-  | "unsupported_or_incomplete";
+  | "unsupported_or_incomplete"
+  | "storage_error"
+  | "graph_upgrade_required";
+
+export interface ImpactOptions {
+  file?: string;
+  symbolId?: string;
+  isIncomplete?: boolean;
+}
 
 export interface ImpactResult {
   target: string;
@@ -42,58 +49,234 @@ export async function getImpactRadius(
   cache: SymbolGraphCache,
   target: string,
   depth: number = 3,
-  options?: { isIncomplete?: boolean },
+  options?: ImpactOptions,
 ): Promise<ImpactResult> {
   const safeDepth = Math.max(1, Math.min(depth, MAX_IMPACT_DEPTH));
   const isIncomplete = options?.isIncomplete ?? (cache.meta.schemaVersion < 2);
-  const reverseIndex = await cache.getReverseFileIndex();
 
-  const targetKind: "file" | "symbol" = looksLikeFilePath(target)
-    ? "file"
-    : "symbol";
+  const targetKind: "file" | "symbol" = options?.symbolId
+    ? "symbol"
+    : looksLikeFilePath(target)
+      ? "file"
+      : "symbol";
 
-  if (targetKind === "file") {
-    const normTarget = toForwardSlash(target);
-    const targetPayload = await cache.getFilePayload(normTarget);
-    if (!targetPayload) {
-      return {
-        target,
-        targetKind,
-        depth: safeDepth,
-        filesByDepth: new Map(),
-        totalFiles: 0,
-        truncated: false,
-        status: "not_found",
-        message: `File '${target}' was not found in the index.`,
-      };
-    }
+  if (cache.meta.schemaVersion < 2) {
+    return {
+      target,
+      targetKind,
+      depth: safeDepth,
+      filesByDepth: new Map(),
+      totalFiles: 0,
+      truncated: false,
+      status: "graph_upgrade_required",
+      message: `The symbol graph is schema v${cache.meta.schemaVersion ?? 1} (legacy / incomplete). Rebuild with codebase_graph_build before querying impact analysis.`,
+    };
+  }
 
-    const visited = new Set<string>([normTarget]);
-    const filesByDepth = new Map<number, string[]>();
-    let frontier = new Set<string>([normTarget]);
-    let truncated = false;
-
-    for (let hop = 1; hop <= safeDepth; hop++) {
-      const next = new Set<string>();
-      for (const calleeFile of frontier) {
-        const callers = reverseIndex.get(calleeFile);
-        if (!callers) continue;
-        for (const callerFile of callers) {
-          if (visited.has(callerFile)) continue;
-          next.add(callerFile);
-          visited.add(callerFile);
-        }
+  try {
+    if (targetKind === "file") {
+      const reverseIndex = await cache.getReverseFileIndex();
+      const normTarget = toForwardSlash(target);
+      const targetPayload = await cache.getFilePayload(normTarget);
+      if (!targetPayload) {
+        return {
+          target,
+          targetKind,
+          depth: safeDepth,
+          filesByDepth: new Map(),
+          totalFiles: 0,
+          truncated: false,
+          status: "not_found",
+          message: `File '${target}' was not found in the index.`,
+        };
       }
-      if (next.size === 0) break;
-      filesByDepth.set(hop, Array.from(next).sort());
-      frontier = next;
 
-      if (hop === safeDepth) {
+      const visited = new Set<string>([normTarget]);
+      const filesByDepth = new Map<number, string[]>();
+      let frontier = new Set<string>([normTarget]);
+      let truncated = false;
+
+      for (let hop = 1; hop <= safeDepth; hop++) {
+        const next = new Set<string>();
         for (const calleeFile of frontier) {
           const callers = reverseIndex.get(calleeFile);
           if (!callers) continue;
           for (const callerFile of callers) {
-            if (!visited.has(callerFile)) {
+            if (visited.has(callerFile)) continue;
+            next.add(callerFile);
+            visited.add(callerFile);
+          }
+        }
+        if (next.size === 0) break;
+        filesByDepth.set(hop, Array.from(next).sort());
+        frontier = next;
+
+        if (hop === safeDepth) {
+          for (const calleeFile of frontier) {
+            const callers = reverseIndex.get(calleeFile);
+            if (!callers) continue;
+            for (const callerFile of callers) {
+              if (!visited.has(callerFile)) {
+                truncated = true;
+                break;
+              }
+            }
+            if (truncated) break;
+          }
+        }
+      }
+
+      let totalFiles = 0;
+      for (const arr of filesByDepth.values()) totalFiles += arr.length;
+
+      if (totalFiles === 0 && isIncomplete) {
+        return {
+          target,
+          targetKind,
+          depth: safeDepth,
+          filesByDepth,
+          totalFiles: 0,
+          truncated: false,
+          status: "unsupported_or_incomplete",
+          message: `The symbol graph is incomplete (schema v${cache.meta.schemaVersion ?? 1} or incomplete language parser support). Rebuild with codebase_graph_build before relying on zero-dependent verification.`,
+        };
+      }
+
+      return {
+        target,
+        targetKind,
+        depth: safeDepth,
+        filesByDepth,
+        totalFiles,
+        truncated,
+        status: "ok",
+      };
+    }
+
+    // Symbol mode: exact symbol resolution and traversal
+    let selectedRefs: Array<{ file: string; id: string }> = [];
+
+    if (options?.symbolId) {
+      const sFile = symbolIdToFile(options.symbolId);
+      if (!sFile) {
+        return {
+          target,
+          targetKind,
+          depth: safeDepth,
+          filesByDepth: new Map(),
+          totalFiles: 0,
+          truncated: false,
+          status: "not_found",
+          message: `Invalid symbolId '${options.symbolId}'.`,
+        };
+      }
+      const payload = await cache.getFilePayload(sFile);
+      const sym = payload?.symbols.find((s) => s.id === options.symbolId);
+      if (!sym) {
+        return {
+          target,
+          targetKind,
+          depth: safeDepth,
+          filesByDepth: new Map(),
+          totalFiles: 0,
+          truncated: false,
+          status: "not_found",
+          message: `Symbol with ID '${options.symbolId}' was not found in file '${sFile}'.`,
+        };
+      }
+      selectedRefs = [{ file: sFile, id: options.symbolId }];
+    } else {
+      const nameIndex = await cache.getNameIndex();
+      let refs = nameIndex.get(target) ?? [];
+
+      if (options?.file) {
+        const normFile = toForwardSlash(options.file);
+        refs = refs.filter((r) => r.file === normFile || r.file.endsWith(`/${normFile}`));
+      }
+
+      if (refs.length === 0) {
+        return {
+          target,
+          targetKind,
+          depth: safeDepth,
+          filesByDepth: new Map(),
+          totalFiles: 0,
+          truncated: false,
+          status: "not_found",
+          message: `Symbol '${target}' was not found in the symbol graph.`,
+        };
+      }
+
+      const distinctIds = Array.from(new Set(refs.map((r) => r.id)));
+      if (distinctIds.length > 1) {
+        const candidates: SymbolNode[] = [];
+        for (const ref of refs) {
+          const payload = await cache.getFilePayload(ref.file);
+          const sym = payload?.symbols.find((s) => s.id === ref.id);
+          if (sym) candidates.push(sym);
+        }
+        const distinctFiles = Array.from(new Set(refs.map((r) => r.file)));
+        const locDesc = distinctFiles.length === 1
+          ? `in file ${distinctFiles[0]}`
+          : `across ${distinctFiles.length} files (${distinctFiles.slice(0, 5).join(", ")}${distinctFiles.length > 5 ? "..." : ""})`;
+
+        return {
+          target,
+          targetKind,
+          depth: safeDepth,
+          filesByDepth: new Map(),
+          totalFiles: 0,
+          truncated: false,
+          status: "ambiguous",
+          message: `Symbol '${target}' is ambiguous (matches ${distinctIds.length} symbols ${locDesc}). Specify 'file' or 'symbolId' to disambiguate.`,
+          candidates,
+        };
+      }
+      selectedRefs = refs;
+    }
+
+    const reverseSymbolIndex = await cache.getReverseSymbolIndex();
+    const targetSymbolIds = new Set(selectedRefs.map((r) => r.id));
+    const visitedSymbols = new Set<string>(targetSymbolIds);
+    const visitedFiles = new Set<string>();
+    const filesByDepth = new Map<number, string[]>();
+
+    let frontierSymbolIds = new Set(targetSymbolIds);
+    let truncated = false;
+
+    for (let hop = 1; hop <= safeDepth; hop++) {
+      const nextSymbolIds = new Set<string>();
+      const nextHopFiles = new Set<string>();
+
+      for (const calleeSymId of frontierSymbolIds) {
+        const callerIds = reverseSymbolIndex.get(calleeSymId);
+        if (!callerIds) continue;
+
+        for (const callerId of callerIds) {
+          const callerFile = callerId.split("::")[0];
+          if (!visitedSymbols.has(callerId)) {
+            visitedSymbols.add(callerId);
+            nextSymbolIds.add(callerId);
+          }
+          if (!visitedFiles.has(callerFile)) {
+            visitedFiles.add(callerFile);
+            nextHopFiles.add(callerFile);
+          }
+        }
+      }
+
+      if (nextSymbolIds.size === 0) break;
+      if (nextHopFiles.size > 0) {
+        filesByDepth.set(hop, Array.from(nextHopFiles).sort());
+      }
+      frontierSymbolIds = nextSymbolIds;
+
+      if (hop === safeDepth) {
+        for (const calleeSymId of frontierSymbolIds) {
+          const callerIds = reverseSymbolIndex.get(calleeSymId);
+          if (!callerIds) continue;
+          for (const callerId of callerIds) {
+            if (!visitedSymbols.has(callerId)) {
               truncated = true;
               break;
             }
@@ -128,143 +311,21 @@ export async function getImpactRadius(
       truncated,
       status: "ok",
     };
-  }
-
-  // Symbol mode: exact symbol resolution and traversal
-  const nameIndex = await cache.getNameIndex();
-  const refs = nameIndex.get(target) ?? [];
-
-  if (refs.length === 0) {
-    return {
-      target,
-      targetKind,
-      depth: safeDepth,
-      filesByDepth: new Map(),
-      totalFiles: 0,
-      truncated: false,
-      status: "not_found",
-      message: `Symbol '${target}' was not found in the symbol graph.`,
-    };
-  }
-
-  const distinctIds = Array.from(new Set(refs.map((r) => r.id)));
-  if (distinctIds.length > 1) {
-    const candidates: SymbolNode[] = [];
-    for (const ref of refs) {
-      const payload = await cache.getFilePayload(ref.file);
-      const sym = payload?.symbols.find((s) => s.id === ref.id);
-      if (sym) candidates.push(sym);
+  } catch (err) {
+    if (err instanceof StorageReadError) {
+      return {
+        target,
+        targetKind,
+        depth: safeDepth,
+        filesByDepth: new Map(),
+        totalFiles: 0,
+        truncated: false,
+        status: "storage_error",
+        message: `Storage read/integrity failure during impact analysis: ${err.message}`,
+      };
     }
-    const distinctFiles = Array.from(new Set(refs.map((r) => r.file)));
-    const locDesc = distinctFiles.length === 1
-      ? `in file ${distinctFiles[0]}`
-      : `across ${distinctFiles.length} files (${distinctFiles.slice(0, 5).join(", ")}${distinctFiles.length > 5 ? "..." : ""})`;
-
-    return {
-      target,
-      targetKind,
-      depth: safeDepth,
-      filesByDepth: new Map(),
-      totalFiles: 0,
-      truncated: false,
-      status: "ambiguous",
-      message: `Symbol '${target}' is ambiguous (matches ${distinctIds.length} symbols ${locDesc}). Specify the file path or qualified name to disambiguate.`,
-      candidates,
-    };
+    throw err;
   }
-
-  const targetSymbolIds = new Set(refs.map((r) => r.id));
-  const distinctFiles = Array.from(new Set(refs.map((r) => r.file)));
-  const visitedFiles = new Set<string>(distinctFiles);
-  const filesByDepth = new Map<number, string[]>();
-
-  let frontierSymbolIds = new Set(targetSymbolIds);
-  let frontierFiles = new Set<string>(distinctFiles);
-  let truncated = false;
-
-  for (let hop = 1; hop <= safeDepth; hop++) {
-    const nextHopFiles = new Set<string>();
-    const nextSymbolIds = new Set<string>();
-    const nextFiles = new Set<string>();
-
-    // For all files that could call into our current frontier files
-    for (const calleeFile of frontierFiles) {
-      const potentialCallerFiles = reverseIndex.get(calleeFile);
-      if (!potentialCallerFiles) continue;
-
-      for (const callerFile of potentialCallerFiles) {
-        const callerPayload = await cache.getFilePayload(callerFile);
-        if (!callerPayload) continue;
-
-        let matched = false;
-        for (const edge of callerPayload.outgoingCalls) {
-          const callsTarget = edge.calleeCandidates.some((candId) =>
-            frontierSymbolIds.has(candId),
-          );
-          if (callsTarget) {
-            matched = true;
-            nextSymbolIds.add(edge.callerId);
-          }
-        }
-
-        if (matched) {
-          if (!visitedFiles.has(callerFile)) {
-            nextHopFiles.add(callerFile);
-            visitedFiles.add(callerFile);
-          }
-          nextFiles.add(callerFile);
-        }
-      }
-    }
-
-    if (nextHopFiles.size === 0) break;
-    filesByDepth.set(hop, Array.from(nextHopFiles).sort());
-    frontierSymbolIds = nextSymbolIds;
-    frontierFiles = nextFiles;
-
-    if (hop === safeDepth) {
-      for (const calleeFile of frontierFiles) {
-        const potentialCallerFiles = reverseIndex.get(calleeFile);
-        if (!potentialCallerFiles) continue;
-        for (const callerFile of potentialCallerFiles) {
-          if (!visitedFiles.has(callerFile)) {
-            const cp = await cache.getFilePayload(callerFile);
-            if (cp?.outgoingCalls.some((e) => e.calleeCandidates.some((c) => frontierSymbolIds.has(c)))) {
-              truncated = true;
-              break;
-            }
-          }
-        }
-        if (truncated) break;
-      }
-    }
-  }
-
-  let totalFiles = 0;
-  for (const arr of filesByDepth.values()) totalFiles += arr.length;
-
-  if (totalFiles === 0 && isIncomplete) {
-    return {
-      target,
-      targetKind,
-      depth: safeDepth,
-      filesByDepth,
-      totalFiles: 0,
-      truncated: false,
-      status: "unsupported_or_incomplete",
-      message: `The symbol graph is incomplete (schema v${cache.meta.schemaVersion ?? 1} or incomplete language parser support). Rebuild with codebase_graph_build before relying on zero-dependent verification.`,
-    };
-  }
-
-  return {
-    target,
-    targetKind,
-    depth: safeDepth,
-    filesByDepth,
-    totalFiles,
-    truncated,
-    status: "ok",
-  };
 }
 
 // ── Call flow (forward DFS) ──────────────────────────────────────────────
@@ -344,10 +405,24 @@ async function walk(
 
 // ── Symbol context (360° view) ───────────────────────────────────────────
 
+export interface SymbolContextCaller {
+  file: string;
+  line: number;
+  symbolId: string;
+  kind?: string;
+}
+
+export interface SymbolContextCallee {
+  name: string;
+  resolved: string[];
+  confidence: string;
+  kind?: string;
+}
+
 export interface SymbolContext {
   symbol: SymbolNode;
-  callers: Array<{ file: string; line: number; symbolId: string }>;
-  callees: Array<{ name: string; resolved: string[]; confidence: string }>;
+  callers: SymbolContextCaller[];
+  callees: SymbolContextCallee[];
 }
 
 export async function getSymbolContext(
@@ -359,11 +434,11 @@ export async function getSymbolContext(
   let refs = nameIndex.get(name) ?? [];
   if (fileHint) {
     const normalizedHint = toForwardSlash(fileHint);
-    refs = refs.filter((r) => r.file === normalizedHint);
+    refs = refs.filter((r) => r.file === normalizedHint || r.file.endsWith(`/${normalizedHint}`));
   }
   if (refs.length === 0) return [];
 
-  const reverseIndex = await cache.getReverseFileIndex();
+  const reverseSymbolIndex = await cache.getReverseSymbolIndex();
   const out: SymbolContext[] = [];
 
   for (const ref of refs) {
@@ -372,27 +447,40 @@ export async function getSymbolContext(
     const sym = payload.symbols.find((s) => s.id === ref.id);
     if (!sym) continue;
 
-    // Callees: edges originating from this symbol
-    const callees: SymbolContext["callees"] = payload.outgoingCalls
+    // Callees: outgoing calls from this symbol
+    const callees: SymbolContextCallee[] = payload.outgoingCalls
       .filter((e) => e.callerId === sym.id)
       .map((e) => ({
         name: e.calleeName,
         resolved: e.calleeCandidates,
         confidence: e.confidence,
+        kind: e.kind,
       }));
 
-    // Callers: scan callerFiles' outgoingCalls for edges pointing at this symbol
-    const callerFiles = reverseIndex.get(ref.file) ?? new Set();
-    const callers: SymbolContext["callers"] = [];
-    for (const cf of callerFiles) {
-      const cp = await cache.getFilePayload(cf);
+    // Callers: query reverse symbol index for callers of this symbol
+    const callerIds = reverseSymbolIndex.get(sym.id) ?? new Set();
+    const callers: SymbolContextCaller[] = [];
+
+    // Group callerIds by file so we fetch each payload at most once
+    const callerIdsByFile = new Map<string, string[]>();
+    for (const cId of callerIds) {
+      const cFile = symbolIdToFile(cId);
+      if (!cFile) continue;
+      const list = callerIdsByFile.get(cFile);
+      if (list) list.push(cId);
+      else callerIdsByFile.set(cFile, [cId]);
+    }
+
+    for (const [cFile, cIds] of callerIdsByFile.entries()) {
+      const cp = await cache.getFilePayload(cFile);
       if (!cp) continue;
       for (const e of cp.outgoingCalls) {
-        if (e.calleeCandidates.includes(sym.id)) {
+        if (e.calleeCandidates.includes(sym.id) && cIds.includes(e.callerId)) {
           callers.push({
             file: e.callSite.file,
             line: e.callSite.line,
             symbolId: e.callerId,
+            kind: e.kind,
           });
         }
       }

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -176,8 +176,8 @@ export function resolveCallSites(
         }
       }
 
-      // Wildcard re-export: `export * from './mod'`
-      if ((edge.calleeName === "*" || edge.importedName === "*") && edgeSourceDep) {
+      // Wildcard re-export: `export * from './mod'` (only when unaliased)
+      if (!edge.localAlias && (edge.calleeName === "*" || edge.importedName === "*") && edgeSourceDep) {
         const sub = findSymbolsInTarget(edgeSourceDep, symbolName, visited);
         candidates.push(...sub);
       }

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -42,11 +42,18 @@ function resolveDepFile(callerFile: string, sourceModule: string, deps: string[]
   const normalized = normalizePath(rawCombined.replace(/^\.\//, "")).replace(/\.[a-zA-Z0-9]+$/, "");
   const cleanSpec = sourceModule.replace(/^[./\\]+/, "").replace(/\.[a-zA-Z0-9]+$/, "");
 
+  // Pass 1: exact normalized match or normalized/index
+  for (const dep of deps) {
+    const depWithoutExt = dep.replace(/\.[a-zA-Z0-9]+$/, "");
+    if (depWithoutExt === normalized || depWithoutExt === `${normalized}/index`) {
+      return dep;
+    }
+  }
+
+  // Pass 2: suffix match (e.g. relative subpath within dependency)
   for (const dep of deps) {
     const depWithoutExt = dep.replace(/\.[a-zA-Z0-9]+$/, "");
     if (
-      depWithoutExt === normalized ||
-      depWithoutExt === `${normalized}/index` ||
       depWithoutExt.endsWith(`/${cleanSpec}`) ||
       depWithoutExt.endsWith(`/${cleanSpec}/index`)
     ) {
@@ -107,8 +114,9 @@ export function resolveCallSites(
     symbolName: string,
     visited = new Set<string>(),
   ): string[] {
-    if (visited.has(targetFile)) return [];
-    visited.add(targetFile);
+    const visitKey = `${targetFile}::${symbolName}`;
+    if (visited.has(visitKey)) return [];
+    visited.add(visitKey);
 
     const candidates: string[] = [];
     const targetIdx = symbolIndexByFile.get(targetFile);

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -123,6 +123,14 @@ export function resolveCallSites(
     depsByFile.set(node.relativePath, node.dependencies.slice());
   }
 
+  // Re-export traversal is on the hot path for every unresolved edge. Build
+  // this once rather than rescanning every edge in a barrel on every lookup.
+  const reexportsByFile = new Map<string, SymbolEdge[]>();
+  for (const [file, edges] of outgoingCallsByFile.entries()) {
+    const reexports = edges.filter((edge) => edge.kind === "reexport");
+    if (reexports.length > 0) reexportsByFile.set(file, reexports);
+  }
+
   /** Recursively find symbols matching `symbolName` in `targetFile` or its re-export chains */
   function findSymbolsInTarget(
     targetFile: string,
@@ -165,12 +173,10 @@ export function resolveCallSites(
     }
 
     // 2. Follow re-export chains in targetFile
-    const targetEdges = outgoingCallsByFile.get(targetFile) ?? [];
+    const targetEdges = reexportsByFile.get(targetFile) ?? [];
     const targetDeps = depsByFile.get(targetFile) ?? [];
 
     for (const edge of targetEdges) {
-      if (edge.kind !== "reexport") continue;
-
       const edgeSourceDep = edge.sourceModule
         ? resolveDepFile(targetFile, edge.sourceModule, targetDeps)
         : null;

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -34,38 +34,53 @@ function normalizePath(p: string): string {
   return stack.join("/");
 }
 
+const KNOWN_CODE_EXT =
+  /\.(?:[jt]sx?|m[jt]s|c[jt]s|py|rb|php|go|rs|java|kt|scala|cs|swift|dart|c|cpp|h|hpp|ex|exs|vue|svelte|lua|sh)$/i;
+
+function stripKnownExt(p: string): string {
+  const lastSlash = p.lastIndexOf("/");
+  const dir = lastSlash >= 0 ? p.slice(0, lastSlash + 1) : "";
+  const fileName = lastSlash >= 0 ? p.slice(lastSlash + 1) : p;
+  const stripped = fileName.replace(KNOWN_CODE_EXT, "");
+  return dir + stripped;
+}
+
 /** Resolve an import's module specifier to a dependency file path */
 function resolveDepFile(callerFile: string, sourceModule: string, deps: string[]): string | null {
   if (!sourceModule) return null;
   const callerDir = callerFile.includes("/") ? callerFile.slice(0, callerFile.lastIndexOf("/")) : "";
   const rawCombined = callerDir ? `${callerDir}/${sourceModule}` : sourceModule;
-  const normalized = normalizePath(rawCombined.replace(/^\.\//, "")).replace(/\.[a-zA-Z0-9]+$/, "");
-  const cleanSpec = sourceModule.replace(/^[./\\]+/, "").replace(/\.[a-zA-Z0-9]+$/, "");
+  const normalized = stripKnownExt(normalizePath(rawCombined.replace(/^\.\//, "")));
+  const cleanSpec = stripKnownExt(sourceModule.replace(/^[./\\]+/, ""));
 
   // Pass 1: exact normalized match or normalized/index
   for (const dep of deps) {
-    const depWithoutExt = dep.replace(/\.[a-zA-Z0-9]+$/, "");
+    const depWithoutExt = stripKnownExt(dep);
     if (depWithoutExt === normalized || depWithoutExt === `${normalized}/index`) {
       return dep;
     }
   }
 
-  // Pass 2: suffix match (e.g. relative subpath within dependency)
+  // Pass 2: suffix match (only if uniquely matched among dependencies)
+  const suffixMatches: string[] = [];
   for (const dep of deps) {
-    const depWithoutExt = dep.replace(/\.[a-zA-Z0-9]+$/, "");
+    const depWithoutExt = stripKnownExt(dep);
     if (
       depWithoutExt.endsWith(`/${cleanSpec}`) ||
       depWithoutExt.endsWith(`/${cleanSpec}/index`)
     ) {
-      return dep;
+      suffixMatches.push(dep);
     }
+  }
+  if (suffixMatches.length === 1) {
+    return suffixMatches[0];
   }
 
   // Fallback: match by basename if unique among dependencies
   const baseSpec = cleanSpec.split("/").pop();
   if (baseSpec) {
     const matches = deps.filter((d) => {
-      const depBase = d.split("/").pop()?.replace(/\.[a-zA-Z0-9]+$/, "");
+      const depBase = stripKnownExt(d.split("/").pop() ?? "");
       return depBase === baseSpec || d.includes(`/${baseSpec}/index.`);
     });
     if (matches.length === 1) return matches[0];

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -19,6 +19,54 @@
 
 import type { CodeGraph, SymbolEdge, SymbolNode } from "../types.js";
 
+/** Normalize relative path components like `foo/../bar` -> `bar` */
+function normalizePath(p: string): string {
+  const parts = p.split("/").filter(Boolean);
+  const stack: string[] = [];
+  for (const part of parts) {
+    if (part === ".") continue;
+    if (part === "..") {
+      stack.pop();
+    } else {
+      stack.push(part);
+    }
+  }
+  return stack.join("/");
+}
+
+/** Resolve an import's module specifier to a dependency file path */
+function resolveDepFile(callerFile: string, sourceModule: string, deps: string[]): string | null {
+  if (!sourceModule) return null;
+  const callerDir = callerFile.includes("/") ? callerFile.slice(0, callerFile.lastIndexOf("/")) : "";
+  const rawCombined = callerDir ? `${callerDir}/${sourceModule}` : sourceModule;
+  const normalized = normalizePath(rawCombined.replace(/^\.\//, "")).replace(/\.[a-zA-Z0-9]+$/, "");
+  const cleanSpec = sourceModule.replace(/^[./\\]+/, "").replace(/\.[a-zA-Z0-9]+$/, "");
+
+  for (const dep of deps) {
+    const depWithoutExt = dep.replace(/\.[a-zA-Z0-9]+$/, "");
+    if (
+      depWithoutExt === normalized ||
+      depWithoutExt === `${normalized}/index` ||
+      depWithoutExt.endsWith(`/${cleanSpec}`) ||
+      depWithoutExt.endsWith(`/${cleanSpec}/index`)
+    ) {
+      return dep;
+    }
+  }
+
+  // Fallback: match by basename if unique among dependencies
+  const baseSpec = cleanSpec.split("/").pop();
+  if (baseSpec) {
+    const matches = deps.filter((d) => {
+      const depBase = d.split("/").pop()?.replace(/\.[a-zA-Z0-9]+$/, "");
+      return depBase === baseSpec || d.includes(`/${baseSpec}/index.`);
+    });
+    if (matches.length === 1) return matches[0];
+  }
+
+  return null;
+}
+
 /**
  * Resolve all call sites for every file in `symbolsByFile`. Mutates the
  * passed-in `outgoingCallsByFile` edges in place.
@@ -37,6 +85,12 @@ export function resolveCallSites(
       const existing = idx.get(s.name);
       if (existing) existing.push(s);
       else idx.set(s.name, [s]);
+
+      if (s.exportedAs && s.exportedAs !== s.name) {
+        const asExisting = idx.get(s.exportedAs);
+        if (asExisting) asExisting.push(s);
+        else idx.set(s.exportedAs, [s]);
+      }
     }
     symbolIndexByFile.set(file, idx);
   }
@@ -47,6 +101,68 @@ export function resolveCallSites(
     depsByFile.set(node.relativePath, node.dependencies.slice());
   }
 
+  /** Recursively find symbols matching `symbolName` in `targetFile` or its re-export chains */
+  function findSymbolsInTarget(
+    targetFile: string,
+    symbolName: string,
+    visited = new Set<string>(),
+  ): string[] {
+    if (visited.has(targetFile)) return [];
+    visited.add(targetFile);
+
+    const candidates: string[] = [];
+    const targetIdx = symbolIndexByFile.get(targetFile);
+
+    // 1. Direct definition in targetFile
+    const directMatches = targetIdx?.get(symbolName);
+    if (directMatches && directMatches.length > 0) {
+      for (const s of directMatches) candidates.push(s.id);
+    }
+
+    // If seeking default export and no exact name match, look for any symbol with exportedAs === "default"
+    if (symbolName === "default" && candidates.length === 0) {
+      const syms = symbolsByFile.get(targetFile) ?? [];
+      for (const s of syms) {
+        if (s.exportedAs === "default" || s.name === "default") {
+          candidates.push(s.id);
+        }
+      }
+    }
+
+    // 2. Follow re-export chains in targetFile
+    const targetEdges = outgoingCallsByFile.get(targetFile) ?? [];
+    const targetDeps = depsByFile.get(targetFile) ?? [];
+
+    for (const edge of targetEdges) {
+      if (edge.kind !== "reexport") continue;
+
+      const edgeSourceDep = edge.sourceModule
+        ? resolveDepFile(targetFile, edge.sourceModule, targetDeps)
+        : null;
+
+      // Named re-export: `export { X as Y } from './mod'` or `export { X } from './mod'`
+      if (edge.localAlias === symbolName || (!edge.localAlias && edge.importedName === symbolName) || (!edge.localAlias && !edge.importedName && edge.calleeName === symbolName)) {
+        const nextName = edge.importedName ?? edge.calleeName;
+        if (edgeSourceDep) {
+          const sub = findSymbolsInTarget(edgeSourceDep, nextName, visited);
+          candidates.push(...sub);
+        } else {
+          // Local re-export within same file
+          const localMatch = targetIdx?.get(nextName);
+          if (localMatch) for (const s of localMatch) candidates.push(s.id);
+        }
+      }
+
+      // Wildcard re-export: `export * from './mod'`
+      if ((edge.calleeName === "*" || edge.importedName === "*") && edgeSourceDep) {
+        const sub = findSymbolsInTarget(edgeSourceDep, symbolName, visited);
+        candidates.push(...sub);
+      }
+    }
+
+    return candidates;
+  }
+
   for (const [callerFile, edges] of outgoingCallsByFile.entries()) {
     const localIdx = symbolIndexByFile.get(callerFile);
     const deps = depsByFile.get(callerFile) ?? [];
@@ -54,32 +170,31 @@ export function resolveCallSites(
     for (const edge of edges) {
       const candidates: string[] = [];
 
-      // 1. Local
-      const local = localIdx?.get(edge.calleeName);
-      if (local && local.length > 0) {
-        for (const s of local) candidates.push(s.id);
-        edge.calleeCandidates = candidates;
-        edge.confidence = "local";
-        continue;
+      // 1. Local (unless edge explicitly specifies an external source module)
+      if (!edge.sourceModule) {
+        const local = localIdx?.get(edge.calleeName);
+        if (local && local.length > 0) {
+          for (const s of local) candidates.push(s.id);
+          edge.calleeCandidates = candidates;
+          edge.confidence = "local";
+          continue;
+        }
       }
 
-      // 2. Imported (walk direct dependencies)
-      for (const dep of deps) {
-        const depIdx = symbolIndexByFile.get(dep);
-        const matches = depIdx?.get(edge.calleeName);
-        if (matches) for (const s of matches) candidates.push(s.id);
-      }
-
-      // 3. Wildcard / re-export — one extra hop through dep files
-      if (candidates.length === 0) {
+      // 2. Module-targeted import / reference
+      if (edge.sourceModule) {
+        const targetDep = resolveDepFile(callerFile, edge.sourceModule, deps);
+        const searchName = edge.importedName ?? edge.calleeName;
+        if (targetDep) {
+          const found = findSymbolsInTarget(targetDep, searchName);
+          candidates.push(...found);
+        }
+      } else {
+        // 3. Untargeted cross-file resolution (fallback for languages without explicit module specifiers)
+        const searchName = edge.importedName ?? edge.calleeName;
         for (const dep of deps) {
-          const transitive = depsByFile.get(dep) ?? [];
-          for (const t of transitive) {
-            if (t === callerFile) continue;
-            const tIdx = symbolIndexByFile.get(t);
-            const matches = tIdx?.get(edge.calleeName);
-            if (matches) for (const s of matches) candidates.push(s.id);
-          }
+          const found = findSymbolsInTarget(dep, searchName);
+          candidates.push(...found);
         }
       }
 

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -136,17 +136,29 @@ export function resolveCallSites(
     const candidates: string[] = [];
     const targetIdx = symbolIndexByFile.get(targetFile);
 
-    // 1. Direct definition in targetFile
+    // 1. Direct definition in targetFile (exported bindings only)
     const directMatches = targetIdx?.get(symbolName);
     if (directMatches && directMatches.length > 0) {
-      for (const s of directMatches) candidates.push(s.id);
+      for (const s of directMatches) {
+        if (s.isExported !== false) {
+          if (symbolName === "default") {
+            if (s.exportedAs === "default" || s.name === "default") {
+              candidates.push(s.id);
+            }
+          } else {
+            if (s.exportedAs === undefined || s.exportedAs === symbolName || s.name === symbolName) {
+              candidates.push(s.id);
+            }
+          }
+        }
+      }
     }
 
     // If seeking default export and no exact name match, look for any symbol with exportedAs === "default"
     if (symbolName === "default" && candidates.length === 0) {
       const syms = symbolsByFile.get(targetFile) ?? [];
       for (const s of syms) {
-        if (s.exportedAs === "default" || s.name === "default") {
+        if (s.isExported !== false && (s.exportedAs === "default" || s.name === "default")) {
           candidates.push(s.id);
         }
       }

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -795,9 +795,61 @@ function extractFromTsLike(
   const root = parse(lang, source).root();
   const symbols: SymbolNode[] = [moduleSym];
   const scopes: ScopeFrame[] = [];
-  const scopeLocalNames = new Map<string, Set<string>>();
+  const moduleScopeSymbolIds = new Set<string>();
 
   const declaredBindingsCache = new Map<string, Set<string>>();
+
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  function isModuleScopeDeclaration(node: any): boolean {
+    let parent = node.parent?.();
+    if (parent?.kind?.() === "export_statement") {
+      parent = parent.parent?.();
+    }
+    return parent?.kind?.() === "program";
+  }
+
+  const functionScopeBoundaries = new Set([
+    "function_declaration",
+    "generator_function_declaration",
+    "function_expression",
+    "generator_function",
+    "arrow_function",
+    "method_definition",
+    "class_declaration",
+    "class_expression",
+  ]);
+
+  // `var` is function-scoped, including through nested blocks, but a nested
+  // function or class starts a different scope. A recursive findAll() crosses
+  // those boundaries and can incorrectly shadow an import in the outer function.
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  function collectFunctionScopedVars(functionNode: any, bound: Set<string>): void {
+    const body = functionNode.field?.("body");
+    if (!body) return;
+
+    // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+    function visit(node: any, isRoot = false): void {
+      const nodeKind = node.kind?.();
+      if (!isRoot && functionScopeBoundaries.has(nodeKind)) return;
+
+      if (nodeKind === "variable_declaration") {
+        for (const decl of node.children?.() ?? []) {
+          if (decl.kind?.() !== "variable_declarator") continue;
+          const nameNode = decl.field?.("name") ?? decl.children?.()[0];
+          if (!nameNode) continue;
+          for (const binding of extractBindingIdentifiers(nameNode)) {
+            bound.add(binding.name);
+          }
+        }
+      }
+
+      for (const child of node.children?.() ?? []) {
+        visit(child);
+      }
+    }
+
+    visit(body, true);
+  }
 
   // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
   function getDeclaredBindingsInNode(node: any): Set<string> {
@@ -827,18 +879,7 @@ function extractFromTsLike(
           }
         }
       }
-      for (const varDecl of safeFindAll(node, "variable_declaration")) {
-        for (const decl of varDecl.children?.() ?? []) {
-          if (decl.kind?.() === "variable_declarator") {
-            const nameNode = decl.field?.("name") ?? decl.children?.()[0];
-            if (nameNode) {
-              for (const b of extractBindingIdentifiers(nameNode)) {
-                bound.add(b.name);
-              }
-            }
-          }
-        }
-      }
+      collectFunctionScopedVars(node, bound);
     }
 
     // 2. Catch clause parameter
@@ -909,22 +950,6 @@ function extractFromTsLike(
     return false;
   }
 
-  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
-  function recordScopeParams(node: any, symbolId: string) {
-    const params = node.field?.("parameters") ?? safeFind(node, "formal_parameters");
-    if (!params) return;
-    let set = scopeLocalNames.get(symbolId);
-    if (!set) {
-      set = new Set<string>();
-      scopeLocalNames.set(symbolId, set);
-    }
-    for (const child of params.children?.() ?? []) {
-      for (const b of extractBindingIdentifiers(child)) {
-        set.add(b.name);
-      }
-    }
-  }
-
   // Class declarations
   for (const node of safeFindAll(root, "class_declaration")) {
     const nameNode = node.field("name")
@@ -946,6 +971,7 @@ function extractFromTsLike(
       file, line: startLine, endLine, language,
     };
     symbols.push(sym);
+    if (isModuleScopeDeclaration(node)) moduleScopeSymbolIds.add(sym.id);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
 
     const body = node.field("body");
@@ -973,7 +999,6 @@ function extractFromTsLike(
       };
       symbols.push(msym);
       scopes.push({ name: qname, startLine: mStart, endLine: mEnd, symbolId: msym.id });
-      recordScopeParams(m, msym.id);
     }
   }
 
@@ -996,8 +1021,8 @@ function extractFromTsLike(
       file, line: startLine, endLine, language,
     };
     symbols.push(sym);
+    if (isModuleScopeDeclaration(node)) moduleScopeSymbolIds.add(sym.id);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
-    recordScopeParams(node, sym.id);
   }
 
   // Generator function declarations
@@ -1019,8 +1044,8 @@ function extractFromTsLike(
       file, line: startLine, endLine, language,
     };
     symbols.push(sym);
+    if (isModuleScopeDeclaration(node)) moduleScopeSymbolIds.add(sym.id);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
-    recordScopeParams(node, sym.id);
   }
 
   // Interface declarations (TS / TSX)
@@ -1040,6 +1065,7 @@ function extractFromTsLike(
       name, qualifiedName: name, kind: "interface", isExported, file, line: startLine, endLine, language,
     };
     symbols.push(sym);
+    if (isModuleScopeDeclaration(node)) moduleScopeSymbolIds.add(sym.id);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
   }
 
@@ -1060,6 +1086,7 @@ function extractFromTsLike(
       name, qualifiedName: name, kind: "type", isExported, file, line: startLine, endLine, language,
     };
     symbols.push(sym);
+    if (isModuleScopeDeclaration(node)) moduleScopeSymbolIds.add(sym.id);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
   }
 
@@ -1079,6 +1106,7 @@ function extractFromTsLike(
       name, qualifiedName: name, kind: "enum", isExported, file, line: startLine, endLine, language,
     };
     symbols.push(sym);
+    if (isModuleScopeDeclaration(node)) moduleScopeSymbolIds.add(sym.id);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
   }
 
@@ -1116,9 +1144,11 @@ function extractFromTsLike(
       const nameNode = decl.field("name") ?? (decl.children?.().find((c: any) => c.kind() === "identifier" || c.kind() === "object_pattern" || c.kind() === "array_pattern"));
       if (!nameNode) continue;
       const bindings = extractBindingIdentifiers(nameNode);
-      const arrow = safeFind(decl, "arrow_function");
-      const fnExpr = safeFind(decl, "function_expression");
-      const fn = arrow ?? fnExpr;
+      const value = decl.field?.("value");
+      const valueKind = value?.kind?.();
+      const fn = valueKind === "arrow_function" || valueKind === "function_expression"
+        ? value
+        : null;
       if (fn && bindings.length === 1) {
         const name = bindings[0].name;
         const r = (fn ?? decl).range();
@@ -1129,6 +1159,7 @@ function extractFromTsLike(
           name, qualifiedName: name, kind: "function", isExported, file, line: startLine, endLine, language,
         };
         symbols.push(sym);
+        moduleScopeSymbolIds.add(sym.id);
         scopes.push({ name, startLine, endLine, symbolId: sym.id });
       } else {
         for (const b of bindings) {
@@ -1141,6 +1172,7 @@ function extractFromTsLike(
             name, qualifiedName: name, kind: "variable", isExported, file, line: startLine, endLine, language,
           };
           symbols.push(sym);
+          moduleScopeSymbolIds.add(sym.id);
         }
       }
     }
@@ -1151,18 +1183,6 @@ function extractFromTsLike(
   for (const s of symbols) {
     if (s.name !== "<module>") {
       declaredNamesAndLines.add(`${s.name}#${s.line}`);
-      if (s.kind === "variable") {
-        for (const sc of scopes) {
-          if (sc.symbolId !== s.id && s.line >= sc.startLine && s.endLine <= sc.endLine) {
-            let set = scopeLocalNames.get(sc.symbolId);
-            if (!set) {
-              set = new Set<string>();
-              scopeLocalNames.set(sc.symbolId, set);
-            }
-            set.add(s.name);
-          }
-        }
-      }
     }
   }
 
@@ -1276,7 +1296,7 @@ function extractFromTsLike(
       if (defMatch) {
         const defName = defMatch[1];
         for (const s of symbols) {
-          if (s.name === defName && s.file === file) {
+          if (s.name === defName && moduleScopeSymbolIds.has(s.id)) {
             s.isExported = true;
             s.exportedAs = "default";
           }
@@ -1293,7 +1313,7 @@ function extractFromTsLike(
       localToExportedName.set(localName, expName);
       if (!sourceModule) {
         for (const s of symbols) {
-          if (s.name === expName && s.file === file) {
+          if (s.name === expName && moduleScopeSymbolIds.has(s.id)) {
             s.isExported = true;
             if (aliasNode) {
               s.exportedAs = aliasNode.text();

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -902,7 +902,9 @@ function extractFromTsLike(
           name, qualifiedName: name, kind: symKind, file, line: startLine, endLine, language,
         };
         symbols.push(sym);
-        scopes.push({ name, startLine, endLine, symbolId: sym.id });
+        if (fn) {
+          scopes.push({ name, startLine, endLine, symbolId: sym.id });
+        }
       }
     }
   }
@@ -916,22 +918,10 @@ function extractFromTsLike(
   }
 
   const rawCalls: ExtractedSymbols["rawCalls"] = [];
-  const importedNames = new Set<string>();
+  const localToExportedName = new Map<string, string>();
+  const namespaceNames = new Set<string>();
 
-  // 1. Call sites
-  for (const node of safeFindAll(root, "call_expression")) {
-    const calleeName = extractCalleeNameJs(node.text());
-    if (!calleeName) continue;
-    const r = node.range();
-    const callLine = r.start.line + 1;
-    const callerId = findCallerId(scopes, callLine, moduleSym.id);
-    rawCalls.push({
-      callerId, calleeName,
-      callSite: { file, line: callLine },
-    });
-  }
-
-  // 2. Import statements: named imports (`import { X, Y as Z }`), type imports (`import type { T }`), default imports (`import D from ...`)
+  // 1. Import statements: named imports (`import { X, Y as Z }`), type imports (`import type { T }`), default imports (`import D from ...`), namespace imports (`import * as NS from ...`)
   for (const imp of safeFindAll(root, "import_statement")) {
     const r = imp.range();
     const line = r.start.line + 1;
@@ -939,13 +929,25 @@ function extractFromTsLike(
     for (const spec of safeFindAll(imp, "import_specifier")) {
       const nameNode = spec.field("name") ?? safeFind(spec, "identifier");
       if (!nameNode) continue;
-      const importedName = nameNode.text();
-      importedNames.add(importedName);
+      const originalName = nameNode.text();
+      const aliasNode = spec.field("alias");
+      const localName = aliasNode ? aliasNode.text() : originalName;
+      localToExportedName.set(localName, originalName);
+
       rawCalls.push({
         callerId: moduleSym.id,
-        calleeName: importedName,
+        calleeName: originalName,
         callSite: { file, line },
       });
+    }
+
+    // Namespace import: `import * as NS from "..."`
+    const nsNode = safeFind(imp, "namespace_import");
+    if (nsNode) {
+      const idNode = safeFind(nsNode, "identifier");
+      if (idNode) {
+        namespaceNames.add(idNode.text());
+      }
     }
 
     const clause = safeFind(imp, "import_clause");
@@ -956,7 +958,7 @@ function extractFromTsLike(
       for (const k of kids) {
         if (k.kind() === "identifier") {
           const defaultName = k.text();
-          importedNames.add(defaultName);
+          localToExportedName.set(defaultName, defaultName);
           rawCalls.push({
             callerId: moduleSym.id,
             calleeName: defaultName,
@@ -967,7 +969,7 @@ function extractFromTsLike(
     }
   }
 
-  // 3. Re-export statements (`export { X, Y } from '...'` and `export { X }`)
+  // 2. Re-export statements (`export { X, Y as Z } from '...'` and `export { X }`)
   for (const exp of safeFindAll(root, "export_statement")) {
     const r = exp.range();
     const line = r.start.line + 1;
@@ -975,13 +977,32 @@ function extractFromTsLike(
       const nameNode = spec.field("name") ?? safeFind(spec, "identifier");
       if (!nameNode) continue;
       const expName = nameNode.text();
-      importedNames.add(expName);
+      const aliasNode = spec.field("alias");
+      const localName = aliasNode ? aliasNode.text() : expName;
+      localToExportedName.set(localName, expName);
       rawCalls.push({
         callerId: moduleSym.id,
         calleeName: expName,
         callSite: { file, line },
       });
     }
+  }
+
+  // 3. Call sites
+  for (const node of safeFindAll(root, "call_expression")) {
+    let calleeName = extractCalleeNameJs(node.text());
+    if (!calleeName) continue;
+    const mapped = localToExportedName.get(calleeName);
+    if (mapped) {
+      calleeName = mapped;
+    }
+    const r = node.range();
+    const callLine = r.start.line + 1;
+    const callerId = findCallerId(scopes, callLine, moduleSym.id);
+    rawCalls.push({
+      callerId, calleeName,
+      callSite: { file, line: callLine },
+    });
   }
 
   // 4. Type references (type annotations, type arguments, implements, extends)
@@ -999,11 +1020,15 @@ function extractFromTsLike(
   ]);
 
   for (const node of safeFindAll(root, "type_identifier")) {
-    const name = node.text();
+    let name = node.text();
     if (TS_BUILTIN_TYPES.has(name)) continue;
     const r = node.range();
     const line = r.start.line + 1;
     if (declaredNamesAndLines.has(`${name}#${line}`)) continue;
+    const mapped = localToExportedName.get(name);
+    if (mapped) {
+      name = mapped;
+    }
     const callerId = findCallerId(scopes, line, moduleSym.id);
     rawCalls.push({
       callerId,
@@ -1012,22 +1037,41 @@ function extractFromTsLike(
     });
   }
 
-  // 5. Value references to imported identifiers in expressions / statements
-  if (importedNames.size > 0) {
+  // 5. Value references and namespace member accesses in expressions / statements
+  if (namespaceNames.size > 0) {
+    for (const node of safeFindAll(root, "member_expression")) {
+      const objNode = node.field("object");
+      const propNode = node.field("property");
+      if (objNode && propNode && namespaceNames.has(objNode.text())) {
+        const propName = propNode.text();
+        const r = node.range();
+        const line = r.start.line + 1;
+        const callerId = findCallerId(scopes, line, moduleSym.id);
+        rawCalls.push({
+          callerId,
+          calleeName: propName,
+          callSite: { file, line },
+        });
+      }
+    }
+  }
+
+  if (localToExportedName.size > 0) {
     for (const idNode of safeFindAll(root, "identifier")) {
-      const name = idNode.text();
-      if (!importedNames.has(name)) continue;
+      const localName = idNode.text();
+      const originalName = localToExportedName.get(localName);
+      if (!originalName) continue;
       const r = idNode.range();
       const line = r.start.line + 1;
       const parentKind = idNode.parent()?.kind?.();
-      // Skip import_specifier / export_specifier definition sites themselves
+      // Skip import_specifier / import_clause / export_specifier definition sites themselves
       if (parentKind === "import_specifier" || parentKind === "import_clause" || parentKind === "export_specifier") {
         continue;
       }
       const callerId = findCallerId(scopes, line, moduleSym.id);
       rawCalls.push({
         callerId,
-        calleeName: name,
+        calleeName: originalName,
         callSite: { file, line },
       });
     }

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -44,7 +44,7 @@ function extractBindingIdentifiers(node: any): Array<{ name: string; node: any }
     const value = node.field?.("value") ?? node.children?.()[2];
     return extractBindingIdentifiers(value);
   }
-  if (kind === "assignment_pattern") {
+  if (kind === "assignment_pattern" || kind === "object_assignment_pattern") {
     const left = node.field?.("left") ?? node.children?.()[0];
     return extractBindingIdentifiers(left);
   }
@@ -57,7 +57,7 @@ function extractBindingIdentifiers(node: any): Array<{ name: string; node: any }
     }
     return [];
   }
-  if (kind === "object_pattern" || kind === "array_pattern" || kind === "object_assignment_pattern") {
+  if (kind === "object_pattern" || kind === "array_pattern") {
     // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
     const result: Array<{ name: string; node: any }> = [];
     const kids = node.children?.() ?? [];
@@ -1126,10 +1126,11 @@ function extractFromTsLike(
   // 3. Call sites and instantiations
   for (const k of ["call_expression", "new_expression"]) {
     for (const node of safeFindAll(root, k)) {
-      let calleeName = extractCalleeNameJs(node.text());
-      if (!calleeName) continue;
-      const impInfo = localToImportInfo.get(calleeName);
-      const mapped = localToExportedName.get(calleeName);
+      const info = extractCalleeInfoJs(node.text());
+      if (!info) continue;
+      let calleeName = info.calleeName;
+      const impInfo = info.isBare ? localToImportInfo.get(calleeName) : undefined;
+      const mapped = info.isBare ? localToExportedName.get(calleeName) : undefined;
       const localAlias = mapped && mapped !== calleeName ? calleeName : undefined;
       if (mapped) {
         calleeName = mapped;
@@ -1237,19 +1238,36 @@ function extractFromTsLike(
     }
   }
 
-  return { symbols, rawCalls };
+  // Deduplicate rawCalls sharing (callerId, calleeName, kind, sourceModule) to keep graph compact
+  const dedupedCalls: ExtractedSymbols["rawCalls"] = [];
+  const seenCalls = new Set<string>();
+  for (const call of rawCalls) {
+    const key = `${call.callerId}::${call.calleeName}::${call.kind}::${call.sourceModule ?? ""}`;
+    if (!seenCalls.has(key)) {
+      seenCalls.add(key);
+      dedupedCalls.push(call);
+    }
+  }
+
+  return { symbols, rawCalls: dedupedCalls };
 }
 
-/** Pull the callee's bare name from the start of a call/new expression's text. */
-function extractCalleeNameJs(text: string): string | null {
+/** Pull the callee name and whether it was an unqualified bare identifier (not a member call). */
+function extractCalleeInfoJs(text: string): { calleeName: string; isBare: boolean } | null {
   const cleaned = text.replace(/^\s*new\s+/, "");
   // `foo(...)` → "foo"  ;  `obj.foo(...)` → "foo"  ;  `obj.bar.foo(...)` → "foo"
   const m = cleaned.match(/^([\w$.]+)\s*(?:\(|$)/);
   if (!m) return null;
   const chain = m[1];
+  const isBare = !chain.includes(".");
   const parts = chain.split(".");
   const last = parts[parts.length - 1];
-  return /^[A-Za-z_$][\w$]*$/.test(last) ? last : null;
+  return /^[A-Za-z_$][\w$]*$/.test(last) ? { calleeName: last, isBare } : null;
+}
+
+/** Pull the callee's bare name from the start of a call/new expression's text. */
+function extractCalleeNameJs(text: string): string | null {
+  return extractCalleeInfoJs(text)?.calleeName ?? null;
 }
 
 /**

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -1241,11 +1241,11 @@ function extractFromTsLike(
     }
   }
 
-  // Deduplicate rawCalls sharing (callerId, calleeName, kind, sourceModule) to keep graph compact
+  // Deduplicate rawCalls sharing (callerId, calleeName, kind, sourceModule, importedName, localAlias) to keep graph compact
   const dedupedCalls: ExtractedSymbols["rawCalls"] = [];
   const seenCalls = new Set<string>();
   for (const call of rawCalls) {
-    const key = `${call.callerId}::${call.calleeName}::${call.kind}::${call.sourceModule ?? ""}`;
+    const key = `${call.callerId}::${call.calleeName}::${call.kind}::${call.sourceModule ?? ""}::${call.importedName ?? ""}::${call.localAlias ?? ""}`;
     if (!seenCalls.has(key)) {
       seenCalls.add(key);
       dedupedCalls.push(call);

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -797,6 +797,117 @@ function extractFromTsLike(
   const scopes: ScopeFrame[] = [];
   const scopeLocalNames = new Map<string, Set<string>>();
 
+  const declaredBindingsCache = new Map<string, Set<string>>();
+
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  function getDeclaredBindingsInNode(node: any): Set<string> {
+    if (!node) return new Set();
+    const range = node.range?.();
+    const cacheKey = range ? `${node.kind?.()}:${range.start.index}:${range.end.index}` : "";
+    if (cacheKey && declaredBindingsCache.has(cacheKey)) {
+      return declaredBindingsCache.get(cacheKey)!;
+    }
+
+    const bound = new Set<string>();
+    const kind = node.kind?.();
+
+    // 1. Function parameters & function hoisted vars
+    if (
+      kind === "function_declaration" ||
+      kind === "function_expression" ||
+      kind === "arrow_function" ||
+      kind === "method_definition"
+    ) {
+      const params = node.field?.("parameters") ?? safeFind(node, "formal_parameters");
+      if (params) {
+        for (const child of params.children?.() ?? []) {
+          for (const b of extractBindingIdentifiers(child)) {
+            bound.add(b.name);
+          }
+        }
+      }
+      for (const varDecl of safeFindAll(node, "variable_declaration")) {
+        for (const decl of varDecl.children?.() ?? []) {
+          if (decl.kind?.() === "variable_declarator") {
+            const nameNode = decl.field?.("name") ?? decl.children?.()[0];
+            if (nameNode) {
+              for (const b of extractBindingIdentifiers(nameNode)) {
+                bound.add(b.name);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // 2. Catch clause parameter
+    if (kind === "catch_clause") {
+      const param = node.field?.("parameter") ?? safeFind(node, "identifier");
+      if (param) {
+        for (const b of extractBindingIdentifiers(param)) {
+          bound.add(b.name);
+        }
+      }
+    }
+
+    // 3. For loops: for (const x of items), for (let i = 0; ...), for (const k in obj)
+    if (kind === "for_statement" || kind === "for_in_statement" || kind === "for_of_statement") {
+      const init = node.field?.("initializer") ?? node.field?.("left");
+      if (init) {
+        for (const decl of safeFindAll(init, "variable_declarator")) {
+          const nameNode = decl.field?.("name") ?? decl.children?.()[0];
+          if (nameNode) {
+            for (const b of extractBindingIdentifiers(nameNode)) {
+              bound.add(b.name);
+            }
+          }
+        }
+      }
+    }
+
+    // 4. Block / function body / switch case declarations
+    if (kind === "statement_block" || kind === "switch_case" || kind === "switch_block") {
+      for (const child of node.children?.() ?? []) {
+        const cKind = child.kind?.();
+        if (cKind === "lexical_declaration" || cKind === "variable_declaration") {
+          for (const decl of child.children?.() ?? []) {
+            if (decl.kind?.() === "variable_declarator") {
+              const nameNode = decl.field?.("name") ?? decl.children?.()[0];
+              if (nameNode) {
+                for (const b of extractBindingIdentifiers(nameNode)) {
+                  bound.add(b.name);
+                }
+              }
+            }
+          }
+        } else if (cKind === "function_declaration" || cKind === "class_declaration") {
+          const nameNode = child.field?.("name") ?? safeFind(child, "identifier");
+          if (nameNode) {
+            bound.add(nameNode.text());
+          }
+        }
+      }
+    }
+
+    if (cacheKey) {
+      declaredBindingsCache.set(cacheKey, bound);
+    }
+    return bound;
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  function isLexicallyBound(idNode: any, name: string): boolean {
+    let curr = idNode.parent?.();
+    while (curr && curr.kind?.() !== "program") {
+      const bound = getDeclaredBindingsInNode(curr);
+      if (bound.has(name)) {
+        return true;
+      }
+      curr = curr.parent?.();
+    }
+    return false;
+  }
+
   // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
   function recordScopeParams(node: any, symbolId: string) {
     const params = node.field?.("parameters") ?? safeFind(node, "formal_parameters");
@@ -825,10 +936,12 @@ function extractFromTsLike(
     const endLine = range.end.line + 1;
     const parentText = node.parent?.()?.kind?.() === "export_statement" ? node.parent().text() : "";
     const isDefaultExport = /^\s*export\s+default\b/.test(node.text()) || /^\s*export\s+default\b/.test(parentText);
+    const isExported = isDefaultExport || /^\s*export\b/.test(node.text()) || /^\s*export\b/.test(parentText);
     const sym: SymbolNode = {
       id: makeId(file, name, startLine),
       name, qualifiedName: name, kind: "class",
       exportedAs: isDefaultExport ? "default" : undefined,
+      isExported,
       file, line: startLine, endLine, language,
     };
     symbols.push(sym);
@@ -873,10 +986,12 @@ function extractFromTsLike(
     const endLine = r.end.line + 1;
     const fnParentText = node.parent?.()?.kind?.() === "export_statement" ? node.parent().text() : "";
     const isDefaultExport = /^\s*export\s+default\b/.test(node.text()) || /^\s*export\s+default\b/.test(fnParentText);
+    const isExported = isDefaultExport || /^\s*export\b/.test(node.text()) || /^\s*export\b/.test(fnParentText);
     const sym: SymbolNode = {
       id: makeId(file, name, startLine),
       name, qualifiedName: name, kind: "function",
       exportedAs: isDefaultExport ? "default" : undefined,
+      isExported,
       file, line: startLine, endLine, language,
     };
     symbols.push(sym);
@@ -892,9 +1007,15 @@ function extractFromTsLike(
     const r = node.range();
     const startLine = r.start.line + 1;
     const endLine = r.end.line + 1;
+    const genParentText = node.parent?.()?.kind?.() === "export_statement" ? node.parent().text() : "";
+    const isDefaultExport = /^\s*export\s+default\b/.test(node.text()) || /^\s*export\s+default\b/.test(genParentText);
+    const isExported = isDefaultExport || /^\s*export\b/.test(node.text()) || /^\s*export\b/.test(genParentText);
     const sym: SymbolNode = {
       id: makeId(file, name, startLine),
-      name, qualifiedName: name, kind: "function", file, line: startLine, endLine, language,
+      name, qualifiedName: name, kind: "function",
+      exportedAs: isDefaultExport ? "default" : undefined,
+      isExported,
+      file, line: startLine, endLine, language,
     };
     symbols.push(sym);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
@@ -911,9 +1032,11 @@ function extractFromTsLike(
     const r = node.range();
     const startLine = r.start.line + 1;
     const endLine = r.end.line + 1;
+    const ifaceParentText = node.parent?.()?.kind?.() === "export_statement" ? node.parent().text() : "";
+    const isExported = /^\s*export\b/.test(node.text()) || /^\s*export\b/.test(ifaceParentText);
     const sym: SymbolNode = {
       id: makeId(file, name, startLine),
-      name, qualifiedName: name, kind: "interface", file, line: startLine, endLine, language,
+      name, qualifiedName: name, kind: "interface", isExported, file, line: startLine, endLine, language,
     };
     symbols.push(sym);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
@@ -929,9 +1052,11 @@ function extractFromTsLike(
     const r = node.range();
     const startLine = r.start.line + 1;
     const endLine = r.end.line + 1;
+    const typeParentText = node.parent?.()?.kind?.() === "export_statement" ? node.parent().text() : "";
+    const isExported = /^\s*export\b/.test(node.text()) || /^\s*export\b/.test(typeParentText);
     const sym: SymbolNode = {
       id: makeId(file, name, startLine),
-      name, qualifiedName: name, kind: "type", file, line: startLine, endLine, language,
+      name, qualifiedName: name, kind: "type", isExported, file, line: startLine, endLine, language,
     };
     symbols.push(sym);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
@@ -946,9 +1071,11 @@ function extractFromTsLike(
     const r = node.range();
     const startLine = r.start.line + 1;
     const endLine = r.end.line + 1;
+    const enumParentText = node.parent?.()?.kind?.() === "export_statement" ? node.parent().text() : "";
+    const isExported = /^\s*export\b/.test(node.text()) || /^\s*export\b/.test(enumParentText);
     const sym: SymbolNode = {
       id: makeId(file, name, startLine),
-      name, qualifiedName: name, kind: "enum", file, line: startLine, endLine, language,
+      name, qualifiedName: name, kind: "enum", isExported, file, line: startLine, endLine, language,
     };
     symbols.push(sym);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
@@ -956,31 +1083,31 @@ function extractFromTsLike(
 
   // Lexical and variable declarations: const, let, var (top-level only, direct declarators)
   // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
-  const topLevelDeclNodes: any[] = [];
+  const topLevelDeclNodes: Array<{ node: any; isExported: boolean }> = [];
   try {
     for (const child of root.children()) {
       if (child.kind() === "export_statement") {
         const decl = child.field("declaration");
         if (decl) {
           if (decl.kind() === "lexical_declaration" || decl.kind() === "variable_declaration") {
-            topLevelDeclNodes.push(decl);
+            topLevelDeclNodes.push({ node: decl, isExported: true });
           }
         } else {
           for (const sub of child.children()) {
             if (sub.kind() === "lexical_declaration" || sub.kind() === "variable_declaration") {
-              topLevelDeclNodes.push(sub);
+              topLevelDeclNodes.push({ node: sub, isExported: true });
             }
           }
         }
       } else if (child.kind() === "lexical_declaration" || child.kind() === "variable_declaration") {
-        topLevelDeclNodes.push(child);
+        topLevelDeclNodes.push({ node: child, isExported: false });
       }
     }
   } catch {
     // fallback if root.children() is unavailable
   }
 
-  for (const node of topLevelDeclNodes) {
+  for (const { node, isExported } of topLevelDeclNodes) {
     // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
     const declarators = (node.children?.() ?? []).filter((c: any) => c.kind() === "variable_declarator");
     for (const decl of declarators) {
@@ -998,7 +1125,7 @@ function extractFromTsLike(
         const endLine = r.end.line + 1;
         const sym: SymbolNode = {
           id: makeId(file, name, startLine),
-          name, qualifiedName: name, kind: "function", file, line: startLine, endLine, language,
+          name, qualifiedName: name, kind: "function", isExported, file, line: startLine, endLine, language,
         };
         symbols.push(sym);
         scopes.push({ name, startLine, endLine, symbolId: sym.id });
@@ -1010,7 +1137,7 @@ function extractFromTsLike(
           const endLine = r.end.line + 1;
           const sym: SymbolNode = {
             id: makeId(file, name, startLine),
-            name, qualifiedName: name, kind: "variable", file, line: startLine, endLine, language,
+            name, qualifiedName: name, kind: "variable", isExported, file, line: startLine, endLine, language,
           };
           symbols.push(sym);
         }
@@ -1143,6 +1270,19 @@ function extractFromTsLike(
       });
     }
 
+    if (!sourceModule) {
+      const defMatch = expText.match(/^\s*export\s+default\s+([a-zA-Z_$][\w$]*)/);
+      if (defMatch) {
+        const defName = defMatch[1];
+        for (const s of symbols) {
+          if (s.name === defName && s.file === file) {
+            s.isExported = true;
+            s.exportedAs = "default";
+          }
+        }
+      }
+    }
+
     for (const spec of safeFindAll(exp, "export_specifier")) {
       const nameNode = spec.field("name") ?? safeFind(spec, "identifier");
       if (!nameNode) continue;
@@ -1150,6 +1290,16 @@ function extractFromTsLike(
       const aliasNode = spec.field("alias");
       const localName = aliasNode ? aliasNode.text() : expName;
       localToExportedName.set(localName, expName);
+      if (!sourceModule) {
+        for (const s of symbols) {
+          if (s.name === expName && s.file === file) {
+            s.isExported = true;
+            if (aliasNode) {
+              s.exportedAs = aliasNode.text();
+            }
+          }
+        }
+      }
       rawCalls.push({
         callerId: moduleSym.id,
         calleeName: expName,
@@ -1297,8 +1447,8 @@ function extractFromTsLike(
         }
       }
       const callerId = findCallerId(scopes, line, moduleSym.id);
-      // Skip if shadowed by local parameter or variable in this scope
-      if (callerId !== moduleSym.id && scopeLocalNames.get(callerId)?.has(localName)) {
+      // Skip if shadowed by local parameter, variable, destructuring, catch binding, or block scope
+      if (isLexicallyBound(idNode, localName)) {
         continue;
       }
       const impInfo = localToImportInfo.get(localName);

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -754,12 +754,6 @@ function extractFromTsLike(
 
   // Class declarations
   for (const node of safeFindAll(root, "class_declaration")) {
-    // The name FIELD, not a subtree search: safeFind's recursive DFS reaches a
-    // decorator's identifier before the class's own name, so `@sealed class X`
-    // would extract as a class named `sealed` and collide with the real
-    // decorator function at resolution time. The field is grammar-precise on
-    // JS (identifier) and TS/TSX (type_identifier) alike; the searches remain
-    // only as a belt for grammars without the field.
     const nameNode = node.field("name")
       ?? safeFind(node, "type_identifier")
       ?? safeFind(node, "identifier");
@@ -775,11 +769,6 @@ function extractFromTsLike(
     symbols.push(sym);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
 
-    // Methods inside the class — DIRECT children of the class body only. A
-    // recursive scan fabricates phantom methods: an object-literal shorthand
-    // handler inside a field initializer or a call argument, or a nested
-    // class's methods, would all be stamped onto THIS class and persisted into
-    // the name index, corrupting name-based resolution and impact seeds.
     const body = node.field("body");
     // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
     let members: any[] = [];
@@ -790,9 +779,6 @@ function extractFromTsLike(
       members = [];
     }
     for (const m of members) {
-      // Name from the field, accepting only a literal property name: a
-      // computed name like `[Symbol.iterator]` has no static identity, and
-      // searching inside it used to persist a method that does not exist.
       const mNameNode = m.field("name");
       const mName = mNameNode?.kind() === "property_identifier" ? mNameNode.text() : null;
       if (!mName) continue;
@@ -843,30 +829,96 @@ function extractFromTsLike(
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
   }
 
-  // Named arrow functions: `const foo = (...) => {...}` or `const foo = function(...) {...}`
-  for (const node of safeFindAll(root, "lexical_declaration")) {
-    for (const decl of safeFindAll(node, "variable_declarator")) {
-      const idNode = safeFind(decl, "identifier");
-      if (!idNode) continue;
-      const name = idNode.text();
-      const arrow = safeFind(decl, "arrow_function");
-      const fnExpr = safeFind(decl, "function_expression");
-      const fn = arrow ?? fnExpr;
-      if (!fn) continue;
-      const r = fn.range();
-      const startLine = r.start.line + 1;
-      const endLine = r.end.line + 1;
-      const sym: SymbolNode = {
-        id: makeId(file, name, startLine),
-        name, qualifiedName: name, kind: "function", file, line: startLine, endLine, language,
-      };
-      symbols.push(sym);
-      scopes.push({ name, startLine, endLine, symbolId: sym.id });
+  // Interface declarations (TS / TSX)
+  for (const node of safeFindAll(root, "interface_declaration")) {
+    const nameNode = node.field("name")
+      ?? safeFind(node, "type_identifier")
+      ?? safeFind(node, "identifier");
+    if (!nameNode) continue;
+    const name = nameNode.text();
+    const r = node.range();
+    const startLine = r.start.line + 1;
+    const endLine = r.end.line + 1;
+    const sym: SymbolNode = {
+      id: makeId(file, name, startLine),
+      name, qualifiedName: name, kind: "interface", file, line: startLine, endLine, language,
+    };
+    symbols.push(sym);
+    scopes.push({ name, startLine, endLine, symbolId: sym.id });
+  }
+
+  // Type alias declarations (TS / TSX)
+  for (const node of safeFindAll(root, "type_alias_declaration")) {
+    const nameNode = node.field("name")
+      ?? safeFind(node, "type_identifier")
+      ?? safeFind(node, "identifier");
+    if (!nameNode) continue;
+    const name = nameNode.text();
+    const r = node.range();
+    const startLine = r.start.line + 1;
+    const endLine = r.end.line + 1;
+    const sym: SymbolNode = {
+      id: makeId(file, name, startLine),
+      name, qualifiedName: name, kind: "type", file, line: startLine, endLine, language,
+    };
+    symbols.push(sym);
+    scopes.push({ name, startLine, endLine, symbolId: sym.id });
+  }
+
+  // Enum declarations (TS / TSX)
+  for (const node of safeFindAll(root, "enum_declaration")) {
+    const nameNode = node.field("name")
+      ?? safeFind(node, "identifier");
+    if (!nameNode) continue;
+    const name = nameNode.text();
+    const r = node.range();
+    const startLine = r.start.line + 1;
+    const endLine = r.end.line + 1;
+    const sym: SymbolNode = {
+      id: makeId(file, name, startLine),
+      name, qualifiedName: name, kind: "enum", file, line: startLine, endLine, language,
+    };
+    symbols.push(sym);
+    scopes.push({ name, startLine, endLine, symbolId: sym.id });
+  }
+
+  // Lexical and variable declarations: const, let, var (including arrow functions and plain constants)
+  const declKinds = ["lexical_declaration", "variable_declaration"];
+  for (const declKind of declKinds) {
+    for (const node of safeFindAll(root, declKind)) {
+      for (const decl of safeFindAll(node, "variable_declarator")) {
+        const idNode = decl.field("name") ?? safeFind(decl, "identifier");
+        if (!idNode) continue;
+        const name = idNode.text();
+        const arrow = safeFind(decl, "arrow_function");
+        const fnExpr = safeFind(decl, "function_expression");
+        const fn = arrow ?? fnExpr;
+        const r = (fn ?? decl).range();
+        const startLine = r.start.line + 1;
+        const endLine = r.end.line + 1;
+        const symKind: SymbolKind = fn ? "function" : "variable";
+        const sym: SymbolNode = {
+          id: makeId(file, name, startLine),
+          name, qualifiedName: name, kind: symKind, file, line: startLine, endLine, language,
+        };
+        symbols.push(sym);
+        scopes.push({ name, startLine, endLine, symbolId: sym.id });
+      }
     }
   }
 
-  // Call sites
+  // Track declaration names and lines to avoid self-referencing declaration identifiers
+  const declaredNamesAndLines = new Set<string>();
+  for (const s of symbols) {
+    if (s.name !== "<module>") {
+      declaredNamesAndLines.add(`${s.name}#${s.line}`);
+    }
+  }
+
   const rawCalls: ExtractedSymbols["rawCalls"] = [];
+  const importedNames = new Set<string>();
+
+  // 1. Call sites
   for (const node of safeFindAll(root, "call_expression")) {
     const calleeName = extractCalleeNameJs(node.text());
     if (!calleeName) continue;
@@ -878,6 +930,109 @@ function extractFromTsLike(
       callSite: { file, line: callLine },
     });
   }
+
+  // 2. Import statements: named imports (`import { X, Y as Z }`), type imports (`import type { T }`), default imports (`import D from ...`)
+  for (const imp of safeFindAll(root, "import_statement")) {
+    const r = imp.range();
+    const line = r.start.line + 1;
+
+    for (const spec of safeFindAll(imp, "import_specifier")) {
+      const nameNode = spec.field("name") ?? safeFind(spec, "identifier");
+      if (!nameNode) continue;
+      const importedName = nameNode.text();
+      importedNames.add(importedName);
+      rawCalls.push({
+        callerId: moduleSym.id,
+        calleeName: importedName,
+        callSite: { file, line },
+      });
+    }
+
+    const clause = safeFind(imp, "import_clause");
+    if (clause) {
+      // Direct identifier in import_clause is default import
+      // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+      const kids = (clause as any).children?.() ?? [];
+      for (const k of kids) {
+        if (k.kind() === "identifier") {
+          const defaultName = k.text();
+          importedNames.add(defaultName);
+          rawCalls.push({
+            callerId: moduleSym.id,
+            calleeName: defaultName,
+            callSite: { file, line },
+          });
+        }
+      }
+    }
+  }
+
+  // 3. Re-export statements (`export { X, Y } from '...'` and `export { X }`)
+  for (const exp of safeFindAll(root, "export_statement")) {
+    const r = exp.range();
+    const line = r.start.line + 1;
+    for (const spec of safeFindAll(exp, "export_specifier")) {
+      const nameNode = spec.field("name") ?? safeFind(spec, "identifier");
+      if (!nameNode) continue;
+      const expName = nameNode.text();
+      importedNames.add(expName);
+      rawCalls.push({
+        callerId: moduleSym.id,
+        calleeName: expName,
+        callSite: { file, line },
+      });
+    }
+  }
+
+  // 4. Type references (type annotations, type arguments, implements, extends)
+  const TS_BUILTIN_TYPES = new Set([
+    "string", "number", "boolean", "any", "unknown", "never", "void", "null", "undefined",
+    "symbol", "bigint", "object", "Function", "true", "false",
+    "Array", "Record", "Promise", "Partial", "Required", "Readonly", "Pick", "Omit",
+    "Exclude", "Extract", "NonNullable", "ReturnType", "InstanceType", "Parameters",
+    "ConstructorParameters", "Awaited", "Map", "Set", "WeakMap", "WeakSet", "Error",
+    "RegExp", "Date", "Uint8Array", "Int8Array", "Uint16Array", "Int16Array",
+    "Uint32Array", "Int32Array", "Float32Array", "Float64Array", "BigInt64Array", "BigUint64Array",
+    "ArrayBuffer", "DataView", "Iterable", "AsyncIterable", "Iterator", "AsyncIterator",
+    "Generator", "AsyncGenerator", "TemplateStringsArray", "PropertyKey",
+    "T", "K", "V", "U", "R", "P",
+  ]);
+
+  for (const node of safeFindAll(root, "type_identifier")) {
+    const name = node.text();
+    if (TS_BUILTIN_TYPES.has(name)) continue;
+    const r = node.range();
+    const line = r.start.line + 1;
+    if (declaredNamesAndLines.has(`${name}#${line}`)) continue;
+    const callerId = findCallerId(scopes, line, moduleSym.id);
+    rawCalls.push({
+      callerId,
+      calleeName: name,
+      callSite: { file, line },
+    });
+  }
+
+  // 5. Value references to imported identifiers in expressions / statements
+  if (importedNames.size > 0) {
+    for (const idNode of safeFindAll(root, "identifier")) {
+      const name = idNode.text();
+      if (!importedNames.has(name)) continue;
+      const r = idNode.range();
+      const line = r.start.line + 1;
+      const parentKind = idNode.parent()?.kind?.();
+      // Skip import_specifier / export_specifier definition sites themselves
+      if (parentKind === "import_specifier" || parentKind === "import_clause" || parentKind === "export_specifier") {
+        continue;
+      }
+      const callerId = findCallerId(scopes, line, moduleSym.id);
+      rawCalls.push({
+        callerId,
+        calleeName: name,
+        callSite: { file, line },
+      });
+    }
+  }
+
   return { symbols, rawCalls };
 }
 

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -1093,13 +1093,15 @@ function extractFromTsLike(
     const sourceModule = sourceNode ? sourceNode.text().replace(/^['"`]|['"`]$/g, "") : undefined;
 
     const expText = exp.text();
-    if (sourceModule && /export\s+\*\s+from/.test(expText)) {
+    const starReexport = expText.match(/export\s+\*(?:\s+as\s+([\w$]+))?\s+from/);
+    if (sourceModule && starReexport) {
       rawCalls.push({
         callerId: moduleSym.id,
-        calleeName: "*",
+        calleeName: starReexport[1] ?? "*",
         kind: "reexport",
         sourceModule,
         importedName: "*",
+        localAlias: starReexport[1],
         callSite: { file, line },
       });
     }
@@ -1219,6 +1221,7 @@ function extractFromTsLike(
       if (!originalName) continue;
       const r = idNode.range();
       const line = r.start.line + 1;
+      if (declaredNamesAndLines.has(`${localName}#${line}`)) continue;
       const parentKind = idNode.parent()?.kind?.();
       // Skip import_specifier / import_clause / export_specifier definition sites themselves
       if (parentKind === "import_specifier" || parentKind === "import_clause" || parentKind === "export_specifier") {

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -9,7 +9,7 @@
 
 import { Lang, parse } from "@ast-grep/napi";
 import { getLanguageFromExtension } from "../constants.js";
-import type { SymbolEdge, SymbolKind, SymbolNode } from "../types.js";
+import type { EdgeKind, SymbolEdge, SymbolKind, SymbolNode } from "../types.js";
 import { analyzeElixirTemplate, isElixirTemplateExtension } from "./elixir-templates.js";
 import { logger } from "./logger.js";
 
@@ -20,6 +20,10 @@ export interface ExtractedSymbols {
   rawCalls: Array<{
     callerId: string;
     calleeName: string;
+    kind: EdgeKind;
+    sourceModule?: string;
+    importedName?: string;
+    localAlias?: string;
     callSite: { file: string; line: number };
   }>;
 }
@@ -29,13 +33,46 @@ function makeId(file: string, qualifiedName: string, line: number): string {
   return `${file}::${qualifiedName}#${line}`;
 }
 
-/**
- * Wrapper around `node.findAll({rule:{kind}})` that swallows ast-grep
- * "Invalid Kind" errors. Different language grammars expose different node
- * kinds, so a kind that is valid for Kotlin (`object_declaration`) may be
- * rejected by Java's grammar and abort the entire extraction. Logging is
- * intentionally omitted at debug-level to avoid log spam on every file.
- */
+// biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+function extractBindingIdentifiers(node: any): Array<{ name: string; node: any }> {
+  if (!node) return [];
+  const kind = node.kind?.();
+  if (kind === "identifier" || kind === "shorthand_property_identifier_pattern") {
+    return [{ name: node.text(), node }];
+  }
+  if (kind === "pair_pattern" || kind === "pair") {
+    const value = node.field?.("value") ?? node.children?.()[2];
+    return extractBindingIdentifiers(value);
+  }
+  if (kind === "assignment_pattern") {
+    const left = node.field?.("left") ?? node.children?.()[0];
+    return extractBindingIdentifiers(left);
+  }
+  if (kind === "rest_pattern") {
+    const kids = node.children?.() ?? [];
+    for (const k of kids) {
+      if (k.kind?.() === "identifier") {
+        return [{ name: k.text(), node: k }];
+      }
+    }
+    return [];
+  }
+  if (kind === "object_pattern" || kind === "array_pattern" || kind === "object_assignment_pattern") {
+    // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+    const result: Array<{ name: string; node: any }> = [];
+    const kids = node.children?.() ?? [];
+    for (const k of kids) {
+      const kKind = k.kind?.();
+      if (kKind !== "{" && kKind !== "}" && kKind !== "[" && kKind !== "]" && kKind !== ",") {
+        result.push(...extractBindingIdentifiers(k));
+      }
+    }
+    return result;
+  }
+  return [];
+}
+
+/** Convert raw call sites to unresolved SymbolEdge objects (resolution in Phase C). */
 // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
 function safeFindAll(node: any, kind: string): any[] {
   try {
@@ -331,6 +368,7 @@ function extractFromElixir(
     rawCalls.push({
       callerId: findCallerId(scopes, line, moduleSym.id),
       calleeName: name,
+      kind: "call",
       callSite: { file, line },
     });
   }
@@ -463,6 +501,7 @@ function extractFromLua(
     rawCalls.push({
       callerId: findCallerId(scopes, line, moduleSym.id),
       calleeName: callee,
+      kind: "call",
       callSite: { file, line },
     });
   }
@@ -732,6 +771,7 @@ function extractFromDart(
     rawCalls.push({
       callerId: findCallerId(scopes, line, moduleSym.id),
       calleeName: callee,
+      kind: "call",
       callSite: { file, line },
     });
   }
@@ -762,9 +802,13 @@ function extractFromTsLike(
     const range = node.range();
     const startLine = range.start.line + 1;
     const endLine = range.end.line + 1;
+    const parentText = node.parent?.()?.kind?.() === "export_statement" ? node.parent().text() : "";
+    const isDefaultExport = /^\s*export\s+default\b/.test(node.text()) || /^\s*export\s+default\b/.test(parentText);
     const sym: SymbolNode = {
       id: makeId(file, name, startLine),
-      name, qualifiedName: name, kind: "class", file, line: startLine, endLine, language,
+      name, qualifiedName: name, kind: "class",
+      exportedAs: isDefaultExport ? "default" : undefined,
+      file, line: startLine, endLine, language,
     };
     symbols.push(sym);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
@@ -805,9 +849,13 @@ function extractFromTsLike(
     const r = node.range();
     const startLine = r.start.line + 1;
     const endLine = r.end.line + 1;
+    const fnParentText = node.parent?.()?.kind?.() === "export_statement" ? node.parent().text() : "";
+    const isDefaultExport = /^\s*export\s+default\b/.test(node.text()) || /^\s*export\s+default\b/.test(fnParentText);
     const sym: SymbolNode = {
       id: makeId(file, name, startLine),
-      name, qualifiedName: name, kind: "function", file, line: startLine, endLine, language,
+      name, qualifiedName: name, kind: "function",
+      exportedAs: isDefaultExport ? "default" : undefined,
+      file, line: startLine, endLine, language,
     };
     symbols.push(sym);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
@@ -882,28 +930,65 @@ function extractFromTsLike(
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
   }
 
-  // Lexical and variable declarations: const, let, var (including arrow functions and plain constants)
-  const declKinds = ["lexical_declaration", "variable_declaration"];
-  for (const declKind of declKinds) {
-    for (const node of safeFindAll(root, declKind)) {
-      for (const decl of safeFindAll(node, "variable_declarator")) {
-        const idNode = decl.field("name") ?? safeFind(decl, "identifier");
-        if (!idNode) continue;
-        const name = idNode.text();
-        const arrow = safeFind(decl, "arrow_function");
-        const fnExpr = safeFind(decl, "function_expression");
-        const fn = arrow ?? fnExpr;
+  // Lexical and variable declarations: const, let, var (top-level only, direct declarators)
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  const topLevelDeclNodes: any[] = [];
+  try {
+    for (const child of root.children()) {
+      if (child.kind() === "export_statement") {
+        const decl = child.field("declaration");
+        if (decl) {
+          if (decl.kind() === "lexical_declaration" || decl.kind() === "variable_declaration") {
+            topLevelDeclNodes.push(decl);
+          }
+        } else {
+          for (const sub of child.children()) {
+            if (sub.kind() === "lexical_declaration" || sub.kind() === "variable_declaration") {
+              topLevelDeclNodes.push(sub);
+            }
+          }
+        }
+      } else if (child.kind() === "lexical_declaration" || child.kind() === "variable_declaration") {
+        topLevelDeclNodes.push(child);
+      }
+    }
+  } catch {
+    // fallback if root.children() is unavailable
+  }
+
+  for (const node of topLevelDeclNodes) {
+    // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+    const declarators = (node.children?.() ?? []).filter((c: any) => c.kind() === "variable_declarator");
+    for (const decl of declarators) {
+      // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+      const nameNode = decl.field("name") ?? (decl.children?.().find((c: any) => c.kind() === "identifier" || c.kind() === "object_pattern" || c.kind() === "array_pattern"));
+      if (!nameNode) continue;
+      const bindings = extractBindingIdentifiers(nameNode);
+      const arrow = safeFind(decl, "arrow_function");
+      const fnExpr = safeFind(decl, "function_expression");
+      const fn = arrow ?? fnExpr;
+      if (fn && bindings.length === 1) {
+        const name = bindings[0].name;
         const r = (fn ?? decl).range();
         const startLine = r.start.line + 1;
         const endLine = r.end.line + 1;
-        const symKind: SymbolKind = fn ? "function" : "variable";
         const sym: SymbolNode = {
           id: makeId(file, name, startLine),
-          name, qualifiedName: name, kind: symKind, file, line: startLine, endLine, language,
+          name, qualifiedName: name, kind: "function", file, line: startLine, endLine, language,
         };
         symbols.push(sym);
-        if (fn) {
-          scopes.push({ name, startLine, endLine, symbolId: sym.id });
+        scopes.push({ name, startLine, endLine, symbolId: sym.id });
+      } else {
+        for (const b of bindings) {
+          const name = b.name;
+          const r = b.node.range();
+          const startLine = r.start.line + 1;
+          const endLine = r.end.line + 1;
+          const sym: SymbolNode = {
+            id: makeId(file, name, startLine),
+            name, qualifiedName: name, kind: "variable", file, line: startLine, endLine, language,
+          };
+          symbols.push(sym);
         }
       }
     }
@@ -919,12 +1004,16 @@ function extractFromTsLike(
 
   const rawCalls: ExtractedSymbols["rawCalls"] = [];
   const localToExportedName = new Map<string, string>();
+  const localToImportInfo = new Map<string, { sourceModule: string; importedName: string }>();
   const namespaceNames = new Set<string>();
+  const namespaceToModule = new Map<string, string>();
 
   // 1. Import statements: named imports (`import { X, Y as Z }`), type imports (`import type { T }`), default imports (`import D from ...`), namespace imports (`import * as NS from ...`)
   for (const imp of safeFindAll(root, "import_statement")) {
     const r = imp.range();
     const line = r.start.line + 1;
+    const sourceNode = imp.field("source") ?? safeFind(imp, "string");
+    const sourceModule = sourceNode ? sourceNode.text().replace(/^['"`]|['"`]$/g, "") : undefined;
 
     for (const spec of safeFindAll(imp, "import_specifier")) {
       const nameNode = spec.field("name") ?? safeFind(spec, "identifier");
@@ -933,10 +1022,17 @@ function extractFromTsLike(
       const aliasNode = spec.field("alias");
       const localName = aliasNode ? aliasNode.text() : originalName;
       localToExportedName.set(localName, originalName);
+      if (sourceModule) {
+        localToImportInfo.set(localName, { sourceModule, importedName: originalName });
+      }
 
       rawCalls.push({
         callerId: moduleSym.id,
         calleeName: originalName,
+        kind: "import",
+        sourceModule,
+        importedName: originalName,
+        localAlias: localName !== originalName ? localName : undefined,
         callSite: { file, line },
       });
     }
@@ -946,7 +1042,20 @@ function extractFromTsLike(
     if (nsNode) {
       const idNode = safeFind(nsNode, "identifier");
       if (idNode) {
-        namespaceNames.add(idNode.text());
+        const nsName = idNode.text();
+        namespaceNames.add(nsName);
+        if (sourceModule) {
+          namespaceToModule.set(nsName, sourceModule);
+        }
+        rawCalls.push({
+          callerId: moduleSym.id,
+          calleeName: nsName,
+          kind: "import",
+          sourceModule,
+          importedName: "*",
+          localAlias: nsName,
+          callSite: { file, line },
+        });
       }
     }
 
@@ -959,9 +1068,16 @@ function extractFromTsLike(
         if (k.kind() === "identifier") {
           const defaultName = k.text();
           localToExportedName.set(defaultName, defaultName);
+          if (sourceModule) {
+            localToImportInfo.set(defaultName, { sourceModule, importedName: "default" });
+          }
           rawCalls.push({
             callerId: moduleSym.id,
             calleeName: defaultName,
+            kind: "import",
+            sourceModule,
+            importedName: "default",
+            localAlias: defaultName,
             callSite: { file, line },
           });
         }
@@ -973,6 +1089,21 @@ function extractFromTsLike(
   for (const exp of safeFindAll(root, "export_statement")) {
     const r = exp.range();
     const line = r.start.line + 1;
+    const sourceNode = exp.field("source") ?? safeFind(exp, "string");
+    const sourceModule = sourceNode ? sourceNode.text().replace(/^['"`]|['"`]$/g, "") : undefined;
+
+    const expText = exp.text();
+    if (sourceModule && /export\s+\*\s+from/.test(expText)) {
+      rawCalls.push({
+        callerId: moduleSym.id,
+        calleeName: "*",
+        kind: "reexport",
+        sourceModule,
+        importedName: "*",
+        callSite: { file, line },
+      });
+    }
+
     for (const spec of safeFindAll(exp, "export_specifier")) {
       const nameNode = spec.field("name") ?? safeFind(spec, "identifier");
       if (!nameNode) continue;
@@ -983,26 +1114,39 @@ function extractFromTsLike(
       rawCalls.push({
         callerId: moduleSym.id,
         calleeName: expName,
+        kind: "reexport",
+        sourceModule,
+        importedName: expName,
+        localAlias: localName !== expName ? localName : undefined,
         callSite: { file, line },
       });
     }
   }
 
-  // 3. Call sites
-  for (const node of safeFindAll(root, "call_expression")) {
-    let calleeName = extractCalleeNameJs(node.text());
-    if (!calleeName) continue;
-    const mapped = localToExportedName.get(calleeName);
-    if (mapped) {
-      calleeName = mapped;
+  // 3. Call sites and instantiations
+  for (const k of ["call_expression", "new_expression"]) {
+    for (const node of safeFindAll(root, k)) {
+      let calleeName = extractCalleeNameJs(node.text());
+      if (!calleeName) continue;
+      const impInfo = localToImportInfo.get(calleeName);
+      const mapped = localToExportedName.get(calleeName);
+      const localAlias = mapped && mapped !== calleeName ? calleeName : undefined;
+      if (mapped) {
+        calleeName = mapped;
+      }
+      const r = node.range();
+      const callLine = r.start.line + 1;
+      const callerId = findCallerId(scopes, callLine, moduleSym.id);
+      rawCalls.push({
+        callerId,
+        calleeName,
+        kind: "call",
+        sourceModule: impInfo?.sourceModule,
+        importedName: impInfo?.importedName,
+        localAlias,
+        callSite: { file, line: callLine },
+      });
     }
-    const r = node.range();
-    const callLine = r.start.line + 1;
-    const callerId = findCallerId(scopes, callLine, moduleSym.id);
-    rawCalls.push({
-      callerId, calleeName,
-      callSite: { file, line: callLine },
-    });
   }
 
   // 4. Type references (type annotations, type arguments, implements, extends)
@@ -1025,7 +1169,9 @@ function extractFromTsLike(
     const r = node.range();
     const line = r.start.line + 1;
     if (declaredNamesAndLines.has(`${name}#${line}`)) continue;
+    const impInfo = localToImportInfo.get(name);
     const mapped = localToExportedName.get(name);
+    const localAlias = mapped && mapped !== name ? name : undefined;
     if (mapped) {
       name = mapped;
     }
@@ -1033,6 +1179,10 @@ function extractFromTsLike(
     rawCalls.push({
       callerId,
       calleeName: name,
+      kind: "type_reference",
+      sourceModule: impInfo?.sourceModule,
+      importedName: impInfo?.importedName,
+      localAlias,
       callSite: { file, line },
     });
   }
@@ -1043,13 +1193,18 @@ function extractFromTsLike(
       const objNode = node.field("object");
       const propNode = node.field("property");
       if (objNode && propNode && namespaceNames.has(objNode.text())) {
+        const objText = objNode.text();
         const propName = propNode.text();
+        const sourceModule = namespaceToModule.get(objText);
         const r = node.range();
         const line = r.start.line + 1;
         const callerId = findCallerId(scopes, line, moduleSym.id);
         rawCalls.push({
           callerId,
           calleeName: propName,
+          kind: "value_reference",
+          sourceModule,
+          importedName: propName,
           callSite: { file, line },
         });
       }
@@ -1068,10 +1223,15 @@ function extractFromTsLike(
       if (parentKind === "import_specifier" || parentKind === "import_clause" || parentKind === "export_specifier") {
         continue;
       }
+      const impInfo = localToImportInfo.get(localName);
       const callerId = findCallerId(scopes, line, moduleSym.id);
       rawCalls.push({
         callerId,
         calleeName: originalName,
+        kind: "value_reference",
+        sourceModule: impInfo?.sourceModule,
+        importedName: impInfo?.importedName,
+        localAlias: localName !== originalName ? localName : undefined,
         callSite: { file, line },
       });
     }
@@ -1080,10 +1240,11 @@ function extractFromTsLike(
   return { symbols, rawCalls };
 }
 
-/** Pull the callee's bare name from the start of a call expression's text. */
+/** Pull the callee's bare name from the start of a call/new expression's text. */
 function extractCalleeNameJs(text: string): string | null {
+  const cleaned = text.replace(/^\s*new\s+/, "");
   // `foo(...)` → "foo"  ;  `obj.foo(...)` → "foo"  ;  `obj.bar.foo(...)` → "foo"
-  const m = text.match(/^([\w$.]+)\s*\(/);
+  const m = cleaned.match(/^([\w$.]+)\s*(?:\(|$)/);
   if (!m) return null;
   const chain = m[1];
   const parts = chain.split(".");
@@ -1221,6 +1382,7 @@ function extractFromPython(
     rawCalls.push({
       callerId: findCallerId(scopes, callLine, moduleSym.id),
       calleeName,
+      kind: "call",
       callSite: { file, line: callLine },
     });
   }
@@ -1276,7 +1438,9 @@ function extractFromGo(
     const callLine = r.start.line + 1;
     rawCalls.push({
       callerId: findCallerId(scopes, callLine, moduleSym.id),
-      calleeName, callSite: { file, line: callLine },
+      calleeName,
+      kind: "call",
+      callSite: { file, line: callLine },
     });
   }
   return { symbols, rawCalls };
@@ -1317,7 +1481,9 @@ function extractFromRust(
     const callLine = r.start.line + 1;
     rawCalls.push({
       callerId: findCallerId(scopes, callLine, moduleSym.id),
-      calleeName, callSite: { file, line: callLine },
+      calleeName,
+      kind: "call",
+      callSite: { file, line: callLine },
     });
   }
   for (const node of safeFindAll(root, "macro_invocation")) {
@@ -1327,7 +1493,9 @@ function extractFromRust(
     const callLine = r.start.line + 1;
     rawCalls.push({
       callerId: findCallerId(scopes, callLine, moduleSym.id),
-      calleeName: nameNode.text(), callSite: { file, line: callLine },
+      calleeName: nameNode.text(),
+      kind: "call",
+      callSite: { file, line: callLine },
     });
   }
   return { symbols, rawCalls };
@@ -1403,7 +1571,9 @@ function extractFromJvm(
       const callLine = r.start.line + 1;
       rawCalls.push({
         callerId: findCallerId(scopes, callLine, moduleSym.id),
-        calleeName, callSite: { file, line: callLine },
+        calleeName,
+        kind: "call",
+        callSite: { file, line: callLine },
       });
     }
   }
@@ -1500,7 +1670,9 @@ function extractFromCSharp(
     const callLine = r.start.line + 1;
     rawCalls.push({
       callerId: findCallerId(scopes, callLine, moduleSym.id),
-      calleeName, callSite: { file, line: callLine },
+      calleeName,
+      kind: "call",
+      callSite: { file, line: callLine },
     });
   }
   return { symbols, rawCalls };
@@ -1568,7 +1740,9 @@ function extractFromCFamily(
     const callLine = r.start.line + 1;
     rawCalls.push({
       callerId: findCallerId(scopes, callLine, moduleSym.id),
-      calleeName, callSite: { file, line: callLine },
+      calleeName,
+      kind: "call",
+      callSite: { file, line: callLine },
     });
   }
   return { symbols, rawCalls };
@@ -1623,15 +1797,6 @@ function extractFromRuby(
 
   const rawCalls: ExtractedSymbols["rawCalls"] = [];
   for (const node of safeFindAll(root, "call")) {
-    // Ask the grammar, not the text. tree-sitter-ruby's `call` node carries the
-    // callee in its `method` field for every call shape — parenthesised or not,
-    // command style (`has_many :posts`), safe navigation (`a&.b`), block calls,
-    // and each link of a fluent chain as its own node. The previous
-    // extractCalleeNameJs(text) parse required a `(` before the name, so every
-    // parenthesis-less call — the dominant Ruby idiom — was silently dropped
-    // and Ruby files contributed almost no call edges. (A bare receiverless,
-    // argumentless `helper` parses as a plain identifier, indistinguishable
-    // from a variable read, so it is not a `call` node and stays out.)
     const methodNode = node.field("method");
     const calleeName = methodNode ? methodNode.text() : extractCalleeNameJs(node.text());
     if (!calleeName) continue;
@@ -1639,7 +1804,9 @@ function extractFromRuby(
     const callLine = r.start.line + 1;
     rawCalls.push({
       callerId: findCallerId(scopes, callLine, moduleSym.id),
-      calleeName, callSite: { file, line: callLine },
+      calleeName,
+      kind: "call",
+      callSite: { file, line: callLine },
     });
   }
   return { symbols, rawCalls };
@@ -1703,7 +1870,9 @@ function extractFromPhp(
       const callLine = r.start.line + 1;
       rawCalls.push({
         callerId: findCallerId(scopes, callLine, moduleSym.id),
-        calleeName, callSite: { file, line: callLine },
+        calleeName,
+        kind: "call",
+        callSite: { file, line: callLine },
       });
     }
   }
@@ -1768,7 +1937,9 @@ function extractFromSwift(
     const callLine = r.start.line + 1;
     rawCalls.push({
       callerId: findCallerId(scopes, callLine, moduleSym.id),
-      calleeName, callSite: { file, line: callLine },
+      calleeName,
+      kind: "call",
+      callSite: { file, line: callLine },
     });
   }
   return { symbols, rawCalls };
@@ -1812,7 +1983,9 @@ function extractFromBash(
     const callLine = r.start.line + 1;
     rawCalls.push({
       callerId: findCallerId(scopes, callLine, moduleSym.id),
-      calleeName: name, callSite: { file, line: callLine },
+      calleeName: name,
+      kind: "call",
+      callSite: { file, line: callLine },
     });
   }
   return { symbols, rawCalls };
@@ -1869,8 +2042,10 @@ function extractFromRegex(
         const callLine = i + 1;
         rawCalls.push({
           callerId: findCallerId(scopes, callLine, moduleSym.id),
-        calleeName: name, callSite: { file, line: callLine },
-      });
+          calleeName: name,
+          kind: "call",
+          callSite: { file, line: callLine },
+        });
       }
       m = callRegex.exec(lines[i]);
     }
@@ -1887,6 +2062,10 @@ export function rawCallsToUnresolvedEdges(
     calleeName: c.calleeName,
     calleeCandidates: [],
     confidence: "unresolved" as const,
+    kind: c.kind,
+    sourceModule: c.sourceModule,
+    importedName: c.importedName,
+    localAlias: c.localAlias,
     callSite: c.callSite,
   }));
 }

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -804,8 +804,9 @@ function extractFromTsLike(
     if (!node) return new Set();
     const range = node.range?.();
     const cacheKey = range ? `${node.kind?.()}:${range.start.index}:${range.end.index}` : "";
-    if (cacheKey && declaredBindingsCache.has(cacheKey)) {
-      return declaredBindingsCache.get(cacheKey)!;
+    if (cacheKey) {
+      const cached = declaredBindingsCache.get(cacheKey);
+      if (cached) return cached;
     }
 
     const bound = new Set<string>();

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -48,6 +48,10 @@ function extractBindingIdentifiers(node: any): Array<{ name: string; node: any }
     const left = node.field?.("left") ?? node.children?.()[0];
     return extractBindingIdentifiers(left);
   }
+  if (kind === "required_parameter" || kind === "optional_parameter") {
+    const pat = node.field?.("pattern") ?? node.children?.()[0];
+    return extractBindingIdentifiers(pat);
+  }
   if (kind === "rest_pattern") {
     const kids = node.children?.() ?? [];
     for (const k of kids) {
@@ -791,6 +795,23 @@ function extractFromTsLike(
   const root = parse(lang, source).root();
   const symbols: SymbolNode[] = [moduleSym];
   const scopes: ScopeFrame[] = [];
+  const scopeLocalNames = new Map<string, Set<string>>();
+
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  function recordScopeParams(node: any, symbolId: string) {
+    const params = node.field?.("parameters") ?? safeFind(node, "formal_parameters");
+    if (!params) return;
+    let set = scopeLocalNames.get(symbolId);
+    if (!set) {
+      set = new Set<string>();
+      scopeLocalNames.set(symbolId, set);
+    }
+    for (const child of params.children?.() ?? []) {
+      for (const b of extractBindingIdentifiers(child)) {
+        set.add(b.name);
+      }
+    }
+  }
 
   // Class declarations
   for (const node of safeFindAll(root, "class_declaration")) {
@@ -838,6 +859,7 @@ function extractFromTsLike(
       };
       symbols.push(msym);
       scopes.push({ name: qname, startLine: mStart, endLine: mEnd, symbolId: msym.id });
+      recordScopeParams(m, msym.id);
     }
   }
 
@@ -859,6 +881,7 @@ function extractFromTsLike(
     };
     symbols.push(sym);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
+    recordScopeParams(node, sym.id);
   }
 
   // Generator function declarations
@@ -875,6 +898,7 @@ function extractFromTsLike(
     };
     symbols.push(sym);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
+    recordScopeParams(node, sym.id);
   }
 
   // Interface declarations (TS / TSX)
@@ -999,6 +1023,18 @@ function extractFromTsLike(
   for (const s of symbols) {
     if (s.name !== "<module>") {
       declaredNamesAndLines.add(`${s.name}#${s.line}`);
+      if (s.kind === "variable") {
+        for (const sc of scopes) {
+          if (sc.symbolId !== s.id && s.line >= sc.startLine && s.endLine <= sc.endLine) {
+            let set = scopeLocalNames.get(sc.symbolId);
+            if (!set) {
+              set = new Set<string>();
+              scopeLocalNames.set(sc.symbolId, set);
+            }
+            set.add(s.name);
+          }
+        }
+      }
     }
   }
 
@@ -1095,12 +1131,13 @@ function extractFromTsLike(
     const expText = exp.text();
     const starReexport = expText.match(/export\s+\*(?:\s+as\s+([\w$]+))?\s+from/);
     if (sourceModule && starReexport) {
+      const isNamespace = Boolean(starReexport[1]);
       rawCalls.push({
         callerId: moduleSym.id,
         calleeName: starReexport[1] ?? "*",
         kind: "reexport",
         sourceModule,
-        importedName: "*",
+        importedName: isNamespace ? undefined : "*",
         localAlias: starReexport[1],
         callSite: { file, line },
       });
@@ -1222,13 +1259,49 @@ function extractFromTsLike(
       const r = idNode.range();
       const line = r.start.line + 1;
       if (declaredNamesAndLines.has(`${localName}#${line}`)) continue;
-      const parentKind = idNode.parent()?.kind?.();
+      const parent = idNode.parent();
+      const parentKind = parent?.kind?.();
       // Skip import_specifier / import_clause / export_specifier definition sites themselves
       if (parentKind === "import_specifier" || parentKind === "import_clause" || parentKind === "export_specifier") {
         continue;
       }
-      const impInfo = localToImportInfo.get(localName);
+      // Skip non-computed member property access (e.g. obj.foo)
+      if (parentKind === "member_expression") {
+        const prop = parent?.field?.("property");
+        if (prop && prop.range().start.index === r.start.index) {
+          continue;
+        }
+      }
+      // Skip object literal keys (e.g. { foo: 1 })
+      if (parentKind === "pair") {
+        const key = parent?.field?.("key");
+        if (key && key.range().start.index === r.start.index) {
+          continue;
+        }
+      }
+      // Skip property or method definitions
+      if (parentKind === "property_signature" || parentKind === "method_definition" || parentKind === "field_definition") {
+        continue;
+      }
+      // Skip direct invocation sites already recorded as calls
+      if (parentKind === "call_expression") {
+        const fn = parent?.field?.("function");
+        if (fn && fn.range().start.index === r.start.index) {
+          continue;
+        }
+      }
+      if (parentKind === "new_expression") {
+        const ctor = parent?.field?.("constructor");
+        if (ctor && ctor.range().start.index === r.start.index) {
+          continue;
+        }
+      }
       const callerId = findCallerId(scopes, line, moduleSym.id);
+      // Skip if shadowed by local parameter or variable in this scope
+      if (callerId !== moduleSym.id && scopeLocalNames.get(callerId)?.has(localName)) {
+        continue;
+      }
+      const impInfo = localToImportInfo.get(localName);
       rawCalls.push({
         callerId,
         calleeName: originalName,

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -49,18 +49,9 @@ import {
   saveProjectMetadata,
   upsertPreEmbeddedChunks,
 } from "./qdrant.js";
-import { updateChangedFilesSymbolGraph } from "./symbol-graph-incremental.js";
-import { loadSymbolGraphMeta } from "./symbol-graph-store.js";
 
 export const FILE_SCAN_BATCH = 50; // Number of files to scan/chunk in parallel (I/O only, no network)
 
-/**
- * Phase F: maximum number of changed/removed files for which the watcher path
- * patches the symbol graph in-place rather than rebuilding it from scratch.
- * Above this threshold a full rebuild is faster than re-running per-file
- * extraction + shard merging, since most shards would be touched anyway.
- */
-const INCREMENTAL_SYMBOL_THRESHOLD = 50;
 
 /** State for tracking indexed files per project (loaded from Qdrant on first use) */
 const projectHashes = new Map<string, Map<string, string>>();
@@ -1455,58 +1446,20 @@ export async function updateProjectIndex(
 
   // Auto-rebuild code graph if any files changed (Phase F).
   //
-  // Strategy:
-  //   - If a symbol-graph already exists AND the change set is small
-  //     (≤ INCREMENTAL_SYMBOL_THRESHOLD files), do a fast file-import-graph
-  //     rebuild then patch the symbol graph per-file via
-  //     `updateChangedFilesSymbolGraph`.
-  //   - Otherwise fall back to a full `rebuildGraph()` that also rebuilds
-  //     the symbol graph end-to-end.
+  // While every changed or removed file requires a complete symbol-graph rebuild,
+  // bypass the incremental branch and perform one complete graph rebuild.
   if (added > 0 || updated > 0 || removed > 0) {
     progress.phase = "building code graph";
-    const projectId = projectIdFromPath(resolvedPath);
     const totalChanged = changedFiles.length + removedRelPaths.length;
-    const meta = await loadSymbolGraphMeta(projectId).catch(() => null);
-    const useIncremental = meta !== null && totalChanged <= INCREMENTAL_SYMBOL_THRESHOLD;
 
     try {
       onProgress?.(
-        useIncremental
-          ? `Building file graph + incrementally updating ${totalChanged} symbol payload(s)...`
+        totalChanged > 0
+          ? `Building code dependency graph (${totalChanged} file(s) changed, full rebuild)...`
           : "Building code dependency graph (full rebuild)...",
       );
-      const graph = await rebuildGraph(resolvedPath, { skipSymbolGraph: useIncremental });
+      const graph = await rebuildGraph(resolvedPath, { skipSymbolGraph: false });
       onProgress?.(`Code graph built: ${graph.nodes.length} files, ${graph.edges.length} edges`);
-
-      if (useIncremental) {
-        try {
-          const result = await updateChangedFilesSymbolGraph(
-            projectId,
-            resolvedPath,
-            graph,
-            changedFiles.map((f) => f.relativePath),
-            removedRelPaths,
-          );
-          if (result.fullRebuildRequired) {
-            // Meta vanished between checks — fall back to a full symbol rebuild.
-            onProgress?.("Symbol graph meta missing — falling back to full rebuild");
-            await rebuildGraph(resolvedPath, { skipSymbolGraph: false });
-          } else {
-            onProgress?.(
-              `Symbol graph patched: +${result.symbolsDelta} symbols, ` +
-                `+${result.edgesDelta} edges (${result.filesChanged} changed, ${result.filesRemoved} removed)`,
-            );
-          }
-        } catch (incErr) {
-          // Last-resort fallback: full rebuild. Never let watcher fail.
-          const incMsg = incErr instanceof Error ? incErr.message : String(incErr);
-          logger.warn("Incremental symbol-graph update failed; falling back to full rebuild", {
-            projectPath: resolvedPath,
-            error: incMsg,
-          });
-          await rebuildGraph(resolvedPath, { skipSymbolGraph: false });
-        }
-      }
     } catch (graphErr) {
       const graphMsg = graphErr instanceof Error ? graphErr.message : String(graphErr);
       logger.warn("Code graph build failed during incremental update (non-fatal)", { projectPath: resolvedPath, error: graphMsg });

--- a/src/services/startup.ts
+++ b/src/services/startup.ts
@@ -17,6 +17,7 @@ import { getIndexingInProgressProjects, getPersistedIndexingStatus, indexProject
 import { getLockHolderPid, releaseAllLocks } from "./lock.js";
 import { logger } from "./logger.js";
 import { getProjectMetadata, listCodebaseCollections } from "./qdrant.js";
+import { cleanStaleGenerations, loadSymbolGraphMeta } from "./symbol-graph-store.js";
 import { isWatching, startWatching, stopAllWatchers } from "./watcher.js";
 
 /**
@@ -308,6 +309,16 @@ async function resumeProject(
       projectPath: resolvedPath,
       error: err instanceof Error ? err.message : String(err),
     });
+  }
+
+  // Retire any abandoned or superseded symbol graph generations left from previous sessions
+  try {
+    const meta = await loadSymbolGraphMeta(projectId);
+    if (meta?.generation) {
+      await cleanStaleGenerations(projectId, meta.generation);
+    }
+  } catch {
+    // Non-fatal
   }
 }
 

--- a/src/services/startup.ts
+++ b/src/services/startup.ts
@@ -12,6 +12,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { collectionName, projectIdFromPath } from "../config.js";
 import { QDRANT_COLLECTION_PREFIX, QDRANT_MODE } from "../constants.js";
+import { isGraphBuildInProgress } from "./code-graph.js";
 import { isDockerAvailable, isQdrantRunning } from "./docker.js";
 import { getIndexingInProgressProjects, getPersistedIndexingStatus, indexProject, requestCancellation, updateProjectIndex } from "./indexer.js";
 import { getLockHolderPid, releaseAllLocks } from "./lock.js";
@@ -311,14 +312,17 @@ async function resumeProject(
     });
   }
 
-  // Retire any abandoned or superseded symbol graph generations left from previous sessions
-  try {
-    const meta = await loadSymbolGraphMeta(projectId);
-    if (meta?.generation) {
-      await cleanStaleGenerations(projectId, meta.generation);
+  // Retire any abandoned or superseded symbol graph generations left from previous sessions,
+  // excluding any project currently undergoing a graph rebuild
+  if (!isGraphBuildInProgress(resolvedPath)) {
+    try {
+      const meta = await loadSymbolGraphMeta(projectId);
+      if (meta?.generation) {
+        await cleanStaleGenerations(projectId, meta.generation);
+      }
+    } catch {
+      // Non-fatal
     }
-  } catch {
-    // Non-fatal
   }
 }
 

--- a/src/services/startup.ts
+++ b/src/services/startup.ts
@@ -18,7 +18,7 @@ import { getIndexingInProgressProjects, getPersistedIndexingStatus, indexProject
 import { getLockHolderPid, releaseAllLocks } from "./lock.js";
 import { logger } from "./logger.js";
 import { getProjectMetadata, listCodebaseCollections } from "./qdrant.js";
-import { cleanStaleGenerations, loadSymbolGraphMeta } from "./symbol-graph-store.js";
+import { cleanStaleGenerations, coordinateProject, loadSymbolGraphMeta } from "./symbol-graph-store.js";
 import { isWatching, startWatching, stopAllWatchers } from "./watcher.js";
 
 /**
@@ -313,13 +313,15 @@ async function resumeProject(
   }
 
   // Retire any abandoned or superseded symbol graph generations left from previous sessions,
-  // excluding any project currently undergoing a graph rebuild
+  // coordinated per project with any active or upcoming graph rebuild
   if (!isGraphBuildInProgress(resolvedPath)) {
     try {
-      const meta = await loadSymbolGraphMeta(projectId);
-      if (meta?.generation) {
-        await cleanStaleGenerations(projectId, meta.generation);
-      }
+      await coordinateProject(projectId, async () => {
+        const meta = await loadSymbolGraphMeta(projectId);
+        if (meta?.generation) {
+          await cleanStaleGenerations(projectId, meta.generation);
+        }
+      });
     } catch {
       // Non-fatal
     }

--- a/src/services/symbol-graph-cache.ts
+++ b/src/services/symbol-graph-cache.ts
@@ -23,6 +23,7 @@ import type {
 import { logger } from "./logger.js";
 import {
   allNameShardKeys,
+  LEGACY_SYMBOL_GRAPH_GENERATION,
   loadFilePayload,
   loadNameShard,
   loadReverseShard,
@@ -30,6 +31,7 @@ import {
   releaseReader,
   resetGenerationLifecycleState,
   retainReader,
+  setActiveSymbolGraphGeneration,
 } from "./symbol-graph-store.js";
 
 // ── Tiny LRU (handwritten, ~20 lines) ────────────────────────────────────
@@ -121,14 +123,18 @@ export class SymbolGraphCache {
    * While any reader lease is held, the generation backing this cache cannot be cleaned up.
    */
   acquireReader(): () => void {
+    const generation = this.meta.generation ?? LEGACY_SYMBOL_GRAPH_GENERATION;
+    // Once another generation is active, a new query may not start on this
+    // cache. Nested reads belonging to a lease already held by this cache are
+    // allowed so an in-flight query can finish against one stable generation.
+    retainReader(this.projectId, generation, this.activeReaders > 0);
     this.activeReaders++;
-    retainReader(this.projectId, this.meta.generation);
     let released = false;
     return () => {
       if (released) return;
       released = true;
       this.activeReaders--;
-      releaseReader(this.projectId, this.meta.generation);
+      releaseReader(this.projectId, generation);
     };
   }
 
@@ -144,7 +150,11 @@ export class SymbolGraphCache {
       const merged = new Map<string, SymbolRef[]>();
       const shardKeys = allNameShardKeys();
       const shards = await Promise.all(
-        shardKeys.map((k) => loadNameShard(this.projectId, k, this.meta.generation)),
+        shardKeys.map((k) => loadNameShard(
+          this.projectId,
+          k,
+          this.meta.generation ?? LEGACY_SYMBOL_GRAPH_GENERATION,
+        )),
       );
       for (const shard of shards) {
         if (!shard) continue;
@@ -174,7 +184,11 @@ export class SymbolGraphCache {
       const buckets: number[] = [];
       for (let i = 0; i < SYMBOL_REVERSE_SHARDS; i++) buckets.push(i);
       const shards = await Promise.all(
-        buckets.map((b) => loadReverseShard(this.projectId, b, this.meta.generation)),
+        buckets.map((b) => loadReverseShard(
+          this.projectId,
+          b,
+          this.meta.generation ?? LEGACY_SYMBOL_GRAPH_GENERATION,
+        )),
       );
       for (const shard of shards) {
         if (!shard) continue;
@@ -232,7 +246,11 @@ export class SymbolGraphCache {
     this.stats.fileLruMisses++;
     const release = this.acquireReader();
     try {
-      const payload = await loadFilePayload(this.projectId, relativePath, this.meta.generation);
+      const payload = await loadFilePayload(
+        this.projectId,
+        relativePath,
+        this.meta.generation ?? LEGACY_SYMBOL_GRAPH_GENERATION,
+      );
       if (payload) this.fileDataLru.set(relativePath, payload);
       this.stats.fileLruSize = this.fileDataLru.size;
       return payload;
@@ -332,6 +350,7 @@ export async function getSymbolGraphCache(
     const meta = await loadSymbolGraphMeta(projectId);
     if (!meta) return null;
     const cache = new SymbolGraphCache(projectId, meta);
+    setActiveSymbolGraphGeneration(projectId, meta.generation);
     cacheRegistry.set(projectId, cache);
     return cache;
   })();
@@ -346,7 +365,22 @@ export async function getSymbolGraphCache(
 
 /** Replace (or insert) the cache for a project — used after a fresh rebuild. */
 export function setSymbolGraphCache(cache: SymbolGraphCache): void {
+  setActiveSymbolGraphGeneration(cache.projectId, cache.meta.generation);
   cacheRegistry.set(cache.projectId, cache);
+}
+
+/** Remove a cached generation only if it is still the registry entry. */
+export function dropSymbolGraphCacheGeneration(
+  projectId: string,
+  generation?: string,
+): void {
+  const cached = cacheRegistry.get(projectId);
+  if (
+    cached
+    && (cached.meta.generation ?? LEGACY_SYMBOL_GRAPH_GENERATION) === generation
+  ) {
+    cacheRegistry.delete(projectId);
+  }
 }
 
 /** Remove a project's cache from the registry. */

--- a/src/services/symbol-graph-cache.ts
+++ b/src/services/symbol-graph-cache.ts
@@ -139,50 +139,60 @@ export class SymbolGraphCache {
   /** Get the full name index, loading all shards on first access. */
   async getNameIndex(): Promise<Map<string, SymbolRef[]>> {
     if (this.nameIndex) return this.nameIndex;
-    const merged = new Map<string, SymbolRef[]>();
-    const shardKeys = allNameShardKeys();
-    const shards = await Promise.all(
-      shardKeys.map((k) => loadNameShard(this.projectId, k, this.meta.generation)),
-    );
-    for (const shard of shards) {
-      if (!shard) continue;
-      for (const [name, refs] of Object.entries(shard)) {
-        const existing = merged.get(name);
-        if (existing) {
-          existing.push(...refs);
-        } else {
-          merged.set(name, [...refs]);
+    const release = this.acquireReader();
+    try {
+      const merged = new Map<string, SymbolRef[]>();
+      const shardKeys = allNameShardKeys();
+      const shards = await Promise.all(
+        shardKeys.map((k) => loadNameShard(this.projectId, k, this.meta.generation)),
+      );
+      for (const shard of shards) {
+        if (!shard) continue;
+        for (const [name, refs] of Object.entries(shard)) {
+          const existing = merged.get(name);
+          if (existing) {
+            existing.push(...refs);
+          } else {
+            merged.set(name, [...refs]);
+          }
         }
       }
+      this.nameIndex = merged;
+      this.stats.nameIndexLoaded = true;
+      return merged;
+    } finally {
+      release();
     }
-    this.nameIndex = merged;
-    this.stats.nameIndexLoaded = true;
-    return merged;
   }
 
   /** Get the full reverse symbol index (calleeSymbolId -> Set<callerSymbolId>), loading all shards on first access. */
   async getReverseSymbolIndex(): Promise<Map<string, Set<string>>> {
     if (this.reverseSymbolIndex) return this.reverseSymbolIndex;
-    const merged = new Map<string, Set<string>>();
-    const buckets: number[] = [];
-    for (let i = 0; i < SYMBOL_REVERSE_SHARDS; i++) buckets.push(i);
-    const shards = await Promise.all(
-      buckets.map((b) => loadReverseShard(this.projectId, b, this.meta.generation)),
-    );
-    for (const shard of shards) {
-      if (!shard) continue;
-      for (const [calleeKey, callerList] of Object.entries(shard)) {
-        const existing = merged.get(calleeKey);
-        if (existing) {
-          for (const f of callerList) existing.add(f);
-        } else {
-          merged.set(calleeKey, new Set(callerList));
+    const release = this.acquireReader();
+    try {
+      const merged = new Map<string, Set<string>>();
+      const buckets: number[] = [];
+      for (let i = 0; i < SYMBOL_REVERSE_SHARDS; i++) buckets.push(i);
+      const shards = await Promise.all(
+        buckets.map((b) => loadReverseShard(this.projectId, b, this.meta.generation)),
+      );
+      for (const shard of shards) {
+        if (!shard) continue;
+        for (const [calleeKey, callerList] of Object.entries(shard)) {
+          const existing = merged.get(calleeKey);
+          if (existing) {
+            for (const f of callerList) existing.add(f);
+          } else {
+            merged.set(calleeKey, new Set(callerList));
+          }
         }
       }
+      this.reverseSymbolIndex = merged;
+      this.stats.reverseIndexLoaded = true;
+      return merged;
+    } finally {
+      release();
     }
-    this.reverseSymbolIndex = merged;
-    this.stats.reverseIndexLoaded = true;
-    return merged;
   }
 
   /** Get the full reverse-call file index, derived from reverseSymbolIndex. */

--- a/src/services/symbol-graph-cache.ts
+++ b/src/services/symbol-graph-cache.ts
@@ -88,6 +88,11 @@ export interface SymbolGraphCacheStats {
   reverseIndexLoaded: boolean;
 }
 
+export type SymbolGraphReaderToken = symbol;
+export type SymbolGraphReaderRelease = (() => void) & {
+  readonly token: SymbolGraphReaderToken;
+};
+
 export class SymbolGraphCache {
   meta: SymbolGraphMeta;
   /** name → list of symbol refs (lazy-loaded as a whole) */
@@ -108,6 +113,7 @@ export class SymbolGraphCache {
   };
 
   private activeReaders = 0;
+  private readonly activeReaderTokens = new Map<SymbolGraphReaderToken, number>();
 
   constructor(
     public readonly projectId: string,
@@ -122,20 +128,33 @@ export class SymbolGraphCache {
    * Acquire a reader lease for this cache instance.
    * While any reader lease is held, the generation backing this cache cannot be cleaned up.
    */
-  acquireReader(): () => void {
+  acquireReader(
+    operationToken?: SymbolGraphReaderToken,
+  ): SymbolGraphReaderRelease {
     const generation = this.meta.generation ?? LEGACY_SYMBOL_GRAPH_GENERATION;
-    // Once another generation is active, a new query may not start on this
-    // cache. Nested reads belonging to a lease already held by this cache are
-    // allowed so an in-flight query can finish against one stable generation.
-    retainReader(this.projectId, generation, this.activeReaders > 0);
+    const continuesOwnedOperation = operationToken !== undefined
+      && this.activeReaderTokens.has(operationToken);
+    const token = continuesOwnedOperation ? operationToken : Symbol("symbol-graph-reader");
+
+    // Once another generation is active, only nested reads carrying the token
+    // of an operation already holding this cache may continue. An unrelated
+    // request cannot borrow another request's lease merely because the cache
+    // has active readers.
+    retainReader(this.projectId, generation, continuesOwnedOperation);
     this.activeReaders++;
+    this.activeReaderTokens.set(token, (this.activeReaderTokens.get(token) ?? 0) + 1);
     let released = false;
-    return () => {
+    const release = (() => {
       if (released) return;
       released = true;
       this.activeReaders--;
+      const tokenCount = (this.activeReaderTokens.get(token) ?? 1) - 1;
+      if (tokenCount <= 0) this.activeReaderTokens.delete(token);
+      else this.activeReaderTokens.set(token, tokenCount);
       releaseReader(this.projectId, generation);
-    };
+    }) as SymbolGraphReaderRelease;
+    Object.defineProperty(release, "token", { value: token });
+    return release;
   }
 
   get activeReaderCount(): number {
@@ -143,10 +162,12 @@ export class SymbolGraphCache {
   }
 
   /** Get the full name index, loading all shards on first access. */
-  async getNameIndex(): Promise<Map<string, SymbolRef[]>> {
-    if (this.nameIndex) return this.nameIndex;
-    const release = this.acquireReader();
+  async getNameIndex(
+    operationToken?: SymbolGraphReaderToken,
+  ): Promise<Map<string, SymbolRef[]>> {
+    const release = this.acquireReader(operationToken);
     try {
+      if (this.nameIndex) return this.nameIndex;
       const merged = new Map<string, SymbolRef[]>();
       const shardKeys = allNameShardKeys();
       const shards = await Promise.all(
@@ -176,10 +197,12 @@ export class SymbolGraphCache {
   }
 
   /** Get the full reverse symbol index (calleeSymbolId -> Set<callerSymbolId>), loading all shards on first access. */
-  async getReverseSymbolIndex(): Promise<Map<string, Set<string>>> {
-    if (this.reverseSymbolIndex) return this.reverseSymbolIndex;
-    const release = this.acquireReader();
+  async getReverseSymbolIndex(
+    operationToken?: SymbolGraphReaderToken,
+  ): Promise<Map<string, Set<string>>> {
+    const release = this.acquireReader(operationToken);
     try {
+      if (this.reverseSymbolIndex) return this.reverseSymbolIndex;
       const merged = new Map<string, Set<string>>();
       const buckets: number[] = [];
       for (let i = 0; i < SYMBOL_REVERSE_SHARDS; i++) buckets.push(i);
@@ -210,42 +233,50 @@ export class SymbolGraphCache {
   }
 
   /** Get the full reverse-call file index, derived from reverseSymbolIndex. */
-  async getReverseFileIndex(): Promise<Map<string, Set<string>>> {
-    if (this.reverseFileIndex) return this.reverseFileIndex;
-    const symIndex = await this.getReverseSymbolIndex();
-    const fileIndex = new Map<string, Set<string>>();
+  async getReverseFileIndex(
+    operationToken?: SymbolGraphReaderToken,
+  ): Promise<Map<string, Set<string>>> {
+    const release = this.acquireReader(operationToken);
+    try {
+      if (this.reverseFileIndex) return this.reverseFileIndex;
+      const symIndex = await this.getReverseSymbolIndex(release.token);
+      const fileIndex = new Map<string, Set<string>>();
 
-    for (const [calleeKey, callerList] of symIndex.entries()) {
-      const calleeFile = calleeKey.includes("::") ? calleeKey.split("::")[0] : calleeKey;
-      let callerSet = fileIndex.get(calleeFile);
-      if (!callerSet) {
-        callerSet = new Set<string>();
-        fileIndex.set(calleeFile, callerSet);
-      }
-      for (const callerId of callerList) {
-        const callerFile = callerId.includes("::") ? callerId.split("::")[0] : callerId;
-        if (callerFile !== calleeFile) {
-          callerSet.add(callerFile);
+      for (const [calleeKey, callerList] of symIndex.entries()) {
+        const calleeFile = calleeKey.includes("::") ? calleeKey.split("::")[0] : calleeKey;
+        let callerSet = fileIndex.get(calleeFile);
+        if (!callerSet) {
+          callerSet = new Set<string>();
+          fileIndex.set(calleeFile, callerSet);
+        }
+        for (const callerId of callerList) {
+          const callerFile = callerId.includes("::") ? callerId.split("::")[0] : callerId;
+          if (callerFile !== calleeFile) {
+            callerSet.add(callerFile);
+          }
         }
       }
-    }
 
-    this.reverseFileIndex = fileIndex;
-    return fileIndex;
+      this.reverseFileIndex = fileIndex;
+      return fileIndex;
+    } finally {
+      release();
+    }
   }
 
   /** Get a per-file payload, hitting the LRU first then Qdrant. */
   async getFilePayload(
     relativePath: string,
+    operationToken?: SymbolGraphReaderToken,
   ): Promise<SymbolGraphFilePayload | null> {
-    const cached = this.fileDataLru.get(relativePath);
-    if (cached) {
-      this.stats.fileLruHits++;
-      return cached;
-    }
-    this.stats.fileLruMisses++;
-    const release = this.acquireReader();
+    const release = this.acquireReader(operationToken);
     try {
+      const cached = this.fileDataLru.get(relativePath);
+      if (cached) {
+        this.stats.fileLruHits++;
+        return cached;
+      }
+      this.stats.fileLruMisses++;
       const payload = await loadFilePayload(
         this.projectId,
         relativePath,

--- a/src/services/symbol-graph-cache.ts
+++ b/src/services/symbol-graph-cache.ts
@@ -27,6 +27,9 @@ import {
   loadNameShard,
   loadReverseShard,
   loadSymbolGraphMeta,
+  releaseReader,
+  resetGenerationLifecycleState,
+  retainReader,
 } from "./symbol-graph-store.js";
 
 // ── Tiny LRU (handwritten, ~20 lines) ────────────────────────────────────
@@ -102,6 +105,8 @@ export class SymbolGraphCache {
     reverseIndexLoaded: false,
   };
 
+  private activeReaders = 0;
+
   constructor(
     public readonly projectId: string,
     meta: SymbolGraphMeta,
@@ -109,6 +114,26 @@ export class SymbolGraphCache {
   ) {
     this.meta = meta;
     this.fileDataLru = new LRUCache(lruCapacity);
+  }
+
+  /**
+   * Acquire a reader lease for this cache instance.
+   * While any reader lease is held, the generation backing this cache cannot be cleaned up.
+   */
+  acquireReader(): () => void {
+    this.activeReaders++;
+    retainReader(this.projectId, this.meta.generation);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.activeReaders--;
+      releaseReader(this.projectId, this.meta.generation);
+    };
+  }
+
+  get activeReaderCount(): number {
+    return this.activeReaders;
   }
 
   /** Get the full name index, loading all shards on first access. */
@@ -195,10 +220,15 @@ export class SymbolGraphCache {
       return cached;
     }
     this.stats.fileLruMisses++;
-    const payload = await loadFilePayload(this.projectId, relativePath, this.meta.generation);
-    if (payload) this.fileDataLru.set(relativePath, payload);
-    this.stats.fileLruSize = this.fileDataLru.size;
-    return payload;
+    const release = this.acquireReader();
+    try {
+      const payload = await loadFilePayload(this.projectId, relativePath, this.meta.generation);
+      if (payload) this.fileDataLru.set(relativePath, payload);
+      this.stats.fileLruSize = this.fileDataLru.size;
+      return payload;
+    } finally {
+      release();
+    }
   }
 
   /** Invalidate cached state for a file (called by watcher on file changes). */
@@ -317,5 +347,6 @@ export function dropSymbolGraphCache(projectId: string): void {
 /** Reset all caches (testing only). */
 export function resetSymbolGraphCacheRegistry(): void {
   cacheRegistry.clear();
+  resetGenerationLifecycleState();
   logger.debug("Symbol graph cache registry cleared");
 }

--- a/src/services/symbol-graph-cache.ts
+++ b/src/services/symbol-graph-cache.ts
@@ -87,7 +87,9 @@ export class SymbolGraphCache {
   meta: SymbolGraphMeta;
   /** name → list of symbol refs (lazy-loaded as a whole) */
   private nameIndex: Map<string, SymbolRef[]> | null = null;
-  /** calleeFile → set of caller files (lazy-loaded as a whole) */
+  /** calleeSymbolId → set of caller symbol IDs (lazy-loaded as a whole) */
+  private reverseSymbolIndex: Map<string, Set<string>> | null = null;
+  /** calleeFile → set of caller files (derived from reverseSymbolIndex) */
   private reverseFileIndex: Map<string, Set<string>> | null = null;
   /** lazy per-file payloads, LRU-bounded */
   fileDataLru: LRUCache<string, SymbolGraphFilePayload>;
@@ -133,9 +135,9 @@ export class SymbolGraphCache {
     return merged;
   }
 
-  /** Get the full reverse-call file index, loading all shards on first access. */
-  async getReverseFileIndex(): Promise<Map<string, Set<string>>> {
-    if (this.reverseFileIndex) return this.reverseFileIndex;
+  /** Get the full reverse symbol index (calleeSymbolId -> Set<callerSymbolId>), loading all shards on first access. */
+  async getReverseSymbolIndex(): Promise<Map<string, Set<string>>> {
+    if (this.reverseSymbolIndex) return this.reverseSymbolIndex;
     const merged = new Map<string, Set<string>>();
     const buckets: number[] = [];
     for (let i = 0; i < SYMBOL_REVERSE_SHARDS; i++) buckets.push(i);
@@ -144,18 +146,43 @@ export class SymbolGraphCache {
     );
     for (const shard of shards) {
       if (!shard) continue;
-      for (const [calleeFile, callerFiles] of Object.entries(shard)) {
-        const existing = merged.get(calleeFile);
+      for (const [calleeKey, callerList] of Object.entries(shard)) {
+        const existing = merged.get(calleeKey);
         if (existing) {
-          for (const f of callerFiles) existing.add(f);
+          for (const f of callerList) existing.add(f);
         } else {
-          merged.set(calleeFile, new Set(callerFiles));
+          merged.set(calleeKey, new Set(callerList));
         }
       }
     }
-    this.reverseFileIndex = merged;
+    this.reverseSymbolIndex = merged;
     this.stats.reverseIndexLoaded = true;
     return merged;
+  }
+
+  /** Get the full reverse-call file index, derived from reverseSymbolIndex. */
+  async getReverseFileIndex(): Promise<Map<string, Set<string>>> {
+    if (this.reverseFileIndex) return this.reverseFileIndex;
+    const symIndex = await this.getReverseSymbolIndex();
+    const fileIndex = new Map<string, Set<string>>();
+
+    for (const [calleeKey, callerList] of symIndex.entries()) {
+      const calleeFile = calleeKey.includes("::") ? calleeKey.split("::")[0] : calleeKey;
+      let callerSet = fileIndex.get(calleeFile);
+      if (!callerSet) {
+        callerSet = new Set<string>();
+        fileIndex.set(calleeFile, callerSet);
+      }
+      for (const callerId of callerList) {
+        const callerFile = callerId.includes("::") ? callerId.split("::")[0] : callerId;
+        if (callerFile !== calleeFile) {
+          callerSet.add(callerFile);
+        }
+      }
+    }
+
+    this.reverseFileIndex = fileIndex;
+    return fileIndex;
   }
 
   /** Get a per-file payload, hitting the LRU first then Qdrant. */
@@ -202,34 +229,31 @@ export class SymbolGraphCache {
     }
   }
 
-  /** Patch the in-memory reverse-file index for an updated file payload. */
+  /** Patch the in-memory reverse-symbol and reverse-file indices for an updated file payload. */
   patchReverseFileIndexForFile(
     oldPayload: SymbolGraphFilePayload | null,
     newPayload: SymbolGraphFilePayload,
   ): void {
-    if (!this.reverseFileIndex) return;
-    const callerFile = newPayload.file;
-    if (oldPayload) {
-      for (const e of oldPayload.outgoingCalls) {
+    if (this.reverseSymbolIndex) {
+      if (oldPayload) {
+        for (const e of oldPayload.outgoingCalls) {
+          for (const calleeId of e.calleeCandidates) {
+            const callers = this.reverseSymbolIndex.get(calleeId);
+            if (!callers) continue;
+            callers.delete(e.callerId);
+            if (callers.size === 0) this.reverseSymbolIndex.delete(calleeId);
+          }
+        }
+      }
+      for (const e of newPayload.outgoingCalls) {
         for (const calleeId of e.calleeCandidates) {
-          const calleeFile = symbolIdToFile(calleeId);
-          if (!calleeFile) continue;
-          const callers = this.reverseFileIndex.get(calleeFile);
-          if (!callers) continue;
-          callers.delete(callerFile);
-          if (callers.size === 0) this.reverseFileIndex.delete(calleeFile);
+          const callers = this.reverseSymbolIndex.get(calleeId);
+          if (callers) callers.add(e.callerId);
+          else this.reverseSymbolIndex.set(calleeId, new Set([e.callerId]));
         }
       }
     }
-    for (const e of newPayload.outgoingCalls) {
-      for (const calleeId of e.calleeCandidates) {
-        const calleeFile = symbolIdToFile(calleeId);
-        if (!calleeFile) continue;
-        const callers = this.reverseFileIndex.get(calleeFile);
-        if (callers) callers.add(callerFile);
-        else this.reverseFileIndex.set(calleeFile, new Set([callerFile]));
-      }
-    }
+    this.reverseFileIndex = null; // Re-derive lazily
   }
 
   /** Replace the cached payload for a file (used after rebuild of one file). */

--- a/src/services/symbol-graph-cache.ts
+++ b/src/services/symbol-graph-cache.ts
@@ -117,7 +117,7 @@ export class SymbolGraphCache {
     const merged = new Map<string, SymbolRef[]>();
     const shardKeys = allNameShardKeys();
     const shards = await Promise.all(
-      shardKeys.map((k) => loadNameShard(this.projectId, k)),
+      shardKeys.map((k) => loadNameShard(this.projectId, k, this.meta.generation)),
     );
     for (const shard of shards) {
       if (!shard) continue;
@@ -142,7 +142,7 @@ export class SymbolGraphCache {
     const buckets: number[] = [];
     for (let i = 0; i < SYMBOL_REVERSE_SHARDS; i++) buckets.push(i);
     const shards = await Promise.all(
-      buckets.map((b) => loadReverseShard(this.projectId, b)),
+      buckets.map((b) => loadReverseShard(this.projectId, b, this.meta.generation)),
     );
     for (const shard of shards) {
       if (!shard) continue;
@@ -195,7 +195,7 @@ export class SymbolGraphCache {
       return cached;
     }
     this.stats.fileLruMisses++;
-    const payload = await loadFilePayload(this.projectId, relativePath);
+    const payload = await loadFilePayload(this.projectId, relativePath, this.meta.generation);
     if (payload) this.fileDataLru.set(relativePath, payload);
     this.stats.fileLruSize = this.fileDataLru.size;
     return payload;

--- a/src/services/symbol-graph-incremental.ts
+++ b/src/services/symbol-graph-incremental.ts
@@ -129,42 +129,29 @@ export async function updateChangedFilesSymbolGraph(
   let filesChangedActual = 0;
   let filesRemovedActual = 0;
 
-  // ── Process removed files ─────────────────────────────────────────────
-  for (const relPath of removedRelPaths) {
-    const oldPayload = await loadFilePayload(projectId, relPath);
-    if (!oldPayload) continue;
-    await applyRemoval(projectId, oldPayload, getNameShard, getReverseShard);
-    await deleteFilePayload(projectId, relPath);
-    symbolsDelta -= countNamedSymbols(oldPayload.symbols);
-    edgesDelta -= oldPayload.outgoingCalls.length;
-    filesRemovedActual++;
+  // ── Pre-process changed files & check for symbol ID modifications ─────
+  // If any symbol IDs changed, cross-file caller edges are invalidated and a
+  // full rebuild is required. Performing this check up front avoids committing
+  // partial changes to storage before bailing out.
+  interface PreparedChange {
+    relPath: string;
+    newPayload: SymbolGraphFilePayload | null; // null if unparseable/loss of grammar
+    oldPayload: SymbolGraphFilePayload | null;
+    wasExtensionlessWithoutGrammar?: boolean;
   }
+  const preparedChanges: PreparedChange[] = [];
 
-  // ── Process changed files (re-extract + diff + upsert) ────────────────
   for (const relPath of changedRelPaths) {
     let ext = path.extname(relPath);
     let lang = getAstGrepLang(ext);
     const isElixirTemplate = isElixirTemplateExtension(ext);
     const wasExtensionless = ext === "";
-    // Detected extensionless files must patch incrementally too, or their
-    // symbols would appear only after a full rebuildGraph() and go stale
-    // between full rebuilds. Grammar-bearing only — `.txt` stays out.
+
     if (!lang && wasExtensionless) {
-      // Distinguish "readable but not code" (→ purge stale symbols below) from a
-      // read/stat failure. The lenient resolver collapses both to null, which
-      // would purge a still-valid payload on a transient I/O blip — and only for
-      // extensionless files (an extensioned file keeps its payload via the
-      // readFile catch below). Use the strict variant so a failure surfaces, and
-      // skip without purging, mirroring the extensioned path.
       let detected: string | null;
       try {
         detected = await resolveExtensionlessExtensionStrict(path.join(projectPath, relPath));
       } catch (err) {
-        // ENOENT (deleted between change-detection and read) is an expected skip —
-        // a real delete is reconciled via removedRelPaths. Any other fault
-        // (EACCES/EIO) means we are keeping a now-stale payload for a changed file
-        // we could not read; surface it at debug, matching the lenient resolver's
-        // non-ENOENT log, rather than swallowing it silently.
         if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
           logger.debug("Could not read changed extensionless file; keeping prior symbols (skipping)", {
             relPath,
@@ -178,34 +165,21 @@ export async function updateChangedFilesSymbolGraph(
         lang = getAstGrepLang(detected);
       }
     }
+
     if (!lang && !isElixirTemplate) {
-      // A *changed* extensionless file that lost its grammar (e.g. its shebang
-      // changed to an unmapped interpreter, so it now detects as .txt) is still
-      // indexable, so it arrives here as changed — never via removedRelPaths.
-      // Drop any prior symbol payload so the incremental graph converges to the
-      // same set as a full rebuild (which excludes grammar-less extensionless
-      // files) rather than leaving phantom symbols behind.
       if (wasExtensionless) {
         const oldPayload = await loadFilePayload(projectId, relPath);
         if (oldPayload) {
-          await applyRemoval(projectId, oldPayload, getNameShard, getReverseShard);
-          await deleteFilePayload(projectId, relPath);
-          symbolsDelta -= countNamedSymbols(oldPayload.symbols);
-          edgesDelta -= oldPayload.outgoingCalls.length;
-          filesRemovedActual++;
+          preparedChanges.push({ relPath, newPayload: null, oldPayload, wasExtensionlessWithoutGrammar: true });
         }
       }
       continue;
     }
+
     let source: string;
     try {
       source = await fs.readFile(path.join(projectPath, relPath), "utf-8");
     } catch (err) {
-      // ENOENT (deleted between change-detection and read) is an expected skip —
-      // a real delete is reconciled via removedRelPaths. Any other fault
-      // (EACCES/EIO) means we are keeping a now-stale payload for a changed file
-      // we could not read; surface it at debug rather than swallowing it, and
-      // skip without purging so a transient blip cannot drop valid symbols.
       if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
         logger.debug("Could not read changed file; keeping prior symbols (skipping)", {
           relPath,
@@ -214,14 +188,11 @@ export async function updateChangedFilesSymbolGraph(
       }
       continue;
     }
+
     const language = getLanguageFromExtension(ext) ?? "plaintext";
     // biome-ignore lint/suspicious/noExplicitAny: ast-grep Lang type unify
     const extracted = extractSymbolsAndCalls(source, (lang ?? "elixir-template") as any, ext, relPath);
 
-    // Resolution: build minimal symbolsByFile/outgoingCallsByFile maps so we
-    // can reuse the existing 3-tier resolver. Other files' symbols are not
-    // available here, so cross-file edges fall back to "unresolved" — that's
-    // acceptable for the watcher path; the next full rebuild will tighten it.
     const symbolsByFile = new Map<string, SymbolNode[]>();
     symbolsByFile.set(relPath, extracted.symbols);
     const unresolvedEdges = rawCallsToUnresolvedEdges(extracted.rawCalls);
@@ -245,8 +216,6 @@ export async function updateChangedFilesSymbolGraph(
     };
 
     const oldPayload = await loadFilePayload(projectId, relPath);
-
-    // Skip work if content hash unchanged (true no-op save).
     if (oldPayload && oldPayload.contentHash === newPayload.contentHash) {
       continue;
     }
@@ -260,22 +229,51 @@ export async function updateChangedFilesSymbolGraph(
 
       if (symbolsChanged) {
         return {
-          filesChanged: filesChangedActual,
-          filesRemoved: filesRemovedActual,
-          symbolsDelta,
-          edgesDelta,
+          filesChanged: 0,
+          filesRemoved: 0,
+          symbolsDelta: 0,
+          edgesDelta: 0,
           fullRebuildRequired: true,
         };
       }
-
-      await applyRemoval(projectId, oldPayload, getNameShard, getReverseShard);
-      symbolsDelta -= countNamedSymbols(oldPayload.symbols);
-      edgesDelta -= oldPayload.outgoingCalls.length;
     }
-    await applyAddition(projectId, newPayload, getNameShard, getReverseShard);
-    await saveFilePayload(projectId, newPayload);
-    symbolsDelta += countNamedSymbols(newPayload.symbols);
-    edgesDelta += newPayload.outgoingCalls.length;
+
+    preparedChanges.push({ relPath, newPayload, oldPayload });
+  }
+
+  // ── Process removed files ─────────────────────────────────────────────
+  for (const relPath of removedRelPaths) {
+    const oldPayload = await loadFilePayload(projectId, relPath);
+    if (!oldPayload) continue;
+    await applyRemoval(projectId, oldPayload, getNameShard, getReverseShard);
+    await deleteFilePayload(projectId, relPath);
+    symbolsDelta -= countNamedSymbols(oldPayload.symbols);
+    edgesDelta -= oldPayload.outgoingCalls.length;
+    filesRemovedActual++;
+  }
+
+  // ── Apply pre-validated changed files ─────────────────────────────────
+  for (const change of preparedChanges) {
+    if (change.wasExtensionlessWithoutGrammar && change.oldPayload) {
+      await applyRemoval(projectId, change.oldPayload, getNameShard, getReverseShard);
+      await deleteFilePayload(projectId, change.relPath);
+      symbolsDelta -= countNamedSymbols(change.oldPayload.symbols);
+      edgesDelta -= change.oldPayload.outgoingCalls.length;
+      filesRemovedActual++;
+      continue;
+    }
+
+    if (!change.newPayload) continue;
+
+    if (change.oldPayload) {
+      await applyRemoval(projectId, change.oldPayload, getNameShard, getReverseShard);
+      symbolsDelta -= countNamedSymbols(change.oldPayload.symbols);
+      edgesDelta -= change.oldPayload.outgoingCalls.length;
+    }
+    await applyAddition(projectId, change.newPayload, getNameShard, getReverseShard);
+    await saveFilePayload(projectId, change.newPayload);
+    symbolsDelta += countNamedSymbols(change.newPayload.symbols);
+    edgesDelta += change.newPayload.outgoingCalls.length;
     filesChangedActual++;
   }
 
@@ -360,18 +358,16 @@ async function applyRemoval(
     if (filtered.length === 0) delete shard[sym.name];
     else shard[sym.name] = filtered;
   }
-  // Remove caller entries from reverse shards.
+  // Remove caller entries from reverse shards (keyed by exact calleeSymbolId).
   for (const edge of payload.outgoingCalls) {
     for (const calleeId of edge.calleeCandidates) {
-      const calleeFile = calleeId.split("::")[0];
-      if (!calleeFile || calleeFile === payload.file) continue;
-      const bucket = reverseShardKey(calleeFile);
+      const bucket = reverseShardKey(calleeId);
       const shard = await getReverseShard(bucket);
-      const arr = shard[calleeFile];
+      const arr = shard[calleeId];
       if (!arr) continue;
-      const filtered = arr.filter((f) => f !== payload.file);
-      if (filtered.length === 0) delete shard[calleeFile];
-      else shard[calleeFile] = filtered;
+      const filtered = arr.filter((callerId) => callerId !== edge.callerId);
+      if (filtered.length === 0) delete shard[calleeId];
+      else shard[calleeId] = filtered;
     }
   }
   // Suppress unused-projectId warning: the helper is closed over the same id
@@ -403,17 +399,16 @@ async function applyAddition(
       shard[sym.name] = [ref];
     }
   }
+  // Add caller entries to reverse shards (keyed by exact calleeSymbolId).
   for (const edge of payload.outgoingCalls) {
     for (const calleeId of edge.calleeCandidates) {
-      const calleeFile = calleeId.split("::")[0];
-      if (!calleeFile || calleeFile === payload.file) continue;
-      const bucket = reverseShardKey(calleeFile);
+      const bucket = reverseShardKey(calleeId);
       const shard = await getReverseShard(bucket);
-      const existing = shard[calleeFile];
+      const existing = shard[calleeId];
       if (existing) {
-        if (!existing.includes(payload.file)) existing.push(payload.file);
+        if (!existing.includes(edge.callerId)) existing.push(edge.callerId);
       } else {
-        shard[calleeFile] = [payload.file];
+        shard[calleeId] = [edge.callerId];
       }
     }
   }

--- a/src/services/symbol-graph-incremental.ts
+++ b/src/services/symbol-graph-incremental.ts
@@ -252,6 +252,22 @@ export async function updateChangedFilesSymbolGraph(
     }
 
     if (oldPayload) {
+      const oldSymbolIds = new Set(oldPayload.symbols.map((s) => s.id));
+      const newSymbolIds = new Set(newPayload.symbols.map((s) => s.id));
+      const symbolsChanged =
+        oldSymbolIds.size !== newSymbolIds.size ||
+        [...oldSymbolIds].some((id) => !newSymbolIds.has(id));
+
+      if (symbolsChanged) {
+        return {
+          filesChanged: filesChangedActual,
+          filesRemoved: filesRemovedActual,
+          symbolsDelta,
+          edgesDelta,
+          fullRebuildRequired: true,
+        };
+      }
+
       await applyRemoval(projectId, oldPayload, getNameShard, getReverseShard);
       symbolsDelta -= countNamedSymbols(oldPayload.symbols);
       edgesDelta -= oldPayload.outgoingCalls.length;

--- a/src/services/symbol-graph-incremental.ts
+++ b/src/services/symbol-graph-incremental.ts
@@ -241,10 +241,17 @@ export async function updateChangedFilesSymbolGraph(
     preparedChanges.push({ relPath, newPayload, oldPayload });
   }
 
-  // ── Process removed files ─────────────────────────────────────────────
+  // ── Pre-process removed files (load prior payloads before mutating) ───
+  const preparedRemovals: Array<{ relPath: string; oldPayload: SymbolGraphFilePayload }> = [];
   for (const relPath of removedRelPaths) {
     const oldPayload = await loadFilePayload(projectId, relPath);
-    if (!oldPayload) continue;
+    if (oldPayload) {
+      preparedRemovals.push({ relPath, oldPayload });
+    }
+  }
+
+  // ── Process removed files ─────────────────────────────────────────────
+  for (const { relPath, oldPayload } of preparedRemovals) {
     await applyRemoval(projectId, oldPayload, getNameShard, getReverseShard);
     await deleteFilePayload(projectId, relPath);
     symbolsDelta -= countNamedSymbols(oldPayload.symbols);
@@ -294,7 +301,6 @@ export async function updateChangedFilesSymbolGraph(
       0,
       meta.fileCount + filesChangedNew(changedRelPaths, removedRelPaths),
     ),
-    builtAt: Date.now(),
     // Note: unresolvedEdgePct is NOT recomputed incrementally — it's an
     // approximation from the last full rebuild plus rough delta. Acceptable
     // until the next full rebuild.

--- a/src/services/symbol-graph-incremental.ts
+++ b/src/services/symbol-graph-incremental.ts
@@ -4,94 +4,53 @@
 /**
  * Per-file incremental updates for the symbol-level call graph.
  *
- * Wired into the watcher path so a single file save does not force a
- * full re-extraction + re-resolution of the entire codebase.
- *
- * Scope of incremental update:
- *   1. Re-extract symbols & raw calls for the changed file.
- *   2. Resolve calls best-effort against the (already-rebuilt) file-import graph.
- *   3. Diff the new file payload against the previous one and patch only the
- *      affected name-index shards (max 27) and reverse-call shards (max 256).
- *   4. Update the meta point with running counts (no recount needed).
- *
- * Falls back to a no-op if no symbol graph meta exists yet — the caller can
- * detect that and trigger a full rebuild instead.
+ * Wired into the watcher path so file saves do not corrupt cross-file symbol graphs.
+ * Rejects schema-v1 graphs with fullRebuildRequired = true.
+ * Until complete symbol-set cross-file incremental resolution is supported,
+ * any changed or removed files trigger fullRebuildRequired = true before mutating storage.
  */
 
-import { promises as fs } from "node:fs";
-import path from "node:path";
 import {
-  getLanguageFromExtension,
   SYMBOL_REVERSE_SHARDS,
 } from "../constants.js";
 import type {
   CodeGraph,
-  SymbolEdge,
   SymbolGraphFilePayload,
-  SymbolGraphMeta,
-  SymbolNode,
   SymbolRef,
 } from "../types.js";
-import { getAstGrepLang } from "./code-graph.js";
-import { ensureElixirTemplateParsers, isElixirTemplateExtension } from "./elixir-templates.js";
-import { resolveExtensionlessExtensionStrict } from "./extensionless.js";
-import { resolveCallSites } from "./graph-symbol-resolution.js";
 import {
-  extractSymbolsAndCalls,
-  rawCallsToUnresolvedEdges,
-} from "./graph-symbols.js";
-import { logger } from "./logger.js";
-import {
-  getSymbolGraphCache,
-  SymbolGraphCache,
-  setSymbolGraphCache,
-} from "./symbol-graph-cache.js";
-import {
-  contentHashOf,
-  deleteFilePayload,
-  loadFilePayload,
-  loadNameShard,
-  loadReverseShard,
   loadSymbolGraphMeta,
   nameShardKey,
-  reverseShardKey,
-  saveFilePayload,
-  saveNameShard,
-  saveReverseShard,
-  saveSymbolGraphMeta,
+  reverseShardKeyForCallee,
 } from "./symbol-graph-store.js";
 
-/** Result of applying an incremental update. */
+// ── Main incremental entry point ─────────────────────────────────────────
+
 export interface IncrementalUpdateResult {
   filesChanged: number;
   filesRemoved: number;
   symbolsDelta: number;
   edgesDelta: number;
-  /** True when meta was missing — caller should trigger a full rebuild. */
+  /** True when the symbol graph is missing, invalid schema version, or needs full rebuild */
   fullRebuildRequired: boolean;
 }
 
 /**
- * Incrementally update the symbol graph for the given changed/removed files.
- * The caller must pass the freshly-built file-import graph (used for
- * dependency-aware call resolution).
+ * Incrementally update the persisted symbol graph for a small batch of
+ * changed and removed files.
  *
- * Files in `changedRelPaths` are re-extracted and upserted.
- * Files in `removedRelPaths` have their payloads, name-index entries, and
- * reverse-call entries removed.
- *
- * Returns `fullRebuildRequired = true` if no meta exists yet — caller should
- * fall back to a full `rebuildGraph()`.
+ * Returns `fullRebuildRequired = true` if no meta exists, schemaVersion < 2,
+ * or if changed/removed files require cross-file caller re-resolution.
  */
 export async function updateChangedFilesSymbolGraph(
   projectId: string,
-  projectPath: string,
-  fileGraph: CodeGraph,
+  _projectPath: string,
+  _fileGraph: CodeGraph,
   changedRelPaths: string[],
   removedRelPaths: string[],
 ): Promise<IncrementalUpdateResult> {
   const meta = await loadSymbolGraphMeta(projectId);
-  if (!meta) {
+  if (!meta || (meta.schemaVersion ?? 1) < 2) {
     return {
       filesChanged: 0,
       filesRemoved: 0,
@@ -100,253 +59,32 @@ export async function updateChangedFilesSymbolGraph(
       fullRebuildRequired: true,
     };
   }
-  if (changedRelPaths.some((file) => isElixirTemplateExtension(path.extname(file)))) {
-    await ensureElixirTemplateParsers();
-  }
 
-  // Track shards that need re-saving so we batch IO at the end.
-  const dirtyNameShards = new Map<string, Record<string, SymbolRef[]>>();
-  const dirtyReverseShards = new Map<number, Record<string, string[]>>();
-
-  // Helper: lazily load a name shard into the dirty map.
-  async function getNameShard(key: string): Promise<Record<string, SymbolRef[]>> {
-    let shard = dirtyNameShards.get(key);
-    if (shard) return shard;
-    shard = (await loadNameShard(projectId, key)) ?? {};
-    dirtyNameShards.set(key, shard);
-    return shard;
-  }
-  async function getReverseShard(bucket: number): Promise<Record<string, string[]>> {
-    let shard = dirtyReverseShards.get(bucket);
-    if (shard) return shard;
-    shard = (await loadReverseShard(projectId, bucket)) ?? {};
-    dirtyReverseShards.set(bucket, shard);
-    return shard;
-  }
-
-  let symbolsDelta = 0;
-  let edgesDelta = 0;
-  let filesChangedActual = 0;
-  let filesRemovedActual = 0;
-
-  // ── Pre-process changed files & check for symbol ID modifications ─────
-  // If any symbol IDs changed, cross-file caller edges are invalidated and a
-  // full rebuild is required. Performing this check up front avoids committing
-  // partial changes to storage before bailing out.
-  interface PreparedChange {
-    relPath: string;
-    newPayload: SymbolGraphFilePayload | null; // null if unparseable/loss of grammar
-    oldPayload: SymbolGraphFilePayload | null;
-    wasExtensionlessWithoutGrammar?: boolean;
-  }
-  const preparedChanges: PreparedChange[] = [];
-
-  for (const relPath of changedRelPaths) {
-    let ext = path.extname(relPath);
-    let lang = getAstGrepLang(ext);
-    const isElixirTemplate = isElixirTemplateExtension(ext);
-    const wasExtensionless = ext === "";
-
-    if (!lang && wasExtensionless) {
-      let detected: string | null;
-      try {
-        detected = await resolveExtensionlessExtensionStrict(path.join(projectPath, relPath));
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
-          logger.debug("Could not read changed extensionless file; keeping prior symbols (skipping)", {
-            relPath,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-        continue;
-      }
-      if (detected) {
-        ext = detected;
-        lang = getAstGrepLang(detected);
-      }
-    }
-
-    if (!lang && !isElixirTemplate) {
-      if (wasExtensionless) {
-        const oldPayload = await loadFilePayload(projectId, relPath);
-        if (oldPayload) {
-          preparedChanges.push({ relPath, newPayload: null, oldPayload, wasExtensionlessWithoutGrammar: true });
-        }
-      }
-      continue;
-    }
-
-    let source: string;
-    try {
-      source = await fs.readFile(path.join(projectPath, relPath), "utf-8");
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
-        logger.debug("Could not read changed file; keeping prior symbols (skipping)", {
-          relPath,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-      continue;
-    }
-
-    const language = getLanguageFromExtension(ext) ?? "plaintext";
-    // biome-ignore lint/suspicious/noExplicitAny: ast-grep Lang type unify
-    const extracted = extractSymbolsAndCalls(source, (lang ?? "elixir-template") as any, ext, relPath);
-
-    const symbolsByFile = new Map<string, SymbolNode[]>();
-    symbolsByFile.set(relPath, extracted.symbols);
-    const unresolvedEdges = rawCallsToUnresolvedEdges(extracted.rawCalls);
-    const outgoingCallsByFile = new Map<string, SymbolEdge[]>();
-    outgoingCallsByFile.set(relPath, unresolvedEdges);
-    try {
-      resolveCallSites(fileGraph, symbolsByFile, outgoingCallsByFile);
-    } catch (err) {
-      logger.debug("Incremental resolveCallSites failed (using unresolved)", {
-        file: relPath,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-
-    const newPayload: SymbolGraphFilePayload = {
-      file: relPath,
-      language,
-      contentHash: contentHashOf(source),
-      symbols: extracted.symbols,
-      outgoingCalls: outgoingCallsByFile.get(relPath) ?? unresolvedEdges,
+  // Until incremental resolution uses the complete symbol set and re-resolves
+  // affected callers, return fullRebuildRequired: true for changed and removed files
+  // before mutating storage.
+  if (changedRelPaths.length > 0 || removedRelPaths.length > 0) {
+    return {
+      filesChanged: 0,
+      filesRemoved: 0,
+      symbolsDelta: 0,
+      edgesDelta: 0,
+      fullRebuildRequired: true,
     };
-
-    const oldPayload = await loadFilePayload(projectId, relPath);
-    if (oldPayload && oldPayload.contentHash === newPayload.contentHash) {
-      continue;
-    }
-
-    if (oldPayload) {
-      const oldSymbolIds = new Set(oldPayload.symbols.map((s) => s.id));
-      const newSymbolIds = new Set(newPayload.symbols.map((s) => s.id));
-      const symbolsChanged =
-        oldSymbolIds.size !== newSymbolIds.size ||
-        [...oldSymbolIds].some((id) => !newSymbolIds.has(id));
-
-      if (symbolsChanged) {
-        return {
-          filesChanged: 0,
-          filesRemoved: 0,
-          symbolsDelta: 0,
-          edgesDelta: 0,
-          fullRebuildRequired: true,
-        };
-      }
-    }
-
-    preparedChanges.push({ relPath, newPayload, oldPayload });
   }
-
-  // ── Pre-process removed files (load prior payloads before mutating) ───
-  const preparedRemovals: Array<{ relPath: string; oldPayload: SymbolGraphFilePayload }> = [];
-  for (const relPath of removedRelPaths) {
-    const oldPayload = await loadFilePayload(projectId, relPath);
-    if (oldPayload) {
-      preparedRemovals.push({ relPath, oldPayload });
-    }
-  }
-
-  // ── Process removed files ─────────────────────────────────────────────
-  for (const { relPath, oldPayload } of preparedRemovals) {
-    await applyRemoval(projectId, oldPayload, getNameShard, getReverseShard);
-    await deleteFilePayload(projectId, relPath);
-    symbolsDelta -= countNamedSymbols(oldPayload.symbols);
-    edgesDelta -= oldPayload.outgoingCalls.length;
-    filesRemovedActual++;
-  }
-
-  // ── Apply pre-validated changed files ─────────────────────────────────
-  for (const change of preparedChanges) {
-    if (change.wasExtensionlessWithoutGrammar && change.oldPayload) {
-      await applyRemoval(projectId, change.oldPayload, getNameShard, getReverseShard);
-      await deleteFilePayload(projectId, change.relPath);
-      symbolsDelta -= countNamedSymbols(change.oldPayload.symbols);
-      edgesDelta -= change.oldPayload.outgoingCalls.length;
-      filesRemovedActual++;
-      continue;
-    }
-
-    if (!change.newPayload) continue;
-
-    if (change.oldPayload) {
-      await applyRemoval(projectId, change.oldPayload, getNameShard, getReverseShard);
-      symbolsDelta -= countNamedSymbols(change.oldPayload.symbols);
-      edgesDelta -= change.oldPayload.outgoingCalls.length;
-    }
-    await applyAddition(projectId, change.newPayload, getNameShard, getReverseShard);
-    await saveFilePayload(projectId, change.newPayload);
-    symbolsDelta += countNamedSymbols(change.newPayload.symbols);
-    edgesDelta += change.newPayload.outgoingCalls.length;
-    filesChangedActual++;
-  }
-
-  // ── Persist dirty shards ──────────────────────────────────────────────
-  for (const [key, shard] of dirtyNameShards.entries()) {
-    await saveNameShard(projectId, key, shard);
-  }
-  for (const [bucket, shard] of dirtyReverseShards.entries()) {
-    await saveReverseShard(projectId, bucket, shard);
-  }
-
-  // ── Update meta with running counts ──────────────────────────────────
-  const newMeta: SymbolGraphMeta = {
-    ...meta,
-    symbolCount: Math.max(0, meta.symbolCount + symbolsDelta),
-    edgeCount: Math.max(0, meta.edgeCount + edgesDelta),
-    fileCount: Math.max(
-      0,
-      meta.fileCount + filesChangedNew(changedRelPaths, removedRelPaths),
-    ),
-    // Note: unresolvedEdgePct is NOT recomputed incrementally — it's an
-    // approximation from the last full rebuild plus rough delta. Acceptable
-    // until the next full rebuild.
-  };
-  await saveSymbolGraphMeta(projectId, newMeta);
-
-  // Refresh in-memory cache: clear any per-shard memoisation by replacing the
-  // cache instance with a fresh one carrying the new meta.
-  setSymbolGraphCache(new SymbolGraphCache(projectId, newMeta));
-  // Touch the registry to drop stale-pre-existing reference if any.
-  await getSymbolGraphCache(projectId);
-
-  logger.info("Symbol graph incrementally updated", {
-    projectId,
-    filesChanged: filesChangedActual,
-    filesRemoved: filesRemovedActual,
-    symbolsDelta,
-    edgesDelta,
-  });
 
   return {
-    filesChanged: filesChangedActual,
-    filesRemoved: filesRemovedActual,
-    symbolsDelta,
-    edgesDelta,
+    filesChanged: 0,
+    filesRemoved: 0,
+    symbolsDelta: 0,
+    edgesDelta: 0,
     fullRebuildRequired: false,
   };
 }
 
 // ── Internal helpers ────────────────────────────────────────────────────
 
-function countNamedSymbols(symbols: SymbolNode[]): number {
-  let n = 0;
-  for (const s of symbols) if (s.name !== "<module>") n++;
-  return n;
-}
-
-/** Net change to fileCount = newly-added files - removed files. */
-function filesChangedNew(changed: string[], removed: string[]): number {
-  // We can't tell here whether a `changed` path was previously known; the
-  // caller is responsible for de-duplication. This approximation is good
-  // enough for the meta counter — full rebuilds correct any drift.
-  return changed.length - removed.length;
-}
-
-async function applyRemoval(
+export async function applyRemoval(
   projectId: string,
   payload: SymbolGraphFilePayload,
   getNameShard: (key: string) => Promise<Record<string, SymbolRef[]>>,
@@ -367,7 +105,7 @@ async function applyRemoval(
   // Remove caller entries from reverse shards (keyed by exact calleeSymbolId).
   for (const edge of payload.outgoingCalls) {
     for (const calleeId of edge.calleeCandidates) {
-      const bucket = reverseShardKey(calleeId);
+      const bucket = reverseShardKeyForCallee(calleeId);
       const shard = await getReverseShard(bucket);
       const arr = shard[calleeId];
       if (!arr) continue;
@@ -376,14 +114,11 @@ async function applyRemoval(
       else shard[calleeId] = filtered;
     }
   }
-  // Suppress unused-projectId warning: the helper is closed over the same id
-  // already; keeping it as a parameter mirrors the public API shape.
   void projectId;
-  // Cap the bucket index to constants to satisfy lint (no dead branches).
   void SYMBOL_REVERSE_SHARDS;
 }
 
-async function applyAddition(
+export async function applyAddition(
   projectId: string,
   payload: SymbolGraphFilePayload,
   getNameShard: (key: string) => Promise<Record<string, SymbolRef[]>>,
@@ -393,11 +128,8 @@ async function applyAddition(
     if (sym.name === "<module>") continue;
     const shard = await getNameShard(nameShardKey(sym.name));
     const ref: SymbolRef = { file: payload.file, id: sym.id };
-    // Use hasOwn — `shard[sym.name]` would return Object.prototype.constructor
-    // (a function) for symbol names like "constructor" / "toString".
     const existing = Object.hasOwn(shard, sym.name) ? shard[sym.name] : undefined;
     if (existing) {
-      // De-dup
       if (!existing.some((e) => e.id === ref.id && e.file === ref.file)) {
         existing.push(ref);
       }
@@ -408,7 +140,7 @@ async function applyAddition(
   // Add caller entries to reverse shards (keyed by exact calleeSymbolId).
   for (const edge of payload.outgoingCalls) {
     for (const calleeId of edge.calleeCandidates) {
-      const bucket = reverseShardKey(calleeId);
+      const bucket = reverseShardKeyForCallee(calleeId);
       const shard = await getReverseShard(bucket);
       const existing = shard[calleeId];
       if (existing) {
@@ -420,3 +152,8 @@ async function applyAddition(
   }
   void projectId;
 }
+
+export const _internal = {
+  applyRemoval,
+  applyAddition,
+};

--- a/src/services/symbol-graph-store.ts
+++ b/src/services/symbol-graph-store.ts
@@ -777,7 +777,7 @@ export async function coordinateProject<T>(
   fn: () => Promise<T>,
 ): Promise<T> {
   const current = projectLocks.get(projectId) ?? Promise.resolve();
-  let release: () => void;
+  let release: () => void = () => {};
   const next = new Promise<void>((res) => {
     release = res;
   });
@@ -790,7 +790,7 @@ export async function coordinateProject<T>(
   try {
     return await fn();
   } finally {
-    release!();
+    release();
     if (projectLocks.get(projectId) === chained) {
       projectLocks.delete(projectId);
     }

--- a/src/services/symbol-graph-store.ts
+++ b/src/services/symbol-graph-store.ts
@@ -349,6 +349,25 @@ export class StorageReadError extends Error {
   }
 }
 
+/** Raised when a query tries to start against a superseded graph generation. */
+export class SymbolGraphGenerationChangedError extends StorageReadError {
+  constructor(
+    public readonly projectId: string,
+    public readonly generation: string,
+    public readonly activeGeneration?: string,
+  ) {
+    super("Symbol graph generation changed while the query was starting", {
+      projectId,
+      generation,
+      activeGeneration,
+    });
+    this.name = "SymbolGraphGenerationChangedError";
+  }
+}
+
+/** Internal lease/storage key for graphs written before generations existed. */
+export const LEGACY_SYMBOL_GRAPH_GENERATION = "__legacy_symbol_graph__";
+
 /**
  * Read a shard written by {@link saveShardPoints}: the point at the shard's
  * original id, plus continuation parts when it declares any. Returns the
@@ -512,6 +531,7 @@ export async function saveSymbolGraphMeta(
   // this file has no unguarded upsert path (#99).
   assertPointFits(point, "symbol graph metadata");
   await qdrant.upsert(collName, { points: [point] });
+  setActiveSymbolGraphGeneration(projectId, meta.generation);
 }
 
 export async function loadSymbolGraphMeta(
@@ -531,6 +551,9 @@ export async function loadSymbolGraphMeta(
     if (meta && meta.schemaVersion === undefined) {
       meta.schemaVersion = 1;
     }
+    if (meta) {
+      setActiveSymbolGraphGeneration(projectId, meta.generation);
+    }
     return meta;
   } catch (err) {
     logger.warn("loadSymbolGraphMeta failed (returning null)", {
@@ -539,6 +562,16 @@ export async function loadSymbolGraphMeta(
     });
     return null;
   }
+}
+
+async function resolveReadGeneration(
+  projectId: string,
+  generation?: string,
+): Promise<string | undefined> {
+  if (generation === LEGACY_SYMBOL_GRAPH_GENERATION) return undefined;
+  if (generation !== undefined) return generation;
+  const meta = await loadSymbolGraphMeta(projectId);
+  return meta?.generation;
 }
 
 // ── Per-file payloads ────────────────────────────────────────────────────
@@ -594,11 +627,7 @@ export async function loadFilePayload(
   generation?: string,
 ): Promise<SymbolGraphFilePayload | null> {
   try {
-    let gen = generation;
-    if (gen === undefined) {
-      const meta = await loadSymbolGraphMeta(projectId);
-      gen = meta?.generation;
-    }
+    const gen = await resolveReadGeneration(projectId, generation);
     const collName = symgraphFileCollectionName(projectId);
     await ensureCollection(collName);
     const qdrant = getClient();
@@ -628,11 +657,7 @@ export async function deleteFilePayload(
   generation?: string,
 ): Promise<void> {
   try {
-    let gen = generation;
-    if (gen === undefined) {
-      const meta = await loadSymbolGraphMeta(projectId);
-      gen = meta?.generation;
-    }
+    const gen = await resolveReadGeneration(projectId, generation);
     const collName = symgraphFileCollectionName(projectId);
     await ensureCollection(collName);
     const qdrant = getClient();
@@ -683,11 +708,7 @@ export async function loadNameShard(
   generation?: string,
 ): Promise<Record<string, SymbolRef[]> | null> {
   try {
-    let gen = generation;
-    if (gen === undefined) {
-      const meta = await loadSymbolGraphMeta(projectId);
-      gen = meta?.generation;
-    }
+    const gen = await resolveReadGeneration(projectId, generation);
     const collName = symgraphIndexCollectionName(projectId);
     await ensureCollection(collName);
     return await loadShardPoints<SymbolRef[]>(
@@ -737,11 +758,7 @@ export async function loadReverseShard(
   generation?: string,
 ): Promise<Record<string, string[]> | null> {
   try {
-    let gen = generation;
-    if (gen === undefined) {
-      const meta = await loadSymbolGraphMeta(projectId);
-      gen = meta?.generation;
-    }
+    const gen = await resolveReadGeneration(projectId, generation);
     const collName = symgraphIndexCollectionName(projectId);
     await ensureCollection(collName);
     const bucketHex = reverseShardHex(bucket);
@@ -767,6 +784,36 @@ const projectLocks = new Map<string, Promise<void>>();
 const stagingGenerationsByProject = new Map<string, Set<string>>();
 const activeReadersByProject = new Map<string, Map<string, number>>();
 const deferredDeletionsByProject = new Map<string, Set<string>>();
+const activeGenerationByProject = new Map<string, string>();
+const deletingGenerationsByProject = new Map<string, Set<string>>();
+
+/** Record the generation named by the project's committed metadata pointer. */
+export function setActiveSymbolGraphGeneration(
+  projectId: string,
+  generation?: string,
+): void {
+  if (generation) {
+    activeGenerationByProject.set(projectId, generation);
+  } else {
+    activeGenerationByProject.delete(projectId);
+  }
+}
+
+function markGenerationDeleting(projectId: string, generation: string): void {
+  let set = deletingGenerationsByProject.get(projectId);
+  if (!set) {
+    set = new Set();
+    deletingGenerationsByProject.set(projectId, set);
+  }
+  set.add(generation);
+}
+
+function unmarkGenerationDeleting(projectId: string, generation: string): void {
+  const set = deletingGenerationsByProject.get(projectId);
+  if (!set) return;
+  set.delete(generation);
+  if (set.size === 0) deletingGenerationsByProject.delete(projectId);
+}
 
 /**
  * Coordinate staging, activation, and cleanup operations per project.
@@ -830,38 +877,61 @@ export function getStagingGenerations(projectId: string): string[] {
   return Array.from(all);
 }
 
-export function retainReader(projectId: string, generation?: string): void {
-  if (!generation) return;
+export function retainReader(
+  projectId: string,
+  generation?: string,
+  allowSupersededGeneration = false,
+): void {
+  const readerGeneration = generation ?? LEGACY_SYMBOL_GRAPH_GENERATION;
+  const activeGeneration = activeGenerationByProject.get(projectId);
+  const isDeleting = deletingGenerationsByProject.get(projectId)?.has(readerGeneration) ?? false;
+  if (
+    isDeleting
+    || (!allowSupersededGeneration && activeGeneration !== undefined && readerGeneration !== activeGeneration)
+  ) {
+    throw new SymbolGraphGenerationChangedError(
+      projectId,
+      readerGeneration,
+      activeGeneration,
+    );
+  }
   let map = activeReadersByProject.get(projectId);
   if (!map) {
     map = new Map();
     activeReadersByProject.set(projectId, map);
   }
-  map.set(generation, (map.get(generation) ?? 0) + 1);
+  map.set(readerGeneration, (map.get(readerGeneration) ?? 0) + 1);
 }
 
 export function releaseReader(projectId: string, generation?: string): void {
-  if (!generation) return;
+  const readerGeneration = generation ?? LEGACY_SYMBOL_GRAPH_GENERATION;
   const map = activeReadersByProject.get(projectId);
   if (!map) return;
-  const count = (map.get(generation) ?? 1) - 1;
+  const count = (map.get(readerGeneration) ?? 1) - 1;
   if (count <= 0) {
-    map.delete(generation);
+    map.delete(readerGeneration);
     if (map.size === 0) activeReadersByProject.delete(projectId);
     const deferred = deferredDeletionsByProject.get(projectId);
-    if (deferred?.has(generation)) {
-      deferred.delete(generation);
+    if (deferred?.has(readerGeneration)) {
+      deferred.delete(readerGeneration);
       if (deferred.size === 0) deferredDeletionsByProject.delete(projectId);
-      deleteGeneration(projectId, generation).catch((err) => {
-        logger.warn("Deferred generation deletion failed", {
-          projectId,
-          generation,
-          error: err instanceof Error ? err.message : String(err),
+      // Mark synchronously before the asynchronous delete starts. A stale
+      // cache cannot acquire a new lease in the gap between release and I/O.
+      markGenerationDeleting(projectId, readerGeneration);
+      deleteGeneration(projectId, readerGeneration)
+        .catch((err) => {
+          logger.warn("Deferred generation deletion failed", {
+            projectId,
+            generation: readerGeneration,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        })
+        .finally(() => {
+          unmarkGenerationDeleting(projectId, readerGeneration);
         });
-      });
     }
   } else {
-    map.set(generation, count);
+    map.set(readerGeneration, count);
   }
 }
 
@@ -879,6 +949,8 @@ export function resetGenerationLifecycleState(): void {
   stagingGenerationsByProject.clear();
   activeReadersByProject.clear();
   deferredDeletionsByProject.clear();
+  activeGenerationByProject.clear();
+  deletingGenerationsByProject.clear();
 }
 
 /** Delete all points belonging to a specific generation from file and index collections. */
@@ -893,9 +965,9 @@ export async function deleteGeneration(projectId: string, generation: string): P
     try {
       await qdrant.delete(collName, {
         wait: true,
-        filter: {
-          must: [{ key: "generation", match: { value: generation } }],
-        },
+        filter: generation === LEGACY_SYMBOL_GRAPH_GENERATION
+          ? { must: [{ is_empty: { key: "generation" } }] }
+          : { must: [{ key: "generation", match: { value: generation } }] },
       });
     } catch (err) {
       logger.warn("deleteGeneration: failed to delete points for generation", {
@@ -931,6 +1003,8 @@ export async function listStoredGenerations(projectId: string): Promise<string[]
           const gen = pt.payload?.generation;
           if (typeof gen === "string" && gen.length > 0) {
             generations.add(gen);
+          } else {
+            generations.add(LEGACY_SYMBOL_GRAPH_GENERATION);
           }
         }
         if (!res.next_page_offset) break;
@@ -952,51 +1026,32 @@ export async function cleanStaleGenerations(
   activeGeneration: string,
 ): Promise<void> {
   if (!activeGeneration) return;
-  const qdrant = getClient();
-  const collNames = [
-    symgraphFileCollectionName(projectId),
-    symgraphIndexCollectionName(projectId),
-  ];
+  setActiveSymbolGraphGeneration(projectId, activeGeneration);
+  const stagingGens = new Set(getStagingGenerations(projectId));
+  const storedGens = await listStoredGenerations(projectId);
 
-  const stagingGens = getStagingGenerations(projectId);
-  const readerGens = getActiveReaderGenerations(projectId);
-  const excludedGenerations = Array.from(
-    new Set([activeGeneration, ...stagingGens, ...readerGens]),
-  );
-  let allDeletesSucceeded = true;
+  // Retire each known stale generation explicitly. Lease acquisition and the
+  // deletion decision are synchronous within one event-loop turn: a reader
+  // acquired while storage was being listed is observed here, while a reader
+  // arriving after markGenerationDeleting is rejected before any I/O begins.
+  for (const gen of storedGens) {
+    if (gen === activeGeneration || stagingGens.has(gen)) continue;
 
-  for (const collName of collNames) {
-    try {
-      await qdrant.delete(collName, {
-        wait: true,
-        filter: {
-          must: [{ key: "generation", match: { except: excludedGenerations } }],
-        },
-      });
-    } catch {
-      allDeletesSucceeded = false;
-    }
-  }
-
-  // Register deferred deletion for any stale generations currently held by active readers
-  for (const gen of readerGens) {
-    if (gen !== activeGeneration && !stagingGens.includes(gen)) {
+    if (hasActiveReaders(projectId, gen)) {
       let deferred = deferredDeletionsByProject.get(projectId);
       if (!deferred) {
         deferred = new Set();
         deferredDeletionsByProject.set(projectId, deferred);
       }
       deferred.add(gen);
+      continue;
     }
-  }
 
-  // If filtered delete did not succeed on all collections, fall back to explicit per-generation delete
-  if (!allDeletesSucceeded) {
-    const stored = await listStoredGenerations(projectId);
-    for (const gen of stored) {
-      if (!excludedGenerations.includes(gen)) {
-        await deleteGeneration(projectId, gen);
-      }
+    markGenerationDeleting(projectId, gen);
+    try {
+      await deleteGeneration(projectId, gen);
+    } finally {
+      unmarkGenerationDeleting(projectId, gen);
     }
   }
 }

--- a/src/services/symbol-graph-store.ts
+++ b/src/services/symbol-graph-store.ts
@@ -58,6 +58,12 @@ export function reverseShardKey(filePath: string): number {
   return digest[0] % SYMBOL_REVERSE_SHARDS;
 }
 
+/** Map a callee symbol ID (e.g. `path/to/file.ts::symbolName`) to its reverse-call shard bucket. */
+export function reverseShardKeyForCallee(calleeId: string): number {
+  const calleeFile = calleeId.split("::")[0] ?? calleeId;
+  return reverseShardKey(calleeFile);
+}
+
 /** Format a reverse-shard bucket as a 2-char zero-padded hex string. */
 export function reverseShardHex(bucket: number): string {
   return bucket.toString(16).padStart(2, "0");
@@ -73,8 +79,9 @@ function uuidFromString(input: string): string {
 function metaPointId(projectId: string): string {
   return uuidFromString(`${projectId}::meta`);
 }
-function filePointId(projectId: string, relativePath: string): string {
-  return uuidFromString(`${projectId}::file::${relativePath}`);
+function filePointId(projectId: string, relativePath: string, generation?: string): string {
+  const genSuffix = generation ? `::gen::${generation}` : "";
+  return uuidFromString(`${projectId}::file::${relativePath}${genSuffix}`);
 }
 /**
  * Seed strings for shard point ids. Single-sourced on purpose: part 0's id and
@@ -82,17 +89,19 @@ function filePointId(projectId: string, relativePath: string): string {
  * place but not the other would strand every split shard's continuation parts
  * at unreachable ids without any type error.
  */
-function nameShardSeed(projectId: string, shardKey: string): string {
-  return `${projectId}::nameidx::${shardKey}`;
+function nameShardSeed(projectId: string, shardKey: string, generation?: string): string {
+  const genSuffix = generation ? `::gen::${generation}` : "";
+  return `${projectId}::nameidx::${shardKey}${genSuffix}`;
 }
-function revShardSeed(projectId: string, bucketHex: string): string {
-  return `${projectId}::revidx::${bucketHex}`;
+function revShardSeed(projectId: string, bucketHex: string, generation?: string): string {
+  const genSuffix = generation ? `::gen::${generation}` : "";
+  return `${projectId}::revidx::${bucketHex}${genSuffix}`;
 }
-function nameShardPointId(projectId: string, shardKey: string): string {
-  return uuidFromString(nameShardSeed(projectId, shardKey));
+function nameShardPointId(projectId: string, shardKey: string, generation?: string): string {
+  return uuidFromString(nameShardSeed(projectId, shardKey, generation));
 }
-function revShardPointId(projectId: string, bucketHex: string): string {
-  return uuidFromString(revShardSeed(projectId, bucketHex));
+function revShardPointId(projectId: string, bucketHex: string, generation?: string): string {
+  return uuidFromString(revShardSeed(projectId, bucketHex, generation));
 }
 /**
  * Id of continuation part `i` (i >= 1) of a shard whose part 0 lives at the
@@ -525,12 +534,13 @@ export async function loadSymbolGraphMeta(
 export async function saveFilePayload(
   projectId: string,
   payload: SymbolGraphFilePayload,
+  generation?: string,
 ): Promise<void> {
   const collName = symgraphFileCollectionName(projectId);
   await ensureCollection(collName);
   const qdrant = getClient();
   const point: SymgraphPoint = {
-    id: filePointId(projectId, payload.file),
+    id: filePointId(projectId, payload.file, generation),
     vector: [0],
     payload: { filePayload: payload },
   };
@@ -547,12 +557,13 @@ export async function saveFilePayload(
 export async function saveFilePayloads(
   projectId: string,
   payloads: SymbolGraphFilePayload[],
+  generation?: string,
 ): Promise<void> {
   if (payloads.length === 0) return;
   const collName = symgraphFileCollectionName(projectId);
   await ensureCollection(collName);
   const points: SymgraphPoint[] = payloads.map((p) => ({
-    id: filePointId(projectId, p.file),
+    id: filePointId(projectId, p.file, generation),
     vector: [0],
     payload: { filePayload: p },
   }));
@@ -562,13 +573,19 @@ export async function saveFilePayloads(
 export async function loadFilePayload(
   projectId: string,
   relativePath: string,
+  generation?: string,
 ): Promise<SymbolGraphFilePayload | null> {
   try {
+    let gen = generation;
+    if (gen === undefined) {
+      const meta = await loadSymbolGraphMeta(projectId);
+      gen = meta?.generation;
+    }
     const collName = symgraphFileCollectionName(projectId);
     await ensureCollection(collName);
     const qdrant = getClient();
     const points = await qdrant.retrieve(collName, {
-      ids: [filePointId(projectId, relativePath)],
+      ids: [filePointId(projectId, relativePath, gen)],
       with_payload: true,
     });
     if (points.length === 0) return null;
@@ -590,13 +607,19 @@ export async function loadFilePayload(
 export async function deleteFilePayload(
   projectId: string,
   relativePath: string,
+  generation?: string,
 ): Promise<void> {
   try {
+    let gen = generation;
+    if (gen === undefined) {
+      const meta = await loadSymbolGraphMeta(projectId);
+      gen = meta?.generation;
+    }
     const collName = symgraphFileCollectionName(projectId);
     await ensureCollection(collName);
     const qdrant = getClient();
     await qdrant.delete(collName, {
-      points: [filePointId(projectId, relativePath)],
+      points: [filePointId(projectId, relativePath, gen)],
     });
   } catch (err) {
     logger.warn("deleteFilePayload failed", {
@@ -618,13 +641,14 @@ export async function saveNameShard(
   projectId: string,
   shardKey: string,
   nameToSymbols: Record<string, SymbolRef[]>,
+  generation?: string,
 ): Promise<void> {
   const collName = symgraphIndexCollectionName(projectId);
   await ensureCollection(collName);
   await saveShardPoints(
     collName,
-    nameShardSeed(projectId, shardKey),
-    nameShardPointId(projectId, shardKey),
+    nameShardSeed(projectId, shardKey, generation),
+    nameShardPointId(projectId, shardKey, generation),
     nameToSymbols,
     `name index shard '${shardKey}'`,
     (entries, part, parts) =>
@@ -637,14 +661,20 @@ export async function saveNameShard(
 export async function loadNameShard(
   projectId: string,
   shardKey: string,
+  generation?: string,
 ): Promise<Record<string, SymbolRef[]> | null> {
   try {
+    let gen = generation;
+    if (gen === undefined) {
+      const meta = await loadSymbolGraphMeta(projectId);
+      gen = meta?.generation;
+    }
     const collName = symgraphIndexCollectionName(projectId);
     await ensureCollection(collName);
     return await loadShardPoints<SymbolRef[]>(
       collName,
-      nameShardSeed(projectId, shardKey),
-      nameShardPointId(projectId, shardKey),
+      nameShardSeed(projectId, shardKey, gen),
+      nameShardPointId(projectId, shardKey, gen),
       (payload) => (payload?.nameToSymbols as Record<string, SymbolRef[]>) ?? null,
       { projectId, shardKey },
     );
@@ -663,14 +693,15 @@ export async function saveReverseShard(
   projectId: string,
   bucket: number,
   reverseEdges: Record<string, string[]>,
+  generation?: string,
 ): Promise<void> {
   const collName = symgraphIndexCollectionName(projectId);
   await ensureCollection(collName);
   const bucketHex = reverseShardHex(bucket);
   await saveShardPoints(
     collName,
-    revShardSeed(projectId, bucketHex),
-    revShardPointId(projectId, bucketHex),
+    revShardSeed(projectId, bucketHex, generation),
+    revShardPointId(projectId, bucketHex, generation),
     reverseEdges,
     `reverse-call index shard ${bucketHex}`,
     (entries, part, parts) =>
@@ -683,15 +714,21 @@ export async function saveReverseShard(
 export async function loadReverseShard(
   projectId: string,
   bucket: number,
+  generation?: string,
 ): Promise<Record<string, string[]> | null> {
   try {
+    let gen = generation;
+    if (gen === undefined) {
+      const meta = await loadSymbolGraphMeta(projectId);
+      gen = meta?.generation;
+    }
     const collName = symgraphIndexCollectionName(projectId);
     await ensureCollection(collName);
     const bucketHex = reverseShardHex(bucket);
     return await loadShardPoints<string[]>(
       collName,
-      revShardSeed(projectId, bucketHex),
-      revShardPointId(projectId, bucketHex),
+      revShardSeed(projectId, bucketHex, gen),
+      revShardPointId(projectId, bucketHex, gen),
       (payload) => (payload?.reverseEdges as Record<string, string[]>) ?? null,
       { projectId, bucket },
     );

--- a/src/services/symbol-graph-store.ts
+++ b/src/services/symbol-graph-store.ts
@@ -289,7 +289,7 @@ async function saveShardPoints<V>(
     vector: [0],
     payload: {
       ...payloadFor(record, 0, 1),
-      ...(generation !== undefined ? { generation } : {}),
+      ...(generation ? { generation } : {}),
     },
   };
   const parts =
@@ -313,7 +313,7 @@ async function saveShardPoints<V>(
           payload: {
             ...payloadFor(entries, i, parts.length),
             write: writeId,
-            ...(generation !== undefined ? { generation } : {}),
+            ...(generation ? { generation } : {}),
           },
         }));
 
@@ -556,7 +556,7 @@ export async function saveFilePayload(
     vector: [0],
     payload: {
       filePayload: payload,
-      ...(generation !== undefined ? { generation } : {}),
+      ...(generation ? { generation } : {}),
     },
   };
   assertPointFits(point, `symbol payload for ${payload.file}`);
@@ -582,7 +582,7 @@ export async function saveFilePayloads(
     vector: [0],
     payload: {
       filePayload: p,
-      ...(generation !== undefined ? { generation } : {}),
+      ...(generation ? { generation } : {}),
     },
   }));
   await upsertWithinBudget(collName, points, (i) => `symbol payload for ${payloads[i].file}`);
@@ -781,19 +781,17 @@ export async function coordinateProject<T>(
   const next = new Promise<void>((res) => {
     release = res;
   });
-  projectLocks.set(
-    projectId,
-    current.then(
-      () => next,
-      () => next,
-    ),
+  const chained = current.then(
+    () => next,
+    () => next,
   );
+  projectLocks.set(projectId, chained);
   await current;
   try {
     return await fn();
   } finally {
     release!();
-    if (projectLocks.get(projectId) === next) {
+    if (projectLocks.get(projectId) === chained) {
       projectLocks.delete(projectId);
     }
   }

--- a/src/services/symbol-graph-store.ts
+++ b/src/services/symbol-graph-store.ts
@@ -763,6 +763,16 @@ export async function loadReverseShard(
 
 // ── Generation lifecycle and cleanup ────────────────────────────────────
 
+const activeStagingGenerations = new Set<string>();
+
+export function registerStagingGeneration(gen: string): void {
+  activeStagingGenerations.add(gen);
+}
+
+export function unregisterStagingGeneration(gen: string): void {
+  activeStagingGenerations.delete(gen);
+}
+
 /** Delete all points belonging to a specific generation from file and index collections. */
 export async function deleteGeneration(projectId: string, generation: string): Promise<void> {
   if (!generation) return;
@@ -804,7 +814,7 @@ export async function listStoredGenerations(projectId: string): Promise<string[]
       let offset: string | number | Record<string, unknown> | undefined;
       while (true) {
         const res = await qdrant.scroll(collName, {
-          limit: 100,
+          limit: 500,
           with_payload: ["generation"],
           with_vector: false,
           offset: offset as string | number | undefined,
@@ -839,23 +849,29 @@ export async function cleanStaleGenerations(
     symgraphIndexCollectionName(projectId),
   ];
 
+  const excludedGenerations = Array.from(new Set([activeGeneration, ...activeStagingGenerations]));
+  let allDeletesSucceeded = true;
+
   for (const collName of collNames) {
     try {
       await qdrant.delete(collName, {
         wait: true,
         filter: {
-          must: [{ key: "generation", match: { except: [activeGeneration] } }],
+          must: [{ key: "generation", match: { except: excludedGenerations } }],
         },
       });
     } catch {
-      // Best-effort
+      allDeletesSucceeded = false;
     }
   }
 
-  const stored = await listStoredGenerations(projectId);
-  for (const gen of stored) {
-    if (gen !== activeGeneration) {
-      await deleteGeneration(projectId, gen);
+  // If filtered deletes did not both succeed cleanly, fall back to generation scan
+  if (!allDeletesSucceeded) {
+    const stored = await listStoredGenerations(projectId);
+    for (const gen of stored) {
+      if (!excludedGenerations.includes(gen)) {
+        await deleteGeneration(projectId, gen);
+      }
     }
   }
 }

--- a/src/services/symbol-graph-store.ts
+++ b/src/services/symbol-graph-store.ts
@@ -761,16 +761,126 @@ export async function loadReverseShard(
   }
 }
 
-// ── Generation lifecycle and cleanup ────────────────────────────────────
+// ── Generation lifecycle and coordination ───────────────────────────────
 
-const activeStagingGenerations = new Set<string>();
+const projectLocks = new Map<string, Promise<void>>();
+const stagingGenerationsByProject = new Map<string, Set<string>>();
+const activeReadersByProject = new Map<string, Map<string, number>>();
+const deferredDeletionsByProject = new Map<string, Set<string>>();
 
-export function registerStagingGeneration(gen: string): void {
-  activeStagingGenerations.add(gen);
+/**
+ * Coordinate staging, activation, and cleanup operations per project.
+ * Guarantees operations for the same projectId do not interleave concurrently.
+ */
+export async function coordinateProject<T>(
+  projectId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const current = projectLocks.get(projectId) ?? Promise.resolve();
+  let release: () => void;
+  const next = new Promise<void>((res) => {
+    release = res;
+  });
+  projectLocks.set(
+    projectId,
+    current.then(
+      () => next,
+      () => next,
+    ),
+  );
+  await current;
+  try {
+    return await fn();
+  } finally {
+    release!();
+    if (projectLocks.get(projectId) === next) {
+      projectLocks.delete(projectId);
+    }
+  }
 }
 
-export function unregisterStagingGeneration(gen: string): void {
-  activeStagingGenerations.delete(gen);
+export function registerStagingGeneration(projectIdOrGen: string, gen?: string): void {
+  const projectId = gen !== undefined ? projectIdOrGen : "";
+  const generation = gen !== undefined ? gen : projectIdOrGen;
+  if (!generation) return;
+  let set = stagingGenerationsByProject.get(projectId);
+  if (!set) {
+    set = new Set();
+    stagingGenerationsByProject.set(projectId, set);
+  }
+  set.add(generation);
+}
+
+export function unregisterStagingGeneration(projectIdOrGen: string, gen?: string): void {
+  const projectId = gen !== undefined ? projectIdOrGen : "";
+  const generation = gen !== undefined ? gen : projectIdOrGen;
+  if (!generation) return;
+  const set = stagingGenerationsByProject.get(projectId);
+  if (set) {
+    set.delete(generation);
+    if (set.size === 0) stagingGenerationsByProject.delete(projectId);
+  }
+}
+
+export function getStagingGenerations(projectId: string): string[] {
+  const projectSpecific = stagingGenerationsByProject.get(projectId);
+  const legacyGlobal = stagingGenerationsByProject.get("");
+  const all = new Set<string>([
+    ...(projectSpecific ?? []),
+    ...(legacyGlobal ?? []),
+  ]);
+  return Array.from(all);
+}
+
+export function retainReader(projectId: string, generation?: string): void {
+  if (!generation) return;
+  let map = activeReadersByProject.get(projectId);
+  if (!map) {
+    map = new Map();
+    activeReadersByProject.set(projectId, map);
+  }
+  map.set(generation, (map.get(generation) ?? 0) + 1);
+}
+
+export function releaseReader(projectId: string, generation?: string): void {
+  if (!generation) return;
+  const map = activeReadersByProject.get(projectId);
+  if (!map) return;
+  const count = (map.get(generation) ?? 1) - 1;
+  if (count <= 0) {
+    map.delete(generation);
+    if (map.size === 0) activeReadersByProject.delete(projectId);
+    const deferred = deferredDeletionsByProject.get(projectId);
+    if (deferred?.has(generation)) {
+      deferred.delete(generation);
+      if (deferred.size === 0) deferredDeletionsByProject.delete(projectId);
+      deleteGeneration(projectId, generation).catch((err) => {
+        logger.warn("Deferred generation deletion failed", {
+          projectId,
+          generation,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
+  } else {
+    map.set(generation, count);
+  }
+}
+
+export function getActiveReaderGenerations(projectId: string): string[] {
+  const map = activeReadersByProject.get(projectId);
+  return map ? Array.from(map.keys()) : [];
+}
+
+export function hasActiveReaders(projectId: string, generation: string): boolean {
+  return (activeReadersByProject.get(projectId)?.get(generation) ?? 0) > 0;
+}
+
+export function resetGenerationLifecycleState(): void {
+  projectLocks.clear();
+  stagingGenerationsByProject.clear();
+  activeReadersByProject.clear();
+  deferredDeletionsByProject.clear();
 }
 
 /** Delete all points belonging to a specific generation from file and index collections. */
@@ -836,7 +946,8 @@ export async function listStoredGenerations(projectId: string): Promise<string[]
 }
 
 /**
- * Remove points belonging to superseded or abandoned generations, keeping only activeGeneration.
+ * Remove points belonging to superseded or abandoned generations, keeping activeGeneration,
+ * generations currently in staging, and generations held by active readers.
  */
 export async function cleanStaleGenerations(
   projectId: string,
@@ -849,7 +960,11 @@ export async function cleanStaleGenerations(
     symgraphIndexCollectionName(projectId),
   ];
 
-  const excludedGenerations = Array.from(new Set([activeGeneration, ...activeStagingGenerations]));
+  const stagingGens = getStagingGenerations(projectId);
+  const readerGens = getActiveReaderGenerations(projectId);
+  const excludedGenerations = Array.from(
+    new Set([activeGeneration, ...stagingGens, ...readerGens]),
+  );
   let allDeletesSucceeded = true;
 
   for (const collName of collNames) {
@@ -865,7 +980,19 @@ export async function cleanStaleGenerations(
     }
   }
 
-  // If filtered deletes did not both succeed cleanly, fall back to generation scan
+  // Register deferred deletion for any stale generations currently held by active readers
+  for (const gen of readerGens) {
+    if (gen !== activeGeneration && !stagingGens.includes(gen)) {
+      let deferred = deferredDeletionsByProject.get(projectId);
+      if (!deferred) {
+        deferred = new Set();
+        deferredDeletionsByProject.set(projectId, deferred);
+      }
+      deferred.add(gen);
+    }
+  }
+
+  // If filtered delete did not succeed on all collections, fall back to explicit per-generation delete
   if (!allDeletesSucceeded) {
     const stored = await listStoredGenerations(projectId);
     for (const gen of stored) {

--- a/src/services/symbol-graph-store.ts
+++ b/src/services/symbol-graph-store.ts
@@ -321,11 +321,18 @@ async function saveShardPoints<V>(
   }
 }
 
+export class StorageReadError extends Error {
+  constructor(message: string, public readonly context?: Record<string, unknown>) {
+    super(message);
+    this.name = "StorageReadError";
+  }
+}
+
 /**
  * Read a shard written by {@link saveShardPoints}: the point at the shard's
  * original id, plus continuation parts when it declares any. Returns the
- * merged entries, or null when a declared part is missing — the shard is then
- * incomplete and pretending otherwise would under-report quietly.
+ * merged entries, or null when genuinely absent (primary point missing), or
+ * throws StorageReadError when a declared part or payload is corrupted/missing.
  */
 async function loadShardPoints<V>(
   collName: string,
@@ -340,7 +347,9 @@ async function loadShardPoints<V>(
 
   const payload = primary[0].payload as Record<string, unknown> | null | undefined;
   const first = entriesOf(payload);
-  if (first === null) return null;
+  if (first === null) {
+    throw new StorageReadError("Shard primary payload is malformed or missing entries", logContext);
+  }
 
   const declared = payload?.parts;
   const parts = typeof declared === "number" && declared > 1 ? declared : 1;
@@ -352,12 +361,15 @@ async function loadShardPoints<V>(
   // absent identity must not slide through as `undefined === undefined`.
   const writeId = payload?.write;
   if (!Number.isInteger(parts) || typeof writeId !== "string" || writeId.length === 0) {
-    logger.warn("Multipart shard has a malformed header (returning null)", {
+    logger.warn("Multipart shard has a malformed header", {
       ...logContext,
       declaredParts: declared,
       hasWriteId: typeof writeId === "string" && writeId.length > 0,
     });
-    return null;
+    throw new StorageReadError("Multipart shard has a malformed header", {
+      ...logContext,
+      declaredParts: declared,
+    });
   }
 
   const restIds: string[] = [];
@@ -376,24 +388,21 @@ async function loadShardPoints<V>(
     rest.push(...(await qdrant.retrieve(collName, { ids: restIds.slice(i, i + RETRIEVE_PART_CHUNK), with_payload: true })));
   }
   if (rest.length !== restIds.length) {
-    logger.warn("Shard is missing continuation parts (returning null)", {
+    logger.warn("Shard is missing continuation parts", {
       ...logContext,
       declaredParts: parts,
       found: rest.length + 1,
     });
-    return null;
+    throw new StorageReadError("Shard is missing continuation parts", {
+      ...logContext,
+      declaredParts: parts,
+      found: rest.length + 1,
+    });
   }
 
   const merged: Record<string, V> = { ...first };
   for (const point of rest) {
     const partPayload = point.payload as Record<string, unknown> | null | undefined;
-    // A continuation part from a DIFFERENT write than part 0 means a rewrite
-    // died partway: the ids line up (they are deterministic) but the contents
-    // are two writes interleaved. Serving the merge would return a record
-    // equal to neither write, silently — treat it exactly like a missing part.
-    // The part/parts headers are cross-checked by expected id, not response
-    // order, so a point sitting at the right id with the wrong headers is
-    // rejected as corruption too.
     const expectedPart = expectedPartById.get(String(point.id));
     if (
       partPayload?.write !== writeId ||
@@ -401,17 +410,21 @@ async function loadShardPoints<V>(
       partPayload?.part !== expectedPart ||
       partPayload?.parts !== parts
     ) {
-      logger.warn("Shard continuation part belongs to a different write or is malformed (returning null)", {
+      logger.warn("Shard continuation part belongs to a different write or is malformed", {
         ...logContext,
         declaredParts: parts,
         pointId: String(point.id),
       });
-      return null;
+      throw new StorageReadError("Shard continuation part belongs to a different write or is malformed", {
+        ...logContext,
+        declaredParts: parts,
+        pointId: String(point.id),
+      });
     }
     const entries = entriesOf(partPayload);
     if (entries === null) {
-      logger.warn("Shard continuation part has no entries (returning null)", { ...logContext });
-      return null;
+      logger.warn("Shard continuation part has no entries", { ...logContext });
+      throw new StorageReadError("Shard continuation part has no entries", logContext);
     }
     Object.assign(merged, entries);
   }
@@ -611,12 +624,11 @@ export async function loadNameShard(
       { projectId, shardKey },
     );
   } catch (err) {
-    logger.warn("loadNameShard failed (returning null)", {
-      projectId,
-      shardKey,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return null;
+    if (err instanceof StorageReadError) throw err;
+    throw new StorageReadError(
+      `loadNameShard failed for shard '${shardKey}': ${err instanceof Error ? err.message : String(err)}`,
+      { projectId, shardKey },
+    );
   }
 }
 
@@ -659,12 +671,11 @@ export async function loadReverseShard(
       { projectId, bucket },
     );
   } catch (err) {
-    logger.warn("loadReverseShard failed (returning null)", {
-      projectId,
-      bucket,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return null;
+    if (err instanceof StorageReadError) throw err;
+    throw new StorageReadError(
+      `loadReverseShard failed for bucket ${bucket}: ${err instanceof Error ? err.message : String(err)}`,
+      { projectId, bucket },
+    );
   }
 }
 

--- a/src/services/symbol-graph-store.ts
+++ b/src/services/symbol-graph-store.ts
@@ -280,10 +280,18 @@ async function saveShardPoints<V>(
   record: Record<string, V>,
   what: string,
   payloadFor: (entries: Record<string, V>, part: number, parts: number) => Record<string, unknown>,
+  generation?: string,
 ): Promise<void> {
   const qdrant = getClient();
 
-  const single: SymgraphPoint = { id: primaryId, vector: [0], payload: payloadFor(record, 0, 1) };
+  const single: SymgraphPoint = {
+    id: primaryId,
+    vector: [0],
+    payload: {
+      ...payloadFor(record, 0, 1),
+      ...(generation !== undefined ? { generation } : {}),
+    },
+  };
   const parts =
     pointBytes(single) <= QDRANT_UPSERT_BUDGET_BYTES
       ? [record]
@@ -302,7 +310,11 @@ async function saveShardPoints<V>(
       : parts.map((entries, i) => ({
           id: i === 0 ? primaryId : shardPartPointId(primaryKey, i),
           vector: [0],
-          payload: { ...payloadFor(entries, i, parts.length), write: writeId },
+          payload: {
+            ...payloadFor(entries, i, parts.length),
+            write: writeId,
+            ...(generation !== undefined ? { generation } : {}),
+          },
         }));
 
   // How many continuation parts did the previous write leave? Read the old
@@ -542,7 +554,10 @@ export async function saveFilePayload(
   const point: SymgraphPoint = {
     id: filePointId(projectId, payload.file, generation),
     vector: [0],
-    payload: { filePayload: payload },
+    payload: {
+      filePayload: payload,
+      ...(generation !== undefined ? { generation } : {}),
+    },
   };
   assertPointFits(point, `symbol payload for ${payload.file}`);
   await qdrant.upsert(collName, { points: [point] });
@@ -565,7 +580,10 @@ export async function saveFilePayloads(
   const points: SymgraphPoint[] = payloads.map((p) => ({
     id: filePointId(projectId, p.file, generation),
     vector: [0],
-    payload: { filePayload: p },
+    payload: {
+      filePayload: p,
+      ...(generation !== undefined ? { generation } : {}),
+    },
   }));
   await upsertWithinBudget(collName, points, (i) => `symbol payload for ${payloads[i].file}`);
 }
@@ -655,6 +673,7 @@ export async function saveNameShard(
       parts === 1
         ? { kind: "name", shard: shardKey, nameToSymbols: entries }
         : { kind: "name", shard: shardKey, part, parts, nameToSymbols: entries },
+    generation,
   );
 }
 
@@ -708,6 +727,7 @@ export async function saveReverseShard(
       parts === 1
         ? { kind: "reverse", bucket, reverseEdges: entries }
         : { kind: "reverse", bucket, part, parts, reverseEdges: entries },
+    generation,
   );
 }
 
@@ -738,6 +758,105 @@ export async function loadReverseShard(
       `loadReverseShard failed for bucket ${bucket}: ${err instanceof Error ? err.message : String(err)}`,
       { projectId, bucket },
     );
+  }
+}
+
+// ── Generation lifecycle and cleanup ────────────────────────────────────
+
+/** Delete all points belonging to a specific generation from file and index collections. */
+export async function deleteGeneration(projectId: string, generation: string): Promise<void> {
+  if (!generation) return;
+  const qdrant = getClient();
+  const collNames = [
+    symgraphFileCollectionName(projectId),
+    symgraphIndexCollectionName(projectId),
+  ];
+  for (const collName of collNames) {
+    try {
+      await qdrant.delete(collName, {
+        wait: true,
+        filter: {
+          must: [{ key: "generation", match: { value: generation } }],
+        },
+      });
+    } catch (err) {
+      logger.warn("deleteGeneration: failed to delete points for generation", {
+        projectId,
+        generation,
+        collName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/** Find all distinct generation IDs present in storage for a project. */
+export async function listStoredGenerations(projectId: string): Promise<string[]> {
+  const qdrant = getClient();
+  const generations = new Set<string>();
+  const collNames = [
+    symgraphFileCollectionName(projectId),
+    symgraphIndexCollectionName(projectId),
+  ];
+
+  for (const collName of collNames) {
+    try {
+      let offset: string | number | Record<string, unknown> | undefined;
+      while (true) {
+        const res = await qdrant.scroll(collName, {
+          limit: 100,
+          with_payload: ["generation"],
+          with_vector: false,
+          offset: offset as string | number | undefined,
+        });
+        for (const pt of res.points) {
+          const gen = pt.payload?.generation;
+          if (typeof gen === "string" && gen.length > 0) {
+            generations.add(gen);
+          }
+        }
+        if (!res.next_page_offset) break;
+        offset = res.next_page_offset;
+      }
+    } catch {
+      // Collection may not exist yet
+    }
+  }
+  return Array.from(generations);
+}
+
+/**
+ * Remove points belonging to superseded or abandoned generations, keeping only activeGeneration.
+ */
+export async function cleanStaleGenerations(
+  projectId: string,
+  activeGeneration: string,
+): Promise<void> {
+  if (!activeGeneration) return;
+  const qdrant = getClient();
+  const collNames = [
+    symgraphFileCollectionName(projectId),
+    symgraphIndexCollectionName(projectId),
+  ];
+
+  for (const collName of collNames) {
+    try {
+      await qdrant.delete(collName, {
+        wait: true,
+        filter: {
+          must: [{ key: "generation", match: { except: [activeGeneration] } }],
+        },
+      });
+    } catch {
+      // Best-effort
+    }
+  }
+
+  const stored = await listStoredGenerations(projectId);
+  for (const gen of stored) {
+    if (gen !== activeGeneration) {
+      await deleteGeneration(projectId, gen);
+    }
   }
 }
 

--- a/src/services/symbol-graph-store.ts
+++ b/src/services/symbol-graph-store.ts
@@ -352,7 +352,19 @@ async function loadShardPoints<V>(
   }
 
   const declared = payload?.parts;
-  const parts = typeof declared === "number" && declared > 1 ? declared : 1;
+  if (declared !== undefined) {
+    if (typeof declared !== "number" || !Number.isInteger(declared) || declared < 2) {
+      logger.warn("Multipart shard has a malformed header", {
+        ...logContext,
+        declaredParts: declared,
+      });
+      throw new StorageReadError("Multipart shard has a malformed header", {
+        ...logContext,
+        declaredParts: declared,
+      });
+    }
+  }
+  const parts = declared ?? 1;
   if (parts === 1) return first; // every pre-split graph, and most shards after
 
   // Fail closed on a malformed multipart header. Only saveShardPoints writes
@@ -360,7 +372,7 @@ async function loadShardPoints<V>(
   // identity, so a missing/non-integer/empty header here is corruption, and an
   // absent identity must not slide through as `undefined === undefined`.
   const writeId = payload?.write;
-  if (!Number.isInteger(parts) || typeof writeId !== "string" || writeId.length === 0) {
+  if (typeof writeId !== "string" || writeId.length === 0) {
     logger.warn("Multipart shard has a malformed header", {
       ...logContext,
       declaredParts: declared,
@@ -494,7 +506,11 @@ export async function loadSymbolGraphMeta(
     });
     if (points.length === 0) return null;
     const payload = points[0].payload;
-    return (payload?.meta as SymbolGraphMeta) ?? null;
+    const meta = (payload?.meta as SymbolGraphMeta) ?? null;
+    if (meta && meta.schemaVersion === undefined) {
+      meta.schemaVersion = 1;
+    }
+    return meta;
   } catch (err) {
     logger.warn("loadSymbolGraphMeta failed (returning null)", {
       projectId,

--- a/src/services/symbol-graph-store.ts
+++ b/src/services/symbol-graph-store.ts
@@ -574,12 +574,16 @@ export async function loadFilePayload(
     if (points.length === 0) return null;
     return (points[0].payload?.filePayload as SymbolGraphFilePayload) ?? null;
   } catch (err) {
-    logger.warn("loadFilePayload failed (returning null)", {
+    logger.warn("loadFilePayload failed", {
       projectId,
       file: relativePath,
       error: err instanceof Error ? err.message : String(err),
     });
-    return null;
+    throw new StorageReadError("loadFilePayload failed", {
+      projectId,
+      file: relativePath,
+      cause: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 
@@ -595,10 +599,15 @@ export async function deleteFilePayload(
       points: [filePointId(projectId, relativePath)],
     });
   } catch (err) {
-    logger.warn("deleteFilePayload failed (ignored)", {
+    logger.warn("deleteFilePayload failed", {
       projectId,
       file: relativePath,
       error: err instanceof Error ? err.message : String(err),
+    });
+    throw new StorageReadError("deleteFilePayload failed", {
+      projectId,
+      file: relativePath,
+      cause: err instanceof Error ? err.message : String(err),
     });
   }
 }

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -405,8 +405,10 @@ async function dispatchGraphTool(
     }
 
     case "codebase_impact": {
-      const target = (args.target as string)?.trim();
-      if (!target) return "Missing required argument: target";
+      const target = (args.target as string | undefined)?.trim() ?? "";
+      const file = (args.file as string | undefined)?.trim();
+      const symbolId = (args.symbolId as string | undefined)?.trim();
+      if (!target && !symbolId) return "Missing required argument: target or symbolId";
       const depth = typeof args.depth === "number" ? args.depth : 3;
       const projectId = projectIdFromPath(projectPath);
       const cache = await getSymbolGraphCache(projectId);
@@ -416,10 +418,16 @@ async function dispatchGraphTool(
       ensureDynamicLanguages();
       const grammarStatus = getDynamicLanguageStatus();
       const isIncomplete = grammarStatus.failed.length > 0 || (cache.meta.schemaVersion ? cache.meta.schemaVersion < 2 : true);
-      const result = await getImpactRadius(cache, target, depth, { isIncomplete });
+      const result = await getImpactRadius(cache, target || (symbolId as string), depth, { file, symbolId, isIncomplete });
 
+      if (result.status === "graph_upgrade_required") {
+        return result.message ?? "The symbol graph requires an upgrade. Rebuild with codebase_graph_build.";
+      }
+      if (result.status === "storage_error") {
+        return `Storage error: ${result.message}`;
+      }
       if (result.status === "not_found") {
-        return result.message ?? `Target '${target}' was not found in the graph.`;
+        return result.message ?? `Target '${target || symbolId}' was not found in the graph.`;
       }
       if (result.status === "ambiguous") {
         const lines = [
@@ -430,13 +438,13 @@ async function dispatchGraphTool(
           lines.push("");
           lines.push("Candidates:");
           for (const c of result.candidates) {
-            lines.push(`  - [${c.kind}] ${c.qualifiedName} in ${c.file}:${c.line}`);
+            lines.push(`  - [${c.kind}] ${c.qualifiedName} in ${c.file}:${c.line} (ID: ${c.id})`);
           }
         }
         return lines.join("\n").trimEnd();
       }
       if (result.status === "unsupported_or_incomplete") {
-        return result.message ?? `Graph analysis for '${target}' is incomplete.`;
+        return result.message ?? `Graph analysis for '${target || symbolId}' is incomplete.`;
       }
 
       const lines = [

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -522,18 +522,19 @@ async function dispatchGraphTool(
       // Zero-arg mode → ranked entry-point list
       if (!entrypoint) {
         const release = cache.acquireReader();
+        const readerToken = release.token;
         try {
           // Build a fresh detection using the file graph + per-file payloads from the cache.
           // For efficiency we only list entry points by walking known symbols via the name index.
           const fileGraph = await getOrBuildGraph(projectPath);
-          const nameIndex = await cache.getNameIndex();
+          const nameIndex = await cache.getNameIndex(readerToken);
           const seenFiles = new Set<string>();
           const payloads = [];
           for (const refs of nameIndex.values()) {
             for (const ref of refs) {
               if (seenFiles.has(ref.file)) continue;
               seenFiles.add(ref.file);
-              const p = await cache.getFilePayload(ref.file);
+              const p = await cache.getFilePayload(ref.file, readerToken);
               if (p) payloads.push(p);
             }
           }
@@ -555,8 +556,9 @@ async function dispatchGraphTool(
 
       // Hold one generation across name resolution and the complete traversal.
       const release = cache.acquireReader();
+      const readerToken = release.token;
       try {
-        const nameIndex = await cache.getNameIndex();
+        const nameIndex = await cache.getNameIndex(readerToken);
         let refs = nameIndex.get(entrypoint) ?? [];
         const fileHint = (args.file as string | undefined)?.trim();
         if (fileHint) refs = refs.filter((r) => r.file === fileHint);
@@ -569,7 +571,7 @@ async function dispatchGraphTool(
           return lines.join("\n");
         }
         const depth = typeof args.depth === "number" ? args.depth : 5;
-        const tree = await getCallFlow(cache, refs[0].id, depth);
+        const tree = await getCallFlow(cache, refs[0].id, depth, readerToken);
         if (!tree) return `Could not load symbol "${entrypoint}".`;
 
         const lines = [`Call flow from ${tree.symbolName} (${tree.file}:${tree.line})`, ""];

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -270,16 +270,17 @@ async function dispatchGraphTool(
       // the real loader state. Idempotent and cheap after the first call.
       ensureDynamicLanguages();
       const grammarStatus = getDynamicLanguageStatus();
+      const BUILTIN_AST_LANGUAGES = [
+        "csharp", "go", "java", "javascript", "kotlin", "python", "rust", "tsx", "typescript",
+      ];
       const renderGrammarBlock = (): string[] => {
-        if (grammarStatus.loaded.length === 0 && grammarStatus.failed.length === 0) {
-          return [];
-        }
         const block: string[] = ["", "AST grammars:"];
+        block.push(`  Built-in (ast-grep, ${BUILTIN_AST_LANGUAGES.length}): ${BUILTIN_AST_LANGUAGES.join(", ")}`);
         if (grammarStatus.loaded.length > 0) {
-          block.push(`  Loaded (${grammarStatus.loaded.length}): ${grammarStatus.loaded.join(", ")}`);
+          block.push(`  Dynamic loaded (${grammarStatus.loaded.length}): ${grammarStatus.loaded.join(", ")}`);
         }
         if (grammarStatus.failed.length > 0) {
-          block.push(`  Failed (${grammarStatus.failed.length}):`);
+          block.push(`  Dynamic failed (${grammarStatus.failed.length}):`);
           for (const f of grammarStatus.failed) {
             block.push(`    - ${f.name}: ${f.error}`);
           }
@@ -413,13 +414,35 @@ async function dispatchGraphTool(
         return "No symbol graph found. Run codebase_graph_build (or codebase_index) first.";
       }
       const result = await getImpactRadius(cache, target, depth);
+
+      if (result.status === "not_found") {
+        return result.message ?? `Target '${target}' was not found in the graph.`;
+      }
+      if (result.status === "ambiguous") {
+        const lines = [
+          `Target '${target}' is ambiguous:`,
+          result.message ?? "",
+        ];
+        if (result.candidates && result.candidates.length > 0) {
+          lines.push("");
+          lines.push("Candidates:");
+          for (const c of result.candidates) {
+            lines.push(`  - [${c.kind}] ${c.qualifiedName} in ${c.file}:${c.line}`);
+          }
+        }
+        return lines.join("\n").trimEnd();
+      }
+      if (result.status === "unsupported_or_incomplete") {
+        return result.message ?? `Graph analysis for '${target}' is incomplete.`;
+      }
+
       const lines = [
         `Blast radius for ${result.targetKind}: ${result.target}`,
         `Depth: ${result.depth}    Total impacted files: ${result.totalFiles}`,
         "",
       ];
       if (result.totalFiles === 0) {
-        lines.push("No callers found — nothing else depends on this.");
+        lines.push("No callers or references found — nothing else depends on this.");
       } else {
         for (const [hop, files] of result.filesByDepth.entries()) {
           lines.push(`Hop ${hop} (${files.length} files):`);

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -279,7 +279,7 @@ async function dispatchGraphTool(
       ensureDynamicLanguages();
       const grammarStatus = getDynamicLanguageStatus();
       const BUILTIN_AST_LANGUAGES = [
-        "csharp", "go", "java", "javascript", "kotlin", "python", "rust", "tsx", "typescript",
+        "css", "html", "javascript", "tsx", "typescript",
       ];
       const renderGrammarBlock = (): string[] => {
         const block: string[] = ["", "AST grammars:"];

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -3,7 +3,7 @@
 import path from "node:path";
 import { projectIdFromPath } from "../config.js";
 import { mergeExtraExtensions, SOCRATICODE_VERSION } from "../constants.js";
-import { awaitGraphBuild, describeGraphBuilder, ensureDynamicLanguages, findCircularDependencies, generateMermaidDiagram, getDynamicLanguageStatus, getFileDependencies, getGraphBuildProgress, getGraphStats, getGraphStatus, getLastGraphBuildCompleted, getOrBuildGraph, isGraphBuildInProgress, isImportResolutionLow, rebuildGraph, removeGraph } from "../services/code-graph.js";
+import { awaitGraphBuild, describeGraphBuilder, ensureDynamicLanguages, findCircularDependencies, generateMermaidDiagram, getAstGrepLang, getDynamicLanguageStatus, getFileDependencies, getGraphBuildProgress, getGraphStats, getGraphStatus, getLastGraphBuildCompleted, getOrBuildGraph, isGraphBuildInProgress, isImportResolutionLow, rebuildGraph, removeGraph } from "../services/code-graph.js";
 import { detectEntryPoints } from "../services/graph-entrypoints.js";
 import {
   type FlowNode,
@@ -16,8 +16,14 @@ import {
 import { openInBrowser, writeInteractiveGraphFile } from "../services/graph-visualize-browser.js";
 import { buildInteractiveGraphHtml } from "../services/graph-visualize-html.js";
 import { logger } from "../services/logger.js";
-import { getSymbolGraphCache } from "../services/symbol-graph-cache.js";
-import { StorageReadError } from "../services/symbol-graph-store.js";
+import {
+  dropSymbolGraphCacheGeneration,
+  getSymbolGraphCache,
+} from "../services/symbol-graph-cache.js";
+import {
+  StorageReadError,
+  SymbolGraphGenerationChangedError,
+} from "../services/symbol-graph-store.js";
 import { ensureWatcherStarted } from "../services/watcher.js";
 
 /**
@@ -33,28 +39,56 @@ const SYMBOL_GRAPH_TOOLS = new Set([
   "codebase_symbols",
 ]);
 
+function hasRelevantGrammarFailure(
+  failed: Array<{ name: string }>,
+  target: string,
+  file?: string,
+  symbolId?: string,
+): boolean {
+  if (failed.length === 0) return false;
+  const hintedFile = symbolId?.split("::")[0]
+    ?? file
+    ?? (looksLikeFilePath(target) ? target : undefined);
+  if (!hintedFile) return true;
+
+  const grammar = getAstGrepLang(path.extname(hintedFile).toLowerCase());
+  if (!grammar) return true;
+  return failed.some(({ name }) => name.toLowerCase() === String(grammar).toLowerCase());
+}
+
 export async function handleGraphTool(
   name: string,
   args: Record<string, unknown>,
 ): Promise<string> {
-  try {
-    const result = await dispatchGraphTool(name, args);
-    if (!SYMBOL_GRAPH_TOOLS.has(name)) return result;
-    const resolved = path.resolve((args.projectPath as string) || process.cwd());
-    const symbolGraphError = getLastGraphBuildCompleted(resolved)?.symbolGraphError;
-    if (!symbolGraphError) return result;
-    return [
-      `WARNING: the last graph build could not persist the symbol graph: ${symbolGraphError}`,
-      "Results below may be stale or incomplete until a rebuild succeeds.",
-      "",
-      result,
-    ].join("\n");
-  } catch (err) {
-    if (err instanceof StorageReadError) {
-      return `Storage error: ${err.message}`;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const result = await dispatchGraphTool(name, args);
+      if (!SYMBOL_GRAPH_TOOLS.has(name)) return result;
+      const resolved = path.resolve((args.projectPath as string) || process.cwd());
+      const symbolGraphError = getLastGraphBuildCompleted(resolved)?.symbolGraphError;
+      if (!symbolGraphError) return result;
+      return [
+        `WARNING: the last graph build could not persist the symbol graph: ${symbolGraphError}`,
+        "Results below may be stale or incomplete until a rebuild succeeds.",
+        "",
+        result,
+      ].join("\n");
+    } catch (err) {
+      if (
+        err instanceof SymbolGraphGenerationChangedError
+        && SYMBOL_GRAPH_TOOLS.has(name)
+        && attempt === 0
+      ) {
+        dropSymbolGraphCacheGeneration(err.projectId, err.generation);
+        continue;
+      }
+      if (err instanceof StorageReadError) {
+        return `Storage error: ${err.message}`;
+      }
+      throw err;
     }
-    throw err;
   }
+  return "Storage error: symbol graph generation changed repeatedly while the query was starting";
 }
 
 async function dispatchGraphTool(
@@ -425,7 +459,12 @@ async function dispatchGraphTool(
       }
       ensureDynamicLanguages();
       const grammarStatus = getDynamicLanguageStatus();
-      const isIncomplete = grammarStatus.failed.length > 0 || (cache.meta.schemaVersion ? cache.meta.schemaVersion < 2 : true);
+      const isIncomplete = hasRelevantGrammarFailure(
+        grammarStatus.failed,
+        target,
+        file,
+        symbolId,
+      ) || (cache.meta.schemaVersion ? cache.meta.schemaVersion < 2 : true);
       const result = await getImpactRadius(cache, target || (symbolId as string), depth, { file, symbolId, isIncomplete });
 
       if (result.status === "graph_upgrade_required") {
@@ -514,26 +553,31 @@ async function dispatchGraphTool(
         }
       }
 
-      // Resolve symbol name → id via name index (file hint disambiguates)
-      const nameIndex = await cache.getNameIndex();
-      let refs = nameIndex.get(entrypoint) ?? [];
-      const fileHint = (args.file as string | undefined)?.trim();
-      if (fileHint) refs = refs.filter((r) => r.file === fileHint);
-      if (refs.length === 0) {
-        return `No symbol named "${entrypoint}" found${fileHint ? ` in ${fileHint}` : ""}.`;
-      }
-      if (refs.length > 1) {
-        const lines = [`Symbol "${entrypoint}" is ambiguous (${refs.length} matches). Pass \`file\` to disambiguate:`, ""];
-        for (const r of refs) lines.push(`  - ${r.file}`);
-        return lines.join("\n");
-      }
-      const depth = typeof args.depth === "number" ? args.depth : 5;
-      const tree = await getCallFlow(cache, refs[0].id, depth);
-      if (!tree) return `Could not load symbol "${entrypoint}".`;
+      // Hold one generation across name resolution and the complete traversal.
+      const release = cache.acquireReader();
+      try {
+        const nameIndex = await cache.getNameIndex();
+        let refs = nameIndex.get(entrypoint) ?? [];
+        const fileHint = (args.file as string | undefined)?.trim();
+        if (fileHint) refs = refs.filter((r) => r.file === fileHint);
+        if (refs.length === 0) {
+          return `No symbol named "${entrypoint}" found${fileHint ? ` in ${fileHint}` : ""}.`;
+        }
+        if (refs.length > 1) {
+          const lines = [`Symbol "${entrypoint}" is ambiguous (${refs.length} matches). Pass \`file\` to disambiguate:`, ""];
+          for (const r of refs) lines.push(`  - ${r.file}`);
+          return lines.join("\n");
+        }
+        const depth = typeof args.depth === "number" ? args.depth : 5;
+        const tree = await getCallFlow(cache, refs[0].id, depth);
+        if (!tree) return `Could not load symbol "${entrypoint}".`;
 
-      const lines = [`Call flow from ${tree.symbolName} (${tree.file}:${tree.line})`, ""];
-      renderFlowTree(tree, "", true, lines);
-      return lines.join("\n");
+        const lines = [`Call flow from ${tree.symbolName} (${tree.file}:${tree.line})`, ""];
+        renderFlowTree(tree, "", true, lines);
+        return lines.join("\n");
+      } finally {
+        release();
+      }
     }
 
     case "codebase_symbol": {

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -413,7 +413,10 @@ async function dispatchGraphTool(
       if (!cache) {
         return "No symbol graph found. Run codebase_graph_build (or codebase_index) first.";
       }
-      const result = await getImpactRadius(cache, target, depth);
+      ensureDynamicLanguages();
+      const grammarStatus = getDynamicLanguageStatus();
+      const isIncomplete = grammarStatus.failed.length > 0 || (cache.meta.schemaVersion ? cache.meta.schemaVersion < 2 : true);
+      const result = await getImpactRadius(cache, target, depth, { isIncomplete });
 
       if (result.status === "not_found") {
         return result.message ?? `Target '${target}' was not found in the graph.`;

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -543,13 +543,13 @@ async function dispatchGraphTool(
         lines.push("");
         lines.push(`Callers (${ctx.callers.length}):`);
         if (ctx.callers.length === 0) lines.push("  (none — possibly an entry point or unused)");
-        else for (const c of ctx.callers.slice(0, 30)) lines.push(`  ← ${c.file}:${c.line}`);
+        else for (const c of ctx.callers.slice(0, 30)) lines.push(`  ← ${c.file}:${c.line}${c.kind ? ` (${c.kind})` : ""}`);
         if (ctx.callers.length > 30) lines.push(`  ... and ${ctx.callers.length - 30} more`);
         lines.push("");
         lines.push(`Callees (${ctx.callees.length}):`);
         if (ctx.callees.length === 0) lines.push("  (none)");
         else for (const c of ctx.callees.slice(0, 30)) {
-          lines.push(`  → ${c.name} [${c.confidence}${c.resolved.length > 0 ? `, ${c.resolved.length} candidate(s)` : ""}]`);
+          lines.push(`  → ${c.name} [${c.confidence}${c.resolved.length > 0 ? `, ${c.resolved.length} candidate(s)` : ""}${c.kind ? `, ${c.kind}` : ""}]`);
         }
         if (ctx.callees.length > 30) lines.push(`  ... and ${ctx.callees.length - 30} more`);
         lines.push("---");

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -482,31 +482,36 @@ async function dispatchGraphTool(
 
       // Zero-arg mode → ranked entry-point list
       if (!entrypoint) {
-        // Build a fresh detection using the file graph + per-file payloads from the cache.
-        // For efficiency we only list entry points by walking known symbols via the name index.
-        const fileGraph = await getOrBuildGraph(projectPath);
-        const nameIndex = await cache.getNameIndex();
-        const seenFiles = new Set<string>();
-        const payloads = [];
-        for (const refs of nameIndex.values()) {
-          for (const ref of refs) {
-            if (seenFiles.has(ref.file)) continue;
-            seenFiles.add(ref.file);
-            const p = await cache.getFilePayload(ref.file);
-            if (p) payloads.push(p);
+        const release = cache.acquireReader();
+        try {
+          // Build a fresh detection using the file graph + per-file payloads from the cache.
+          // For efficiency we only list entry points by walking known symbols via the name index.
+          const fileGraph = await getOrBuildGraph(projectPath);
+          const nameIndex = await cache.getNameIndex();
+          const seenFiles = new Set<string>();
+          const payloads = [];
+          for (const refs of nameIndex.values()) {
+            for (const ref of refs) {
+              if (seenFiles.has(ref.file)) continue;
+              seenFiles.add(ref.file);
+              const p = await cache.getFilePayload(ref.file);
+              if (p) payloads.push(p);
+            }
           }
+          const entries = detectEntryPoints(fileGraph, payloads);
+          if (entries.length === 0) {
+            return "No entry points detected. The codebase may not have orphan files, conventional main() functions, or framework routes.";
+          }
+          const lines = [`Detected ${entries.length} entry point(s):`, ""];
+          for (const e of entries.slice(0, 50)) {
+            lines.push(`  ${e.name} (${e.file}${e.line ? `:${e.line}` : ""}) — ${e.reason}`);
+          }
+          if (entries.length > 50) lines.push(`  ... and ${entries.length - 50} more`);
+          lines.push("", "Pass `entrypoint` to trace forward call flow from any of these.");
+          return lines.join("\n");
+        } finally {
+          release();
         }
-        const entries = detectEntryPoints(fileGraph, payloads);
-        if (entries.length === 0) {
-          return "No entry points detected. The codebase may not have orphan files, conventional main() functions, or framework routes.";
-        }
-        const lines = [`Detected ${entries.length} entry point(s):`, ""];
-        for (const e of entries.slice(0, 50)) {
-          lines.push(`  ${e.name} (${e.file}${e.line ? `:${e.line}` : ""}) — ${e.reason}`);
-        }
-        if (entries.length > 50) lines.push(`  ... and ${entries.length - 50} more`);
-        lines.push("", "Pass `entrypoint` to trace forward call flow from any of these.");
-        return lines.join("\n");
       }
 
       // Resolve symbol name → id via name index (file hint disambiguates)

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -17,6 +17,7 @@ import { openInBrowser, writeInteractiveGraphFile } from "../services/graph-visu
 import { buildInteractiveGraphHtml } from "../services/graph-visualize-html.js";
 import { logger } from "../services/logger.js";
 import { getSymbolGraphCache } from "../services/symbol-graph-cache.js";
+import { StorageReadError } from "../services/symbol-graph-store.js";
 import { ensureWatcherStarted } from "../services/watcher.js";
 
 /**
@@ -36,17 +37,24 @@ export async function handleGraphTool(
   name: string,
   args: Record<string, unknown>,
 ): Promise<string> {
-  const result = await dispatchGraphTool(name, args);
-  if (!SYMBOL_GRAPH_TOOLS.has(name)) return result;
-  const resolved = path.resolve((args.projectPath as string) || process.cwd());
-  const symbolGraphError = getLastGraphBuildCompleted(resolved)?.symbolGraphError;
-  if (!symbolGraphError) return result;
-  return [
-    `WARNING: the last graph build could not persist the symbol graph: ${symbolGraphError}`,
-    "Results below may be stale or incomplete until a rebuild succeeds.",
-    "",
-    result,
-  ].join("\n");
+  try {
+    const result = await dispatchGraphTool(name, args);
+    if (!SYMBOL_GRAPH_TOOLS.has(name)) return result;
+    const resolved = path.resolve((args.projectPath as string) || process.cwd());
+    const symbolGraphError = getLastGraphBuildCompleted(resolved)?.symbolGraphError;
+    if (!symbolGraphError) return result;
+    return [
+      `WARNING: the last graph build could not persist the symbol graph: ${symbolGraphError}`,
+      "Results below may be stale or incomplete until a rebuild succeeds.",
+      "",
+      result,
+    ].join("\n");
+  } catch (err) {
+    if (err instanceof StorageReadError) {
+      return `Storage error: ${err.message}`;
+    }
+    throw err;
+  }
 }
 
 async function dispatchGraphTool(

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,14 @@ export interface SymbolNode {
   language: string;
 }
 
+/** Kind of relationship an edge represents */
+export type EdgeKind =
+  | "call"
+  | "value_reference"
+  | "type_reference"
+  | "import"
+  | "reexport";
+
 /** Confidence level for a resolved call edge */
 export type SymbolEdgeConfidence =
   | "local"
@@ -149,6 +157,13 @@ export interface SymbolEdge {
   /** Resolved SymbolNode.ids: 0 = external, 1 = unique, >1 = ambiguous */
   calleeCandidates: string[];
   confidence: SymbolEdgeConfidence;
+  kind: EdgeKind;
+  /** Source module specifier from import statement (e.g. "./utils") */
+  sourceModule?: string;
+  /** Original imported or exported name in the source module */
+  importedName?: string;
+  /** Local binding alias in the caller file */
+  localAlias?: string;
   callSite: { file: string; line: number };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export type SymbolKind =
   | "enum"
   | "module"
   | "struct"
+  | "type"
   | "variable";
 
 /** A single symbol (definition) extracted from source code */
@@ -167,7 +168,7 @@ export interface SymbolGraphMeta {
   fileCount: number;
   unresolvedEdgePct: number;
   builtAt: number;
-  schemaVersion: 1;
+  schemaVersion: 1 | 2;
 }
 
 /** Per-file payload stored in `_symgraph_file` */

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,6 +187,7 @@ export interface SymbolGraphMeta {
   unresolvedEdgePct: number;
   builtAt: number;
   schemaVersion: 1 | 2;
+  generation?: string;
 }
 
 /** Per-file payload stored in `_symgraph_file` */

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,7 +162,7 @@ export interface SymbolEdge {
   sourceModule?: string;
   /** Original imported or exported name in the source module */
   importedName?: string;
-  /** Local binding alias in the caller file */
+  /** Local binding alias in the caller file (or exported alias `Y` in `export { X as Y }` for re-exports) */
   localAlias?: string;
   callSite: { file: string; line: number };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,7 +162,10 @@ export interface SymbolEdge {
   sourceModule?: string;
   /** Original imported or exported name in the source module */
   importedName?: string;
-  /** Local binding alias in the caller file (or exported alias `Y` in `export { X as Y }` for re-exports) */
+  /**
+   * Local binding alias in the caller file for import edges (e.g. `localFoo` in `import { foo as localFoo }`),
+   * or the exported alias for re-export edges (e.g. `Y` in `export { X as Y }` or `export * as Y from './mod'`).
+   */
   localAlias?: string;
   callSite: { file: string; line: number };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,8 @@ export interface SymbolNode {
   endLine: number;
   /** Re-export alias, if any */
   exportedAs?: string;
+  /** Whether the symbol is exported from its containing module */
+  isExported?: boolean;
   language: string;
 }
 

--- a/tests/integration/symbol-graph-incremental.test.ts
+++ b/tests/integration/symbol-graph-incremental.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   dropSymbolGraphCache,
   getSymbolGraphCache,
+  type SymbolGraphReaderRelease,
 } from "../../src/services/symbol-graph-cache.js";
 import { updateChangedFilesSymbolGraph } from "../../src/services/symbol-graph-incremental.js";
 import {
@@ -211,7 +212,7 @@ describe.skipIf(!dockerAvailable)(
       const legacyProjectId = projectIdFromPath(legacyFixture.root);
       const relativePath = "src/index.ts";
       const absolutePath = path.join(legacyFixture.root, relativePath);
-      let releaseLegacyReader: (() => void) | undefined;
+      let releaseLegacyReader: SymbolGraphReaderRelease | undefined;
 
       const legacyPayload: SymbolGraphFilePayload = {
         file: relativePath,
@@ -258,7 +259,10 @@ describe.skipIf(!dockerAvailable)(
         );
         await rebuildGraph(legacyFixture.root);
 
-        const legacyRead = await legacyCache.getFilePayload(relativePath);
+        const legacyRead = await legacyCache.getFilePayload(
+          relativePath,
+          releaseLegacyReader.token,
+        );
         expect(legacyRead?.symbols.map((symbol) => symbol.name)).toContain("legacyEntry");
         expect(legacyRead?.symbols.map((symbol) => symbol.name)).not.toContain("currentEntry");
 

--- a/tests/integration/symbol-graph-incremental.test.ts
+++ b/tests/integration/symbol-graph-incremental.test.ts
@@ -2,20 +2,18 @@
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 import fs from "node:fs";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { projectIdFromPath } from "../../src/config.js";
 import {
   invalidateGraphCache,
   rebuildGraph,
 } from "../../src/services/code-graph.js";
-import { logger } from "../../src/services/logger.js";
 import { updateChangedFilesSymbolGraph } from "../../src/services/symbol-graph-incremental.js";
 import {
   loadFilePayload,
   loadSymbolGraphMeta,
 } from "../../src/services/symbol-graph-store.js";
 import {
-  canTestPermissionDenied,
   createFixtureProject,
   type FixtureProject,
   isDockerAvailable,
@@ -58,7 +56,7 @@ describe.skipIf(!dockerAvailable)(
       expect(result.filesRemoved).toBe(0);
     });
 
-    it("re-extracts and persists a changed file's payload", async () => {
+    it("returns fullRebuildRequired=true on a changed file and full rebuild persists new symbols", async () => {
       const graph = await rebuildGraph(fixture.root);
       const rel = "src/index.ts";
 
@@ -79,8 +77,10 @@ describe.skipIf(!dockerAvailable)(
           [rel],
           [],
         );
-        expect(result.fullRebuildRequired).toBe(false);
-        expect(result.filesChanged).toBe(1);
+        expect(result.fullRebuildRequired).toBe(true);
+
+        // Rebuild graph via caller fallback
+        await rebuildGraph(fixture.root);
 
         // The new symbol should appear in the persisted payload.
         const payload = await loadFilePayload(projectId, rel);
@@ -92,26 +92,7 @@ describe.skipIf(!dockerAvailable)(
       }
     });
 
-    it("is a no-op when content hash is unchanged", async () => {
-      const graph = await rebuildGraph(fixture.root);
-      const rel = "src/index.ts";
-      const before = await loadSymbolGraphMeta(projectId);
-      const result = await updateChangedFilesSymbolGraph(
-        projectId,
-        fixture.root,
-        graph,
-        [rel],
-        [],
-      );
-      // The diff path detects identical hash and skips writes.
-      expect(result.fullRebuildRequired).toBe(false);
-      expect(result.symbolsDelta).toBe(0);
-      expect(result.edgesDelta).toBe(0);
-      const after = await loadSymbolGraphMeta(projectId);
-      expect(after?.symbolCount).toBe(before?.symbolCount);
-    });
-
-    it("removes a deleted file's payload from the store", async () => {
+    it("returns fullRebuildRequired=true when a file is removed", async () => {
       const graph = await rebuildGraph(fixture.root);
       const rel = "src/utils/helpers.ts";
       // Confirm baseline.
@@ -125,11 +106,7 @@ describe.skipIf(!dockerAvailable)(
         [],
         [rel],
       );
-      expect(result.fullRebuildRequired).toBe(false);
-      expect(result.filesRemoved).toBe(1);
-
-      const after = await loadFilePayload(projectId, rel);
-      expect(after).toBeNull();
+      expect(result.fullRebuildRequired).toBe(true);
     });
 
     it("handles symbols whose names collide with Object.prototype keys (regression)", async () => {
@@ -157,8 +134,6 @@ describe.skipIf(!dockerAvailable)(
         "utf-8",
       );
       try {
-        // The original crash happened during the *full* persistSymbolGraph
-        // path, so exercise that as well.
         await rebuildGraph(fixture.root);
         const meta = await loadSymbolGraphMeta(projectId);
         expect(meta).not.toBeNull();
@@ -168,9 +143,6 @@ describe.skipIf(!dockerAvailable)(
         // All three prototype-collision names must be present.
         expect(names).toEqual(expect.arrayContaining(["constructor", "toString", "hasOwnProperty"]));
 
-        // And the incremental path must also accept them without throwing.
-        // Mutate the file so the incremental layer doesn't skip it as
-        // unchanged (its hash already matches after the full rebuild above).
         fs.appendFileSync(filePath, "\nexport const PROTO_KEYS_REV = 2;\n", "utf-8");
         const graph = await rebuildGraph(fixture.root, { skipSymbolGraph: true });
         const result = await updateChangedFilesSymbolGraph(
@@ -180,53 +152,13 @@ describe.skipIf(!dockerAvailable)(
           [rel],
           [],
         );
-        expect(result.fullRebuildRequired).toBe(false);
-        expect(result.filesChanged).toBe(1);
+        expect(result.fullRebuildRequired).toBe(true);
       } finally {
         try { fs.unlinkSync(filePath); } catch { /* ignore */ }
       }
     });
 
-    it("patches a detected extensionless Python file on the incremental path", async () => {
-      // A no-shebang Python file with NO extension. The `extra()` symbol is
-      // appended AFTER the full rebuild, so it can only reach the store via the
-      // incremental path, which skips any file whose getAstGrepLang(ext) is null
-      // unless the extension is re-detected first. Proves the gate re-detects it.
-      const rel = "deploy/gen-config";
-      const abs = path.join(fixture.root, rel);
-      fs.mkdirSync(path.dirname(abs), { recursive: true });
-      fs.writeFileSync(
-        abs,
-        "def render_config():\n    return build_section()\n\ndef build_section():\n    return 1\n",
-        "utf-8",
-      );
-      try {
-        const graph = await rebuildGraph(fixture.root);
-        fs.appendFileSync(abs, "\ndef extra():\n    return render_config()\n", "utf-8");
-
-        const result = await updateChangedFilesSymbolGraph(projectId, fixture.root, graph, [rel], []);
-        expect(result.fullRebuildRequired).toBe(false);
-        expect(result.filesChanged).toBe(1);
-
-        const payload = await loadFilePayload(projectId, rel);
-        expect(payload).toBeTruthy();
-        expect(payload?.language).toBe("python");
-        const names = payload?.symbols.map((s) => s.name) ?? [];
-        expect(names).toEqual(expect.arrayContaining(["render_config", "build_section", "extra"]));
-      } finally {
-        try {
-          fs.rmSync(path.join(fixture.root, "deploy"), { recursive: true, force: true });
-        } catch {
-          /* ignore */
-        }
-      }
-    });
-
     it("full rebuild persists a detected extensionless Python file; .txt-detected is excluded", async () => {
-      // Both graph paths: the incremental path is covered above; this covers
-      // the full rebuildGraph() path. A no-shebang Python file (grammar-bearing)
-      // is persisted with its symbols; a perl-shebang file (detected .txt) is
-      // grammar-less and must not enter the symbol graph.
       const pyRel = "tools/gen";
       const txtRel = "tools/legacy";
       fs.mkdirSync(path.join(fixture.root, "tools"), { recursive: true });
@@ -256,154 +188,5 @@ describe.skipIf(!dockerAvailable)(
         }
       }
     });
-
-    it("skips extensionless files on the incremental path when INDEX_EXTENSIONLESS=false", async () => {
-      const rel = "offswitch/gen";
-      const abs = path.join(fixture.root, rel);
-      fs.mkdirSync(path.dirname(abs), { recursive: true });
-      fs.writeFileSync(abs, "def off_marker():\n    return 1\n", "utf-8");
-      // Build the file-import graph with detection ON (so the file is present),
-      // then disable and run the incremental patch — it must skip the file.
-      const graph = await rebuildGraph(fixture.root, { skipSymbolGraph: true });
-      const prev = process.env.INDEX_EXTENSIONLESS;
-      process.env.INDEX_EXTENSIONLESS = "false";
-      try {
-        const result = await updateChangedFilesSymbolGraph(projectId, fixture.root, graph, [rel], []);
-        expect(result.fullRebuildRequired).toBe(false);
-        expect(result.filesChanged).toBe(0);
-      } finally {
-        if (prev === undefined) delete process.env.INDEX_EXTENSIONLESS;
-        else process.env.INDEX_EXTENSIONLESS = prev;
-        try {
-          fs.rmSync(path.join(fixture.root, "offswitch"), { recursive: true, force: true });
-        } catch {
-          /* ignore */
-        }
-      }
-    });
-
-    it("purges stale symbols when a changed extensionless file loses its grammar (grammar → .txt)", async () => {
-      const rel = "svc/gen";
-      const abs = path.join(fixture.root, rel);
-      fs.mkdirSync(path.dirname(abs), { recursive: true });
-      // No-shebang Python → detected .py → symbols + an intra-file call edge
-      // (render_thing → helper) extracted and persisted, so the purge must
-      // decrement both the symbol and the edge counters.
-      fs.writeFileSync(abs, "def render_thing():\n    return helper()\n\ndef helper():\n    return 1\n", "utf-8");
-      try {
-        await rebuildGraph(fixture.root);
-        const before = await loadFilePayload(projectId, rel);
-        expect(before).toBeTruthy();
-        expect((before?.symbols ?? []).map((s) => s.name)).toContain("render_thing");
-
-        // Content now detects as .txt (unmapped perl shebang). It stays indexable,
-        // so it arrives as a *changed* (not removed) file — but its stale python
-        // symbols must be dropped to match a full rebuild (which excludes .txt).
-        fs.writeFileSync(abs, '#!/usr/bin/perl\nprint "no longer python\\n";\n', "utf-8");
-        const graph = await rebuildGraph(fixture.root, { skipSymbolGraph: true });
-        const result = await updateChangedFilesSymbolGraph(projectId, fixture.root, graph, [rel], []);
-        expect(result.fullRebuildRequired).toBe(false);
-        // Pin the removal bookkeeping (feeds persisted meta counts), not just the
-        // payload delete — else dropping the counter lines would go uncaught.
-        expect(result.filesRemoved).toBe(1);
-        expect(result.symbolsDelta).toBeLessThan(0);
-        expect(result.edgesDelta).toBeLessThan(0);
-
-        const after = await loadFilePayload(projectId, rel);
-        expect(after).toBeNull();
-      } finally {
-        try {
-          fs.rmSync(path.join(fixture.root, "svc"), { recursive: true, force: true });
-        } catch {
-          /* ignore */
-        }
-      }
-    });
-
-    it.skipIf(!canTestPermissionDenied)(
-      "keeps a changed extensionless file's payload when its head-read fails transiently",
-      async () => {
-        const rel = "ro/probe";
-        const abs = path.join(fixture.root, rel);
-        fs.mkdirSync(path.dirname(abs), { recursive: true });
-        // Readable code first → gets a persisted payload with symbols.
-        fs.writeFileSync(abs, "def a():\n    return b()\n\ndef b():\n    return 1\n", "utf-8");
-        try {
-          await rebuildGraph(fixture.root);
-          const before = await loadFilePayload(projectId, rel);
-          expect(before).toBeTruthy();
-          expect((before?.symbols ?? []).map((s) => s.name)).toContain("a");
-
-          // Now make the head-read fail (EACCES). A transient read failure must
-          // NOT be read as "lost grammar": the payload must survive, mirroring
-          // the extensioned readFile-catch path (an extensioned file with the
-          // same error keeps its payload).
-          fs.chmodSync(abs, 0o000);
-          const graph = await rebuildGraph(fixture.root, { skipSymbolGraph: true });
-          const result = await updateChangedFilesSymbolGraph(projectId, fixture.root, graph, [rel], []);
-          expect(result.filesRemoved).toBe(0);
-
-          const after = await loadFilePayload(projectId, rel);
-          expect(after).toBeTruthy();
-          expect((after?.symbols ?? []).map((s) => s.name)).toContain("a");
-        } finally {
-          try {
-            fs.chmodSync(abs, 0o644);
-          } catch {
-            /* ignore */
-          }
-          try {
-            fs.rmSync(path.join(fixture.root, "ro"), { recursive: true, force: true });
-          } catch {
-            /* ignore */
-          }
-        }
-      },
-    );
-
-    it.skipIf(!canTestPermissionDenied)(
-      "logs a transient read failure for a changed extensioned file and keeps its payload",
-      async () => {
-        const rel = "ro2/probe.py";
-        const abs = path.join(fixture.root, rel);
-        fs.mkdirSync(path.dirname(abs), { recursive: true });
-        fs.writeFileSync(abs, "def a():\n    return b()\n\ndef b():\n    return 1\n", "utf-8");
-        const debugSpy = vi.spyOn(logger, "debug");
-        try {
-          await rebuildGraph(fixture.root);
-          const before = await loadFilePayload(projectId, rel);
-          expect((before?.symbols ?? []).map((s) => s.name)).toContain("a");
-
-          fs.chmodSync(abs, 0o000);
-          const graph = await rebuildGraph(fixture.root, { skipSymbolGraph: true });
-          const result = await updateChangedFilesSymbolGraph(projectId, fixture.root, graph, [rel], []);
-          expect(result.filesRemoved).toBe(0);
-
-          // The payload survives — that is what the continue exists to protect.
-          const after = await loadFilePayload(projectId, rel);
-          expect((after?.symbols ?? []).map((s) => s.name)).toContain("a");
-
-          // The fault is reported, not swallowed. Matched in full because the
-          // extensionless catch above ends in the same "keeping prior symbols
-          // (skipping)" fragment, so a substring match would not tell the two apart.
-          expect(debugSpy).toHaveBeenCalledWith(
-            "Could not read changed file; keeping prior symbols (skipping)",
-            expect.objectContaining({ relPath: rel }),
-          );
-        } finally {
-          debugSpy.mockRestore();
-          try {
-            fs.chmodSync(abs, 0o644);
-          } catch {
-            /* ignore */
-          }
-          try {
-            fs.rmSync(path.join(fixture.root, "ro2"), { recursive: true, force: true });
-          } catch {
-            /* ignore */
-          }
-        }
-      },
-    );
   },
 );

--- a/tests/integration/symbol-graph-incremental.test.ts
+++ b/tests/integration/symbol-graph-incremental.test.ts
@@ -8,11 +8,21 @@ import {
   invalidateGraphCache,
   rebuildGraph,
 } from "../../src/services/code-graph.js";
+import {
+  dropSymbolGraphCache,
+  getSymbolGraphCache,
+} from "../../src/services/symbol-graph-cache.js";
 import { updateChangedFilesSymbolGraph } from "../../src/services/symbol-graph-incremental.js";
 import {
+  deleteSymbolGraphData,
+  LEGACY_SYMBOL_GRAPH_GENERATION,
+  listStoredGenerations,
   loadFilePayload,
   loadSymbolGraphMeta,
+  saveFilePayload,
+  saveSymbolGraphMeta,
 } from "../../src/services/symbol-graph-store.js";
+import type { SymbolGraphFilePayload, SymbolGraphMeta } from "../../src/types.js";
 import {
   createFixtureProject,
   type FixtureProject,
@@ -186,6 +196,103 @@ describe.skipIf(!dockerAvailable)(
         } catch {
           /* ignore */
         }
+      }
+    });
+  },
+);
+
+describe.skipIf(!dockerAvailable)(
+  "symbol-graph legacy generation compatibility",
+  { timeout: 120_000 },
+  () => {
+    it("keeps a schema-v1 reader stable until the replacement generation is committed", async () => {
+      await waitForQdrant();
+      const legacyFixture = createFixtureProject("symbol-graph-legacy-generation-test");
+      const legacyProjectId = projectIdFromPath(legacyFixture.root);
+      const relativePath = "src/index.ts";
+      const absolutePath = path.join(legacyFixture.root, relativePath);
+      let releaseLegacyReader: (() => void) | undefined;
+
+      const legacyPayload: SymbolGraphFilePayload = {
+        file: relativePath,
+        language: "typescript",
+        contentHash: "legacy-content-hash",
+        symbols: [{
+          id: `${relativePath}::legacyEntry#1`,
+          name: "legacyEntry",
+          qualifiedName: "legacyEntry",
+          kind: "function",
+          isExported: true,
+          file: relativePath,
+          line: 1,
+          endLine: 1,
+          language: "typescript",
+        }],
+        outgoingCalls: [],
+      };
+      const legacyMeta: SymbolGraphMeta = {
+        projectId: legacyProjectId,
+        symbolCount: 1,
+        edgeCount: 0,
+        fileCount: 1,
+        unresolvedEdgePct: 0,
+        builtAt: Date.now(),
+        schemaVersion: 1,
+      };
+
+      try {
+        await deleteSymbolGraphData(legacyProjectId);
+        dropSymbolGraphCache(legacyProjectId);
+        await saveFilePayload(legacyProjectId, legacyPayload);
+        await saveSymbolGraphMeta(legacyProjectId, legacyMeta);
+
+        const legacyCache = await getSymbolGraphCache(legacyProjectId);
+        expect(legacyCache).not.toBeNull();
+        if (!legacyCache) return;
+        releaseLegacyReader = legacyCache.acquireReader();
+
+        fs.writeFileSync(
+          absolutePath,
+          "export function currentEntry(): number { return 2; }\n",
+          "utf-8",
+        );
+        await rebuildGraph(legacyFixture.root);
+
+        const legacyRead = await legacyCache.getFilePayload(relativePath);
+        expect(legacyRead?.symbols.map((symbol) => symbol.name)).toContain("legacyEntry");
+        expect(legacyRead?.symbols.map((symbol) => symbol.name)).not.toContain("currentEntry");
+
+        const currentCache = await getSymbolGraphCache(legacyProjectId);
+        expect(currentCache?.meta.generation).toBeDefined();
+        const currentGeneration = currentCache?.meta.generation;
+        const currentRead = await currentCache?.getFilePayload(relativePath);
+        expect(currentRead?.symbols.map((symbol) => symbol.name)).toContain("currentEntry");
+        expect(await listStoredGenerations(legacyProjectId)).toEqual(
+          expect.arrayContaining([
+            LEGACY_SYMBOL_GRAPH_GENERATION,
+            currentGeneration,
+          ]),
+        );
+
+        releaseLegacyReader();
+        releaseLegacyReader = undefined;
+
+        const deadline = Date.now() + 5_000;
+        let generations = await listStoredGenerations(legacyProjectId);
+        while (
+          generations.includes(LEGACY_SYMBOL_GRAPH_GENERATION)
+          && Date.now() < deadline
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          generations = await listStoredGenerations(legacyProjectId);
+        }
+        expect(generations).toEqual([currentGeneration]);
+      } finally {
+        releaseLegacyReader?.();
+        dropSymbolGraphCache(legacyProjectId);
+        invalidateGraphCache(legacyFixture.root);
+        try { await deleteSymbolGraphData(legacyProjectId); } catch { /* ignore */ }
+        legacyFixture.cleanup();
       }
     });
   },

--- a/tests/integration/symbol-graph-scale.test.ts
+++ b/tests/integration/symbol-graph-scale.test.ts
@@ -18,8 +18,8 @@
  *   2. Symbol-graph meta is persisted with the expected counts.
  *   3. Cold queries (codebase_impact / codebase_symbol via the cache) return
  *      results within a small budget after a fresh process state.
- *   4. Phase F incremental update for a single changed file is at least
- *      4× faster than a full rebuild (the whole point of Phase F).
+ *   4. A changed file requests a safe full symbol-graph rebuild without
+ *      mutating the active generation before that rebuild completes.
  *
  * Skipped automatically when Docker is unavailable.
  */
@@ -59,7 +59,6 @@ const TOTAL_SYMBOLS = N_FILES * SYMBOLS_PER_FILE;
 // Wall-clock budgets (intentionally loose — we only fail on order-of-magnitude regressions).
 const FULL_REBUILD_BUDGET_MS = LARGE ? 10 * 60_000 : 90_000; // 90s for 1k files locally; 10min for 10k
 const COLD_QUERY_BUDGET_MS = 5_000;
-const INCREMENTAL_SPEEDUP_MIN = 4; // Phase F must beat full rebuild by ≥4×
 
 /**
  * Generate a Python project with N files. Each file imports the *previous*
@@ -96,8 +95,6 @@ describe.skipIf(!dockerAvailable)(
   () => {
     let projectRoot: string;
     let projectId: string;
-    let fullRebuildMs: number;
-
     beforeAll(async () => {
       await waitForQdrant();
       projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-scale-"));
@@ -118,7 +115,7 @@ describe.skipIf(!dockerAvailable)(
     it(`builds the symbol graph for ${N_FILES} files / ${TOTAL_SYMBOLS} symbols within budget`, async () => {
       const start = Date.now();
       await rebuildGraph(projectRoot);
-      fullRebuildMs = Date.now() - start;
+      const fullRebuildMs = Date.now() - start;
       // Log so the number shows up in test output even on success.
       console.log(`[scale] Full rebuild: ${N_FILES} files / ${TOTAL_SYMBOLS} symbols in ${fullRebuildMs} ms`);
       expect(fullRebuildMs).toBeLessThan(FULL_REBUILD_BUDGET_MS);
@@ -151,35 +148,23 @@ describe.skipIf(!dockerAvailable)(
       expect(impactMs).toBeLessThan(COLD_QUERY_BUDGET_MS);
     });
 
-    // retry: a wall-clock ratio on shared hardware can lose to a transient
-    // load spike (measured: a saturated box turns the 4x margin into 1.4x).
-    // A retry re-measures both sides under fresh conditions; a genuine
-    // Phase F regression fails every attempt.
-    it("Phase F incremental update is significantly faster than a full rebuild", { retry: 2 }, async () => {
-      // Re-measure the full rebuild HERE rather than reusing the timing from
-      // the earlier it block: the two blocks run minutes apart under
-      // different machine state (Qdrant warm-up, GC, background load), and
-      // comparing timings across that boundary flaked on unmodified runs.
-      // Both numbers in this assertion now come from the same block.
-      const fullStart = Date.now();
-      await rebuildGraph(projectRoot);
-      const freshFullRebuildMs = Date.now() - fullStart;
-
+    it("requests a safe full rebuild for a changed file before mutating graph storage", async () => {
       // Touch one file: append a new symbol.
       const rel = "pkg/mod_42.py";
       const abs = path.join(projectRoot, rel);
       const original = fs.readFileSync(abs, "utf-8");
+      const beforeMeta = await loadSymbolGraphMeta(projectId);
+      const beforeGeneration = beforeMeta?.generation;
+      expect(beforeGeneration).toBeDefined();
       fs.writeFileSync(
         abs,
         `${original}\ndef fn_42_${SYMBOLS_PER_FILE}_inc():\n    return -1\n`,
         "utf-8",
       );
       try {
-        // Build a fresh file-import graph (cheap part of Phase F) and time
-        // only the per-file symbol patch.
+        // Build only the file-import graph, then ask the compatibility guard
+        // whether a symbol-graph update may be applied in place.
         const graph = await rebuildGraph(projectRoot, { skipSymbolGraph: true });
-
-        const start = Date.now();
         const result = await updateChangedFilesSymbolGraph(
           projectId,
           projectRoot,
@@ -187,14 +172,22 @@ describe.skipIf(!dockerAvailable)(
           [rel],
           [],
         );
-        const incrementalMs = Date.now() - start;
-        console.log(`[scale] Phase F incremental update (1 file in ${N_FILES}-file repo): ${incrementalMs} ms (full rebuild was ${freshFullRebuildMs} ms)`);
-        expect(result.fullRebuildRequired).toBe(false);
-        expect(result.filesChanged).toBeGreaterThanOrEqual(1);
-        // Phase F's whole reason to exist: must beat full rebuild on a small
-        // change set by a wide margin. We allow 4× as a deliberately loose
-        // threshold to avoid CI flakiness.
-        expect(incrementalMs * INCREMENTAL_SPEEDUP_MIN).toBeLessThan(freshFullRebuildMs);
+        expect(result.fullRebuildRequired).toBe(true);
+
+        // The guard itself must leave the committed generation untouched.
+        const guardedMeta = await loadSymbolGraphMeta(projectId);
+        expect(guardedMeta?.generation).toBe(beforeGeneration);
+        const guardedCache = await getSymbolGraphCache(projectId);
+        const guardedPayload = await guardedCache?.getFilePayload(rel);
+        expect(guardedPayload?.symbols.some((symbol) => symbol.name.endsWith("_inc"))).toBe(false);
+
+        // The caller's full rebuild publishes the changed graph atomically.
+        await rebuildGraph(projectRoot);
+        const rebuiltMeta = await loadSymbolGraphMeta(projectId);
+        expect(rebuiltMeta?.generation).not.toBe(beforeGeneration);
+        const rebuiltCache = await getSymbolGraphCache(projectId);
+        const rebuiltPayload = await rebuiltCache?.getFilePayload(rel);
+        expect(rebuiltPayload?.symbols.some((symbol) => symbol.name === `fn_42_${SYMBOLS_PER_FILE}_inc`)).toBe(true);
       } finally {
         fs.writeFileSync(abs, original, "utf-8");
       }

--- a/tests/integration/tools.test.ts
+++ b/tests/integration/tools.test.ts
@@ -363,15 +363,35 @@ describe.skipIf(!dockerAvailable)(
         expect(result).toContain("Missing required argument");
       });
 
-      it("returns a blast-radius report for a known symbol", async () => {
+      it("returns a blast-radius report for a known function symbol", async () => {
         const result = await handleGraphTool("codebase_impact", {
           projectPath: fixture.root,
-          target: "main",
+          target: "greet",
           depth: 3,
         });
         expect(typeof result).toBe("string");
-        // Either "Blast radius for ..." (found) or graceful empty/no-graph message.
-        expect(result.length).toBeGreaterThan(0);
+        expect(result).toContain("Blast radius for symbol: greet");
+        expect(result).toContain("src/index.ts");
+      });
+
+      it("returns a blast-radius report for an interface export (issue #132)", async () => {
+        const result = await handleGraphTool("codebase_impact", {
+          projectPath: fixture.root,
+          target: "UserConfig",
+          depth: 3,
+        });
+        expect(typeof result).toBe("string");
+        expect(result).toContain("Blast radius for symbol: UserConfig");
+        expect(result).toContain("src/index.ts");
+      });
+
+      it("returns informative not found error for non-existent symbol", async () => {
+        const result = await handleGraphTool("codebase_impact", {
+          projectPath: fixture.root,
+          target: "NonExistentSymbolXYZ",
+          depth: 3,
+        });
+        expect(result).toContain("not found");
       });
     });
 

--- a/tests/unit/graph-impact.test.ts
+++ b/tests/unit/graph-impact.test.ts
@@ -392,9 +392,10 @@ describe("graph-impact exact symbol traversal and fail-closed", () => {
 
     const result = await getImpactRadius(cache, "computeCore", 3);
     expect(result.status).toBe("ok");
-    expect(result.totalFiles).toBe(2);
-    // Hop 1: same file utils.ts (via publicHelper)
-    expect(result.filesByDepth.get(1)).toEqual(["src/utils.ts"]);
+    expect(result.totalFiles).toBe(1);
+    // Hop 1 has only the same-file helper, so the defining file is not
+    // counted again as an impacted file.
+    expect(result.filesByDepth.get(1)).toBeUndefined();
     // Hop 2: app.ts (via main calling publicHelper)
     expect(result.filesByDepth.get(2)).toEqual(["src/app.ts"]);
   });

--- a/tests/unit/graph-impact.test.ts
+++ b/tests/unit/graph-impact.test.ts
@@ -542,4 +542,97 @@ describe("graph-impact exact symbol traversal and fail-closed", () => {
     expect(fileResult.totalFiles).toBe(1);
     expect(fileResult.filesByDepth.get(1)).toEqual(["src/serviceA.ts"]);
   });
+
+  it("traverses target -> same-file helper -> external caller on legacy schema v1", async () => {
+    const symTarget: SymbolNode = {
+      id: "src/utils.ts::computeCore#1",
+      name: "computeCore",
+      qualifiedName: "computeCore",
+      kind: "function",
+      file: "src/utils.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+    const symHelper: SymbolNode = {
+      id: "src/utils.ts::publicHelper#10",
+      name: "publicHelper",
+      qualifiedName: "publicHelper",
+      kind: "function",
+      file: "src/utils.ts",
+      line: 10,
+      endLine: 15,
+      language: "typescript",
+    };
+    const symApp: SymbolNode = {
+      id: "src/app.ts::main#1",
+      name: "main",
+      qualifiedName: "main",
+      kind: "function",
+      file: "src/app.ts",
+      line: 1,
+      endLine: 10,
+      language: "typescript",
+    };
+
+    const cache = createMockCache({
+      symbols: [symTarget, symHelper, symApp],
+      reverseFileIndex: new Map([
+        ["src/utils.ts", new Set(["src/app.ts"])],
+      ]),
+      filePayloads: new Map([
+        [
+          "src/utils.ts",
+          {
+            file: "src/utils.ts",
+            language: "typescript",
+            contentHash: "h_u",
+            symbols: [symTarget, symHelper],
+            outgoingCalls: [
+              // Same-file call: publicHelper calls computeCore
+              {
+                callerId: "src/utils.ts::publicHelper#10",
+                calleeName: "computeCore",
+                kind: "call",
+                calleeCandidates: ["src/utils.ts::computeCore#1"],
+                confidence: "local",
+                callSite: { file: "src/utils.ts", line: 12 },
+              },
+            ],
+          },
+        ],
+        [
+          "src/app.ts",
+          {
+            file: "src/app.ts",
+            language: "typescript",
+            contentHash: "h_a",
+            symbols: [symApp],
+            outgoingCalls: [
+              // External call: main calls publicHelper
+              {
+                callerId: "src/app.ts::main#1",
+                calleeName: "publicHelper",
+                kind: "call",
+                sourceModule: "./utils",
+                importedName: "publicHelper",
+                calleeCandidates: ["src/utils.ts::publicHelper#10"],
+                confidence: "unique",
+                callSite: { file: "src/app.ts", line: 3 },
+              },
+            ],
+          },
+        ],
+      ]),
+    });
+    cache.meta.schemaVersion = 1;
+
+    const result = await getImpactRadius(cache, "computeCore", 3);
+    expect(result.status).toBe("ok");
+    expect(result.totalFiles).toBe(1);
+    // Hop 1 had only same-file helper (utils.ts already visited as target file)
+    expect(result.filesByDepth.get(1)).toBeUndefined();
+    // Hop 2 reaches external caller app.ts via publicHelper
+    expect(result.filesByDepth.get(2)).toEqual(["src/app.ts"]);
+  });
 });

--- a/tests/unit/graph-impact.test.ts
+++ b/tests/unit/graph-impact.test.ts
@@ -37,6 +37,22 @@ function createMockCache(opts: {
   // @ts-expect-error accessing private field for unit testing
   cache.reverseFileIndex = opts.reverseFileIndex;
 
+  const reverseSymbolIndex = new Map<string, Set<string>>();
+  for (const payload of opts.filePayloads.values()) {
+    for (const e of payload.outgoingCalls) {
+      for (const calleeId of e.calleeCandidates) {
+        let set = reverseSymbolIndex.get(calleeId);
+        if (!set) {
+          set = new Set();
+          reverseSymbolIndex.set(calleeId, set);
+        }
+        set.add(e.callerId);
+      }
+    }
+  }
+  // @ts-expect-error accessing private field for unit testing
+  cache.reverseSymbolIndex = reverseSymbolIndex;
+
   for (const [f, payload] of opts.filePayloads) {
     cache.fileDataLru.set(f, payload);
   }
@@ -295,5 +311,192 @@ describe("graph-impact exact symbol traversal and fail-closed", () => {
     expect(result.status).toBe("ok");
     expect(result.totalFiles).toBe(2);
     expect(result.filesByDepth.get(1)).toEqual(["src/services/evaluator.ts", "src/services/other.ts"]);
+  });
+
+  it("traverses same-file caller and transitively reaches external consumers", async () => {
+    const symTarget: SymbolNode = {
+      id: "src/utils.ts::computeCore#1",
+      name: "computeCore",
+      qualifiedName: "computeCore",
+      kind: "function",
+      file: "src/utils.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+    const symHelper: SymbolNode = {
+      id: "src/utils.ts::publicHelper#10",
+      name: "publicHelper",
+      qualifiedName: "publicHelper",
+      kind: "function",
+      file: "src/utils.ts",
+      line: 10,
+      endLine: 15,
+      language: "typescript",
+    };
+    const symApp: SymbolNode = {
+      id: "src/app.ts::main#1",
+      name: "main",
+      qualifiedName: "main",
+      kind: "function",
+      file: "src/app.ts",
+      line: 1,
+      endLine: 10,
+      language: "typescript",
+    };
+
+    const cache = createMockCache({
+      symbols: [symTarget, symHelper, symApp],
+      reverseFileIndex: new Map(),
+      filePayloads: new Map([
+        ["src/utils.ts", {
+          file: "src/utils.ts",
+          language: "typescript",
+          contentHash: "h_u",
+          symbols: [symTarget, symHelper],
+          outgoingCalls: [
+            // same-file call: publicHelper calls computeCore
+            {
+              callerId: "src/utils.ts::publicHelper#10",
+              calleeName: "computeCore",
+              kind: "call",
+              calleeCandidates: ["src/utils.ts::computeCore#1"],
+              confidence: "local",
+              callSite: { file: "src/utils.ts", line: 12 },
+            },
+          ],
+        }],
+        ["src/app.ts", {
+          file: "src/app.ts",
+          language: "typescript",
+          contentHash: "h_a",
+          symbols: [symApp],
+          outgoingCalls: [
+            // external call: main calls publicHelper
+            {
+              callerId: "src/app.ts::main#1",
+              calleeName: "publicHelper",
+              kind: "call",
+              sourceModule: "./utils",
+              importedName: "publicHelper",
+              calleeCandidates: ["src/utils.ts::publicHelper#10"],
+              confidence: "unique",
+              callSite: { file: "src/app.ts", line: 3 },
+            },
+          ],
+        }],
+      ]),
+    });
+
+    const result = await getImpactRadius(cache, "computeCore", 3);
+    expect(result.status).toBe("ok");
+    expect(result.totalFiles).toBe(2);
+    // Hop 1: same file utils.ts (via publicHelper)
+    expect(result.filesByDepth.get(1)).toEqual(["src/utils.ts"]);
+    // Hop 2: app.ts (via main calling publicHelper)
+    expect(result.filesByDepth.get(2)).toEqual(["src/app.ts"]);
+  });
+
+  it("disambiguates ambiguous symbols when file option is provided", async () => {
+    const symA: SymbolNode = {
+      id: "src/serviceA.ts::init#1",
+      name: "init",
+      qualifiedName: "init",
+      kind: "function",
+      file: "src/serviceA.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+    const symB: SymbolNode = {
+      id: "src/serviceB.ts::init#1",
+      name: "init",
+      qualifiedName: "init",
+      kind: "function",
+      file: "src/serviceB.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+    const callerSym: SymbolNode = {
+      id: "src/app.ts::start#1",
+      name: "start",
+      qualifiedName: "start",
+      kind: "function",
+      file: "src/app.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+
+    const cache = createMockCache({
+      symbols: [symA, symB, callerSym],
+      reverseFileIndex: new Map(),
+      filePayloads: new Map([
+        ["src/serviceA.ts", { file: "src/serviceA.ts", language: "typescript", contentHash: "ha", symbols: [symA], outgoingCalls: [] }],
+        ["src/serviceB.ts", { file: "src/serviceB.ts", language: "typescript", contentHash: "hb", symbols: [symB], outgoingCalls: [] }],
+        ["src/app.ts", {
+          file: "src/app.ts",
+          language: "typescript",
+          contentHash: "happ",
+          symbols: [callerSym],
+          outgoingCalls: [
+            {
+              callerId: "src/app.ts::start#1",
+              calleeName: "init",
+              kind: "call",
+              sourceModule: "./serviceA",
+              importedName: "init",
+              calleeCandidates: ["src/serviceA.ts::init#1"],
+              confidence: "unique",
+              callSite: { file: "src/app.ts", line: 2 },
+            },
+          ],
+        }],
+      ]),
+    });
+
+    const result = await getImpactRadius(cache, "init", 2, { file: "src/serviceA.ts" });
+    expect(result.status).toBe("ok");
+    expect(result.totalFiles).toBe(1);
+    expect(result.filesByDepth.get(1)).toEqual(["src/app.ts"]);
+  });
+
+  it("targets exact symbol when symbolId option is provided", async () => {
+    const symA: SymbolNode = {
+      id: "src/serviceA.ts::init#1",
+      name: "init",
+      qualifiedName: "init",
+      kind: "function",
+      file: "src/serviceA.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+
+    const cache = createMockCache({
+      symbols: [symA],
+      reverseFileIndex: new Map(),
+      filePayloads: new Map([
+        ["src/serviceA.ts", { file: "src/serviceA.ts", language: "typescript", contentHash: "ha", symbols: [symA], outgoingCalls: [] }],
+      ]),
+    });
+
+    const result = await getImpactRadius(cache, "", 2, { symbolId: "src/serviceA.ts::init#1" });
+    expect(result.status).toBe("ok");
+    expect(result.targetKind).toBe("symbol");
+  });
+
+  it("fails immediately with graph_upgrade_required when schemaVersion is 1", async () => {
+    const cache = createMockCache({
+      symbols: [],
+      reverseFileIndex: new Map(),
+      filePayloads: new Map(),
+    });
+    cache.meta.schemaVersion = 1;
+
+    const result = await getImpactRadius(cache, "someSymbol");
+    expect(result.status).toBe("graph_upgrade_required");
+    expect(result.totalFiles).toBe(0);
   });
 });

--- a/tests/unit/graph-impact.test.ts
+++ b/tests/unit/graph-impact.test.ts
@@ -489,16 +489,57 @@ describe("graph-impact exact symbol traversal and fail-closed", () => {
     expect(result.targetKind).toBe("symbol");
   });
 
-  it("fails immediately with graph_upgrade_required when schemaVersion is 1", async () => {
+  it("supports legacy schema v1 graphs without mandatory rebuild", async () => {
+    const symCallee: SymbolNode = {
+      id: "src/serviceB.ts::callee#1",
+      name: "callee",
+      qualifiedName: "callee",
+      kind: "function",
+      file: "src/serviceB.ts",
+      line: 1,
+      endLine: 3,
+      language: "typescript",
+    };
     const cache = createMockCache({
-      symbols: [],
-      reverseFileIndex: new Map(),
-      filePayloads: new Map(),
+      symbols: [symCallee],
+      reverseFileIndex: new Map([["src/serviceB.ts", new Set(["src/serviceA.ts"])]]),
+      filePayloads: new Map([
+        [
+          "src/serviceB.ts",
+          { file: "src/serviceB.ts", language: "typescript", contentHash: "hb", symbols: [symCallee], outgoingCalls: [] },
+        ],
+        [
+          "src/serviceA.ts",
+          {
+            file: "src/serviceA.ts",
+            language: "typescript",
+            contentHash: "ha",
+            symbols: [],
+            outgoingCalls: [
+              {
+                callerId: "src/serviceA.ts::init#1",
+                calleeName: "callee",
+                calleeCandidates: ["src/serviceB.ts::callee#1"],
+                confidence: "unique",
+                callSite: { file: "src/serviceA.ts", line: 2 },
+              },
+            ],
+          },
+        ],
+      ]),
     });
     cache.meta.schemaVersion = 1;
 
-    const result = await getImpactRadius(cache, "someSymbol");
-    expect(result.status).toBe("graph_upgrade_required");
-    expect(result.totalFiles).toBe(0);
+    // Symbol query on schema v1: resolves caller file via legacy path
+    const symResult = await getImpactRadius(cache, "callee");
+    expect(symResult.status).toBe("ok");
+    expect(symResult.totalFiles).toBe(1);
+    expect(symResult.filesByDepth.get(1)).toEqual(["src/serviceA.ts"]);
+
+    // File query on schema v1: resolves caller file via reverseFileIndex
+    const fileResult = await getImpactRadius(cache, "src/serviceB.ts");
+    expect(fileResult.status).toBe("ok");
+    expect(fileResult.totalFiles).toBe(1);
+    expect(fileResult.filesByDepth.get(1)).toEqual(["src/serviceA.ts"]);
   });
 });

--- a/tests/unit/graph-impact.test.ts
+++ b/tests/unit/graph-impact.test.ts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+import { describe, expect, it } from "vitest";
+import { getImpactRadius } from "../../src/services/graph-impact.js";
+import { SymbolGraphCache } from "../../src/services/symbol-graph-cache.js";
+import type { SymbolGraphFilePayload, SymbolGraphMeta, SymbolNode } from "../../src/types.js";
+
+function createMockCache(opts: {
+  symbols: SymbolNode[];
+  reverseFileIndex: Map<string, Set<string>>;
+  filePayloads: Map<string, SymbolGraphFilePayload>;
+}): SymbolGraphCache {
+  const meta: SymbolGraphMeta = {
+    projectId: "test-proj",
+    symbolCount: opts.symbols.length,
+    edgeCount: 0,
+    fileCount: opts.filePayloads.size,
+    unresolvedEdgePct: 0,
+    builtAt: Date.now(),
+    schemaVersion: 2,
+  };
+
+  const cache = new SymbolGraphCache("test-proj", meta);
+
+  // Pre-seed cache fields directly
+  const nameIndex = new Map<string, Array<{ file: string; id: string }>>();
+  for (const s of opts.symbols) {
+    if (s.name === "<module>") continue;
+    const list = nameIndex.get(s.name) ?? [];
+    list.push({ file: s.file, id: s.id });
+    nameIndex.set(s.name, list);
+  }
+
+  // @ts-expect-error accessing private field for unit testing
+  cache.nameIndex = nameIndex;
+  // @ts-expect-error accessing private field for unit testing
+  cache.reverseFileIndex = opts.reverseFileIndex;
+
+  for (const [f, payload] of opts.filePayloads) {
+    cache.fileDataLru.set(f, payload);
+  }
+
+  return cache;
+}
+
+describe("graph-impact exact symbol traversal and fail-closed", () => {
+  it("returns not_found status when symbol is not in index", async () => {
+    const cache = createMockCache({
+      symbols: [],
+      reverseFileIndex: new Map(),
+      filePayloads: new Map(),
+    });
+
+    const result = await getImpactRadius(cache, "NonExistentSymbol");
+    expect(result.status).toBe("not_found");
+    expect(result.totalFiles).toBe(0);
+    expect(result.message).toContain("not found");
+  });
+
+  it("returns ambiguous status when symbol is defined in multiple files", async () => {
+    const sym1: SymbolNode = {
+      id: "src/a.ts::Config#1",
+      name: "Config",
+      qualifiedName: "Config",
+      kind: "interface",
+      file: "src/a.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+    const sym2: SymbolNode = {
+      id: "src/b.ts::Config#1",
+      name: "Config",
+      qualifiedName: "Config",
+      kind: "interface",
+      file: "src/b.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+
+    const cache = createMockCache({
+      symbols: [sym1, sym2],
+      reverseFileIndex: new Map(),
+      filePayloads: new Map([
+        ["src/a.ts", { file: "src/a.ts", language: "typescript", contentHash: "h1", symbols: [sym1], outgoingCalls: [] }],
+        ["src/b.ts", { file: "src/b.ts", language: "typescript", contentHash: "h2", symbols: [sym2], outgoingCalls: [] }],
+      ]),
+    });
+
+    const result = await getImpactRadius(cache, "Config");
+    expect(result.status).toBe("ambiguous");
+    expect(result.totalFiles).toBe(0);
+    expect(result.message).toContain("ambiguous");
+    expect(result.candidates).toHaveLength(2);
+  });
+
+  it("isolates blast radius between different symbols in the same file (issue #132)", async () => {
+    // Defining file with two symbols: JobOfferSnapshot (type) and UnrelatedConstant (const)
+    const symType: SymbolNode = {
+      id: "src/domain/snapshot.ts::JobOfferSnapshot#10",
+      name: "JobOfferSnapshot",
+      qualifiedName: "JobOfferSnapshot",
+      kind: "type",
+      file: "src/domain/snapshot.ts",
+      line: 10,
+      endLine: 15,
+      language: "typescript",
+    };
+    const symConst: SymbolNode = {
+      id: "src/domain/snapshot.ts::UnrelatedConstant#20",
+      name: "UnrelatedConstant",
+      qualifiedName: "UnrelatedConstant",
+      kind: "variable",
+      file: "src/domain/snapshot.ts",
+      line: 20,
+      endLine: 20,
+      language: "typescript",
+    };
+
+    // Caller 1 references JobOfferSnapshot
+    const caller1: SymbolGraphFilePayload = {
+      file: "src/services/evaluator.ts",
+      language: "typescript",
+      contentHash: "h_eval",
+      symbols: [],
+      outgoingCalls: [
+        {
+          callerId: "src/services/evaluator.ts::eval#5",
+          calleeName: "JobOfferSnapshot",
+          calleeCandidates: ["src/domain/snapshot.ts::JobOfferSnapshot#10"],
+          confidence: "unique",
+          callSite: { file: "src/services/evaluator.ts", line: 6 },
+        },
+      ],
+    };
+
+    // Caller 2 references UnrelatedConstant only
+    const caller2: SymbolGraphFilePayload = {
+      file: "src/services/other.ts",
+      language: "typescript",
+      contentHash: "h_other",
+      symbols: [],
+      outgoingCalls: [
+        {
+          callerId: "src/services/other.ts::doOther#2",
+          calleeName: "UnrelatedConstant",
+          calleeCandidates: ["src/domain/snapshot.ts::UnrelatedConstant#20"],
+          confidence: "unique",
+          callSite: { file: "src/services/other.ts", line: 3 },
+        },
+      ],
+    };
+
+    const cache = createMockCache({
+      symbols: [symType, symConst],
+      reverseFileIndex: new Map([
+        ["src/domain/snapshot.ts", new Set(["src/services/evaluator.ts", "src/services/other.ts"])],
+      ]),
+      filePayloads: new Map([
+        ["src/domain/snapshot.ts", {
+          file: "src/domain/snapshot.ts",
+          language: "typescript",
+          contentHash: "h_snap",
+          symbols: [symType, symConst],
+          outgoingCalls: [],
+        }],
+        ["src/services/evaluator.ts", caller1],
+        ["src/services/other.ts", caller2],
+      ]),
+    });
+
+    // Querying JobOfferSnapshot must ONLY return evaluator.ts, NOT other.ts!
+    const resultSnapshot = await getImpactRadius(cache, "JobOfferSnapshot");
+    expect(resultSnapshot.status).toBe("ok");
+    expect(resultSnapshot.totalFiles).toBe(1);
+    expect(resultSnapshot.filesByDepth.get(1)).toEqual(["src/services/evaluator.ts"]);
+
+    // Querying UnrelatedConstant must ONLY return other.ts, NOT evaluator.ts!
+    const resultConst = await getImpactRadius(cache, "UnrelatedConstant");
+    expect(resultConst.status).toBe("ok");
+    expect(resultConst.totalFiles).toBe(1);
+    expect(resultConst.filesByDepth.get(1)).toEqual(["src/services/other.ts"]);
+  });
+
+  it("returns status ok and totalFiles 0 for a genuine zero-dependent symbol", async () => {
+    const symUnused: SymbolNode = {
+      id: "src/unused.ts::UNUSED_SYMBOL#1",
+      name: "UNUSED_SYMBOL",
+      qualifiedName: "UNUSED_SYMBOL",
+      kind: "variable",
+      file: "src/unused.ts",
+      line: 1,
+      endLine: 1,
+      language: "typescript",
+    };
+
+    const cache = createMockCache({
+      symbols: [symUnused],
+      reverseFileIndex: new Map(),
+      filePayloads: new Map([
+        ["src/unused.ts", { file: "src/unused.ts", language: "typescript", contentHash: "h_u", symbols: [symUnused], outgoingCalls: [] }],
+      ]),
+    });
+
+    const result = await getImpactRadius(cache, "UNUSED_SYMBOL");
+    expect(result.status).toBe("ok");
+    expect(result.totalFiles).toBe(0);
+  });
+
+  it("file mode traverses all dependents of a target file", async () => {
+    const cache = createMockCache({
+      symbols: [],
+      reverseFileIndex: new Map([
+        ["src/domain/snapshot.ts", new Set(["src/services/evaluator.ts", "src/services/other.ts"])],
+      ]),
+      filePayloads: new Map([
+        ["src/domain/snapshot.ts", { file: "src/domain/snapshot.ts", language: "typescript", contentHash: "h1", symbols: [], outgoingCalls: [] }],
+      ]),
+    });
+
+    const result = await getImpactRadius(cache, "src/domain/snapshot.ts");
+    expect(result.targetKind).toBe("file");
+    expect(result.status).toBe("ok");
+    expect(result.totalFiles).toBe(2);
+    expect(result.filesByDepth.get(1)).toEqual(["src/services/evaluator.ts", "src/services/other.ts"]);
+  });
+});

--- a/tests/unit/graph-impact.test.ts
+++ b/tests/unit/graph-impact.test.ts
@@ -209,6 +209,76 @@ describe("graph-impact exact symbol traversal and fail-closed", () => {
     expect(result.totalFiles).toBe(0);
   });
 
+  it("returns ambiguous status when multiple symbols share the same unqualified name in the same file (e.g. A.run and B.run)", async () => {
+    const symA: SymbolNode = {
+      id: "src/app.ts::A.run#5",
+      name: "run",
+      qualifiedName: "A.run",
+      kind: "method",
+      file: "src/app.ts",
+      line: 5,
+      endLine: 7,
+      language: "typescript",
+    };
+    const symB: SymbolNode = {
+      id: "src/app.ts::B.run#12",
+      name: "run",
+      qualifiedName: "B.run",
+      kind: "method",
+      file: "src/app.ts",
+      line: 12,
+      endLine: 14,
+      language: "typescript",
+    };
+
+    const cache = createMockCache({
+      symbols: [symA, symB],
+      reverseFileIndex: new Map(),
+      filePayloads: new Map([
+        ["src/app.ts", {
+          file: "src/app.ts",
+          language: "typescript",
+          contentHash: "h_app",
+          symbols: [symA, symB],
+          outgoingCalls: [],
+        }],
+      ]),
+    });
+
+    const result = await getImpactRadius(cache, "run");
+    expect(result.status).toBe("ambiguous");
+    expect(result.totalFiles).toBe(0);
+    expect(result.message).toContain("matches 2 symbols");
+    expect(result.candidates).toHaveLength(2);
+    expect(result.candidates?.map((c) => c.qualifiedName)).toEqual(["A.run", "B.run"]);
+  });
+
+  it("returns unsupported_or_incomplete before zero-impact result when graph is incomplete", async () => {
+    const symUnused: SymbolNode = {
+      id: "src/unused.ts::UNUSED_SYMBOL#1",
+      name: "UNUSED_SYMBOL",
+      qualifiedName: "UNUSED_SYMBOL",
+      kind: "variable",
+      file: "src/unused.ts",
+      line: 1,
+      endLine: 1,
+      language: "typescript",
+    };
+
+    const cache = createMockCache({
+      symbols: [symUnused],
+      reverseFileIndex: new Map(),
+      filePayloads: new Map([
+        ["src/unused.ts", { file: "src/unused.ts", language: "typescript", contentHash: "h_u", symbols: [symUnused], outgoingCalls: [] }],
+      ]),
+    });
+
+    const result = await getImpactRadius(cache, "UNUSED_SYMBOL", 3, { isIncomplete: true });
+    expect(result.status).toBe("unsupported_or_incomplete");
+    expect(result.totalFiles).toBe(0);
+    expect(result.message).toContain("incomplete");
+  });
+
   it("file mode traverses all dependents of a target file", async () => {
     const cache = createMockCache({
       symbols: [],

--- a/tests/unit/graph-impact.test.ts
+++ b/tests/unit/graph-impact.test.ts
@@ -145,6 +145,7 @@ describe("graph-impact exact symbol traversal and fail-closed", () => {
         {
           callerId: "src/services/evaluator.ts::eval#5",
           calleeName: "JobOfferSnapshot",
+          kind: "type_reference",
           calleeCandidates: ["src/domain/snapshot.ts::JobOfferSnapshot#10"],
           confidence: "unique",
           callSite: { file: "src/services/evaluator.ts", line: 6 },
@@ -162,6 +163,7 @@ describe("graph-impact exact symbol traversal and fail-closed", () => {
         {
           callerId: "src/services/other.ts::doOther#2",
           calleeName: "UnrelatedConstant",
+          kind: "value_reference",
           calleeCandidates: ["src/domain/snapshot.ts::UnrelatedConstant#20"],
           confidence: "unique",
           callSite: { file: "src/services/other.ts", line: 3 },

--- a/tests/unit/graph-symbol-resolution.test.ts
+++ b/tests/unit/graph-symbol-resolution.test.ts
@@ -339,9 +339,9 @@ describe("graph-symbol-resolution", () => {
   it("resolves aliased named re-export when preceded by wildcard re-export from same dep", () => {
     const graph: CodeGraph = {
       nodes: [
-        { relativePath: "src/barrel.ts", language: "typescript", dependencies: ["src/dep.ts"] },
-        { relativePath: "src/dep.ts", language: "typescript", dependencies: [] },
-        { relativePath: "src/consumer.ts", language: "typescript", dependencies: ["src/barrel.ts"] },
+        { filePath: "/project/src/barrel.ts", relativePath: "src/barrel.ts", language: "typescript", dependencies: ["src/dep.ts"], imports: [], exports: [], dependents: [] },
+        { filePath: "/project/src/dep.ts", relativePath: "src/dep.ts", language: "typescript", dependencies: [], imports: [], exports: [], dependents: [] },
+        { filePath: "/project/src/consumer.ts", relativePath: "src/consumer.ts", language: "typescript", dependencies: ["src/barrel.ts"], imports: [], exports: [], dependents: [] },
       ],
       edges: [],
     };
@@ -421,12 +421,16 @@ describe("graph-symbol-resolution", () => {
     const graph: CodeGraph = {
       nodes: [
         {
+          filePath: "/project/src/app.ts",
           relativePath: "src/app.ts",
           language: "typescript",
           dependencies: ["src/button.ts", "src/components/button.ts"],
+          imports: [],
+          exports: [],
+          dependents: [],
         },
-        { relativePath: "src/button.ts", language: "typescript", dependencies: [] },
-        { relativePath: "src/components/button.ts", language: "typescript", dependencies: [] },
+        { filePath: "/project/src/button.ts", relativePath: "src/button.ts", language: "typescript", dependencies: [], imports: [], exports: [], dependents: [] },
+        { filePath: "/project/src/components/button.ts", relativePath: "src/components/button.ts", language: "typescript", dependencies: [], imports: [], exports: [], dependents: [] },
       ],
       edges: [],
     };

--- a/tests/unit/graph-symbol-resolution.test.ts
+++ b/tests/unit/graph-symbol-resolution.test.ts
@@ -303,13 +303,13 @@ describe("graph-symbol-resolution", () => {
       [
         "src/barrelB.ts",
         [
-          // Circular re-export to A plus re-export to target
+          // Circular wildcard re-export to A plus wildcard re-export to target
           {
             callerId: "src/barrelB.ts::<module>#1",
-            calleeName: "other",
+            calleeName: "*",
             kind: "reexport",
             sourceModule: "./barrelA",
-            importedName: "other",
+            importedName: "*",
             calleeCandidates: [],
             confidence: "unresolved",
             callSite: { file: "src/barrelB.ts", line: 1 },
@@ -334,6 +334,154 @@ describe("graph-symbol-resolution", () => {
     expect(clientEdge).toBeDefined();
     expect(clientEdge?.confidence).toBe("unique");
     expect(clientEdge?.calleeCandidates).toEqual(["src/target.ts::helper#1"]);
+  });
+
+  it("resolves aliased named re-export when preceded by wildcard re-export from same dep", () => {
+    const graph: CodeGraph = {
+      nodes: [
+        { relativePath: "src/barrel.ts", language: "typescript", dependencies: ["src/dep.ts"] },
+        { relativePath: "src/dep.ts", language: "typescript", dependencies: [] },
+        { relativePath: "src/consumer.ts", language: "typescript", dependencies: ["src/barrel.ts"] },
+      ],
+      edges: [],
+    };
+
+    const symOriginal: SymbolNode = {
+      id: "src/dep.ts::computeCore#1",
+      name: "computeCore",
+      qualifiedName: "computeCore",
+      kind: "function",
+      file: "src/dep.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+
+    const symbolsByFile = new Map<string, SymbolNode[]>([
+      ["src/dep.ts", [symOriginal]],
+      ["src/barrel.ts", []],
+      ["src/consumer.ts", []],
+    ]);
+
+    const outgoing = new Map<string, SymbolEdge[]>([
+      [
+        "src/barrel.ts",
+        [
+          // 1. Wildcard re-export from dep
+          {
+            callerId: "src/barrel.ts::<module>#1",
+            calleeName: "*",
+            kind: "reexport",
+            sourceModule: "./dep",
+            importedName: "*",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/barrel.ts", line: 1 },
+          },
+          // 2. Aliased re-export from same dep: export { computeCore as customAlias } from './dep'
+          {
+            callerId: "src/barrel.ts::<module>#1",
+            calleeName: "customAlias",
+            kind: "reexport",
+            sourceModule: "./dep",
+            importedName: "computeCore",
+            localAlias: "customAlias",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/barrel.ts", line: 2 },
+          },
+        ],
+      ],
+      [
+        "src/consumer.ts",
+        [
+          {
+            callerId: "src/consumer.ts::main#1",
+            calleeName: "customAlias",
+            kind: "call",
+            sourceModule: "./barrel",
+            importedName: "customAlias",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/consumer.ts", line: 3 },
+          },
+        ],
+      ],
+    ]);
+
+    resolveCallSites(graph, symbolsByFile, outgoing);
+
+    const edge = outgoing.get("src/consumer.ts")?.[0];
+    expect(edge).toBeDefined();
+    expect(edge?.confidence).toBe("unique");
+    expect(edge?.calleeCandidates).toEqual(["src/dep.ts::computeCore#1"]);
+  });
+
+  it("prioritizes exact normalized module match over suffix match in resolveDepFile", () => {
+    const graph: CodeGraph = {
+      nodes: [
+        {
+          relativePath: "src/app.ts",
+          language: "typescript",
+          dependencies: ["src/button.ts", "src/components/button.ts"],
+        },
+        { relativePath: "src/button.ts", language: "typescript", dependencies: [] },
+        { relativePath: "src/components/button.ts", language: "typescript", dependencies: [] },
+      ],
+      edges: [],
+    };
+
+    const symButton: SymbolNode = {
+      id: "src/button.ts::render#1",
+      name: "render",
+      qualifiedName: "render",
+      kind: "function",
+      file: "src/button.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+    const symCompButton: SymbolNode = {
+      id: "src/components/button.ts::render#1",
+      name: "render",
+      qualifiedName: "render",
+      kind: "function",
+      file: "src/components/button.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+
+    const symbolsByFile = new Map<string, SymbolNode[]>([
+      ["src/button.ts", [symButton]],
+      ["src/components/button.ts", [symCompButton]],
+      ["src/app.ts", []],
+    ]);
+
+    const outgoing = new Map<string, SymbolEdge[]>([
+      [
+        "src/app.ts",
+        [
+          {
+            callerId: "src/app.ts::main#1",
+            calleeName: "render",
+            kind: "call",
+            sourceModule: "./button",
+            importedName: "render",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/app.ts", line: 2 },
+          },
+        ],
+      ],
+    ]);
+
+    resolveCallSites(graph, symbolsByFile, outgoing);
+
+    const edge = outgoing.get("src/app.ts")?.[0];
+    expect(edge).toBeDefined();
+    expect(edge?.confidence).toBe("unique");
+    expect(edge?.calleeCandidates).toEqual(["src/button.ts::render#1"]);
   });
 
   it("computeUnresolvedPct returns 0 when no edges", () => {

--- a/tests/unit/graph-symbol-resolution.test.ts
+++ b/tests/unit/graph-symbol-resolution.test.ts
@@ -691,4 +691,143 @@ describe("graph-symbol-resolution", () => {
     expect(appEdge?.confidence).toBe("unresolved");
     expect(appEdge?.calleeCandidates).toHaveLength(0);
   });
+
+  it("distinguishes private declaration from exported symbol re-exported from dependency", () => {
+    const graph: CodeGraph = {
+      projectId: "p1",
+      projectPath: "/test",
+      builtAt: Date.now(),
+      nodes: [
+        {
+          relativePath: "src/app.ts",
+          imports: ["./index"],
+          exports: [],
+          dependencies: ["src/index.ts"],
+          dependents: [],
+        },
+        {
+          relativePath: "src/index.ts",
+          imports: ["./dep"],
+          exports: [],
+          dependencies: ["src/dep.ts"],
+          dependents: ["src/app.ts"],
+        },
+        {
+          relativePath: "src/dep.ts",
+          imports: [],
+          exports: ["helper"],
+          dependencies: [],
+          dependents: ["src/index.ts"],
+        },
+      ],
+      edges: [],
+    };
+
+    const symIndexPrivateHelper: SymbolNode = {
+      id: "src/index.ts::helper#1",
+      name: "helper",
+      qualifiedName: "helper",
+      kind: "function",
+      file: "src/index.ts",
+      line: 1,
+      endLine: 3,
+      language: "typescript",
+      isExported: false,
+    };
+    const symIndexLocalCaller: SymbolNode = {
+      id: "src/index.ts::callLocal#5",
+      name: "callLocal",
+      qualifiedName: "callLocal",
+      kind: "function",
+      file: "src/index.ts",
+      line: 5,
+      endLine: 7,
+      language: "typescript",
+      isExported: false,
+    };
+    const symDepHelper: SymbolNode = {
+      id: "src/dep.ts::helper#1",
+      name: "helper",
+      qualifiedName: "helper",
+      kind: "function",
+      file: "src/dep.ts",
+      line: 1,
+      endLine: 3,
+      language: "typescript",
+      isExported: true,
+    };
+    const symAppMain: SymbolNode = {
+      id: "src/app.ts::main#1",
+      name: "main",
+      qualifiedName: "main",
+      kind: "function",
+      file: "src/app.ts",
+      line: 1,
+      endLine: 4,
+      language: "typescript",
+      isExported: true,
+    };
+
+    const symbolsByFile = new Map<string, SymbolNode[]>([
+      ["src/index.ts", [symIndexPrivateHelper, symIndexLocalCaller]],
+      ["src/dep.ts", [symDepHelper]],
+      ["src/app.ts", [symAppMain]],
+    ]);
+
+    const outgoing = new Map<string, SymbolEdge[]>([
+      [
+        "src/index.ts",
+        [
+          // Wildcard re-export from dep: `export * from './dep'`
+          {
+            callerId: "src/index.ts::<module>#1",
+            calleeName: "*",
+            kind: "reexport",
+            sourceModule: "./dep",
+            importedName: "*",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/index.ts", line: 4 },
+          },
+          // Same-file local call: callLocal calls helper (unrestricted local resolution)
+          {
+            callerId: "src/index.ts::callLocal#5",
+            calleeName: "helper",
+            kind: "call",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/index.ts", line: 6 },
+          },
+        ],
+      ],
+      [
+        "src/app.ts",
+        [
+          // External import from index: `import { helper } from './index'`
+          {
+            callerId: "src/app.ts::main#1",
+            calleeName: "helper",
+            kind: "call",
+            sourceModule: "./index",
+            importedName: "helper",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/app.ts", line: 2 },
+          },
+        ],
+      ],
+    ]);
+
+    resolveCallSites(graph, symbolsByFile, outgoing);
+
+    // External caller should resolve uniquely to dep.ts::helper (ignoring index.ts's private helper)
+    const appEdge = outgoing.get("src/app.ts")?.[0];
+    expect(appEdge?.confidence).toBe("unique");
+    expect(appEdge?.calleeCandidates).toEqual(["src/dep.ts::helper#1"]);
+
+    // Local caller inside index.ts should resolve locally to index.ts::helper
+    const indexLocalEdge = outgoing.get("src/index.ts")?.[1];
+    expect(indexLocalEdge?.confidence).toBe("local");
+    expect(indexLocalEdge?.calleeCandidates).toEqual(["src/index.ts::helper#1"]);
+  });
 });

--- a/tests/unit/graph-symbol-resolution.test.ts
+++ b/tests/unit/graph-symbol-resolution.test.ts
@@ -109,6 +109,233 @@ describe("graph-symbol-resolution", () => {
     expect(edges[0].calleeCandidates).toEqual([]);
   });
 
+  it("preserves module identity when two dependencies export the same symbol name", () => {
+    const graph: CodeGraph = {
+      nodes: [
+        {
+          relativePath: "src/app.ts",
+          imports: ["./serviceA", "./serviceB"],
+          exports: [],
+          dependencies: ["src/serviceA.ts", "src/serviceB.ts"],
+          dependents: [],
+        },
+        {
+          relativePath: "src/serviceA.ts",
+          imports: [],
+          exports: ["processData"],
+          dependencies: [],
+          dependents: ["src/app.ts"],
+        },
+        {
+          relativePath: "src/serviceB.ts",
+          imports: [],
+          exports: ["processData"],
+          dependencies: [],
+          dependents: ["src/app.ts"],
+        },
+      ],
+      edges: [],
+    };
+    const symbolsByFile = new Map<string, SymbolNode[]>([
+      [
+        "src/app.ts",
+        [{ id: "src/app.ts::run#1", name: "run", qualifiedName: "run", kind: "function", file: "src/app.ts", line: 1, endLine: 5, language: "typescript" }],
+      ],
+      [
+        "src/serviceA.ts",
+        [{ id: "src/serviceA.ts::processData#1", name: "processData", qualifiedName: "processData", kind: "function", file: "src/serviceA.ts", line: 1, endLine: 5, language: "typescript" }],
+      ],
+      [
+        "src/serviceB.ts",
+        [{ id: "src/serviceB.ts::processData#1", name: "processData", qualifiedName: "processData", kind: "function", file: "src/serviceB.ts", line: 1, endLine: 5, language: "typescript" }],
+      ],
+    ]);
+
+    // app.ts specifically imports processData from serviceA
+    const edges: SymbolEdge[] = [
+      {
+        callerId: "src/app.ts::run#1",
+        calleeName: "processData",
+        kind: "call",
+        sourceModule: "./serviceA",
+        importedName: "processData",
+        calleeCandidates: [],
+        confidence: "unresolved",
+        callSite: { file: "src/app.ts", line: 3 },
+      },
+    ];
+    const outgoing = new Map<string, SymbolEdge[]>([["src/app.ts", edges]]);
+
+    resolveCallSites(graph, symbolsByFile, outgoing);
+
+    expect(edges[0].confidence).toBe("unique");
+    expect(edges[0].calleeCandidates).toEqual(["src/serviceA.ts::processData#1"]);
+  });
+
+  it("resolves default imports to default exported symbol", () => {
+    const graph: CodeGraph = {
+      nodes: [
+        {
+          relativePath: "src/main.ts",
+          imports: ["./logger"],
+          exports: [],
+          dependencies: ["src/logger.ts"],
+          dependents: [],
+        },
+        {
+          relativePath: "src/logger.ts",
+          imports: [],
+          exports: ["default"],
+          dependencies: [],
+          dependents: ["src/main.ts"],
+        },
+      ],
+      edges: [],
+    };
+    const symbolsByFile = new Map<string, SymbolNode[]>([
+      [
+        "src/main.ts",
+        [{ id: "src/main.ts::main#1", name: "main", qualifiedName: "main", kind: "function", file: "src/main.ts", line: 1, endLine: 5, language: "typescript" }],
+      ],
+      [
+        "src/logger.ts",
+        [{ id: "src/logger.ts::Logger#1", name: "Logger", qualifiedName: "Logger", exportedAs: "default", kind: "class", file: "src/logger.ts", line: 1, endLine: 10, language: "typescript" }],
+      ],
+    ]);
+
+    const edges: SymbolEdge[] = [
+      {
+        callerId: "src/main.ts::main#1",
+        calleeName: "Logger",
+        kind: "call",
+        sourceModule: "./logger",
+        importedName: "default",
+        localAlias: "Logger",
+        calleeCandidates: [],
+        confidence: "unresolved",
+        callSite: { file: "src/main.ts", line: 2 },
+      },
+    ];
+    const outgoing = new Map<string, SymbolEdge[]>([["src/main.ts", edges]]);
+
+    resolveCallSites(graph, symbolsByFile, outgoing);
+
+    expect(edges[0].confidence).toBe("unique");
+    expect(edges[0].calleeCandidates).toEqual(["src/logger.ts::Logger#1"]);
+  });
+
+  it("resolves multi-level re-export barrel chains with cycle protection", () => {
+    const graph: CodeGraph = {
+      nodes: [
+        {
+          relativePath: "src/client.ts",
+          imports: ["./barrelA"],
+          exports: [],
+          dependencies: ["src/barrelA.ts"],
+          dependents: [],
+        },
+        {
+          relativePath: "src/barrelA.ts",
+          imports: ["./barrelB"],
+          exports: ["helper"],
+          dependencies: ["src/barrelB.ts"],
+          dependents: ["src/client.ts", "src/barrelB.ts"],
+        },
+        {
+          relativePath: "src/barrelB.ts",
+          imports: ["./barrelA", "./target"],
+          exports: ["helper"],
+          dependencies: ["src/barrelA.ts", "src/target.ts"],
+          dependents: ["src/barrelA.ts"],
+        },
+        {
+          relativePath: "src/target.ts",
+          imports: [],
+          exports: ["helper"],
+          dependencies: [],
+          dependents: ["src/barrelB.ts"],
+        },
+      ],
+      edges: [],
+    };
+    const symbolsByFile = new Map<string, SymbolNode[]>([
+      [
+        "src/client.ts",
+        [{ id: "src/client.ts::run#1", name: "run", qualifiedName: "run", kind: "function", file: "src/client.ts", line: 1, endLine: 3, language: "typescript" }],
+      ],
+      [
+        "src/target.ts",
+        [{ id: "src/target.ts::helper#1", name: "helper", qualifiedName: "helper", kind: "function", file: "src/target.ts", line: 1, endLine: 5, language: "typescript" }],
+      ],
+    ]);
+
+    const outgoing = new Map<string, SymbolEdge[]>([
+      [
+        "src/client.ts",
+        [
+          {
+            callerId: "src/client.ts::run#1",
+            calleeName: "helper",
+            kind: "call",
+            sourceModule: "./barrelA",
+            importedName: "helper",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/client.ts", line: 2 },
+          },
+        ],
+      ],
+      [
+        "src/barrelA.ts",
+        [
+          {
+            callerId: "src/barrelA.ts::<module>#1",
+            calleeName: "helper",
+            kind: "reexport",
+            sourceModule: "./barrelB",
+            importedName: "helper",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/barrelA.ts", line: 1 },
+          },
+        ],
+      ],
+      [
+        "src/barrelB.ts",
+        [
+          // Circular re-export to A plus re-export to target
+          {
+            callerId: "src/barrelB.ts::<module>#1",
+            calleeName: "other",
+            kind: "reexport",
+            sourceModule: "./barrelA",
+            importedName: "other",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/barrelB.ts", line: 1 },
+          },
+          {
+            callerId: "src/barrelB.ts::<module>#1",
+            calleeName: "*",
+            kind: "reexport",
+            sourceModule: "./target",
+            importedName: "*",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/barrelB.ts", line: 2 },
+          },
+        ],
+      ],
+    ]);
+
+    resolveCallSites(graph, symbolsByFile, outgoing);
+
+    const clientEdge = outgoing.get("src/client.ts")?.[0];
+    expect(clientEdge).toBeDefined();
+    expect(clientEdge?.confidence).toBe("unique");
+    expect(clientEdge?.calleeCandidates).toEqual(["src/target.ts::helper#1"]);
+  });
+
   it("computeUnresolvedPct returns 0 when no edges", () => {
     expect(computeUnresolvedPct(new Map())).toBe(0);
   });
@@ -118,8 +345,8 @@ describe("graph-symbol-resolution", () => {
       [
         "src/a.ts",
         [
-          { callerId: "x", calleeName: "y", calleeCandidates: ["x"], confidence: "unique", callSite: { file: "x", line: 1 } },
-          { callerId: "x", calleeName: "z", calleeCandidates: [], confidence: "unresolved", callSite: { file: "x", line: 2 } },
+          { callerId: "x", calleeName: "y", kind: "call", calleeCandidates: ["x"], confidence: "unique", callSite: { file: "x", line: 1 } },
+          { callerId: "x", calleeName: "z", kind: "call", calleeCandidates: [], confidence: "unresolved", callSite: { file: "x", line: 2 } },
         ],
       ],
     ]);

--- a/tests/unit/graph-symbol-resolution.test.ts
+++ b/tests/unit/graph-symbol-resolution.test.ts
@@ -638,4 +638,57 @@ describe("graph-symbol-resolution", () => {
     ]);
     expect(computeUnresolvedPct(map)).toBe(50);
   });
+
+  it("does not resolve an internal helper through an aliased namespace re-export barrel", () => {
+    const graph: CodeGraph = {
+      nodes: [
+        { relativePath: "src/index.ts", imports: ["./helpers"], exports: ["utils"], dependencies: ["src/helpers.ts"], dependents: ["src/app.ts"] },
+        { relativePath: "src/helpers.ts", imports: [], exports: ["secret"], dependencies: [], dependents: ["src/index.ts"] },
+        { relativePath: "src/app.ts", imports: ["./index"], exports: [], dependencies: ["src/index.ts"], dependents: [] },
+      ],
+      edges: [],
+    };
+    const symbolsByFile = new Map<string, SymbolNode[]>([
+      ["src/index.ts", [{ id: "src/index.ts::<module>#1", name: "<module>", qualifiedName: "<module>", kind: "function", file: "src/index.ts", line: 1, endLine: 1, language: "typescript" }]],
+      ["src/helpers.ts", [{ id: "src/helpers.ts::secret#1", name: "secret", qualifiedName: "secret", kind: "function", file: "src/helpers.ts", line: 1, endLine: 3, language: "typescript" }]],
+      ["src/app.ts", [{ id: "src/app.ts::main#1", name: "main", qualifiedName: "main", kind: "function", file: "src/app.ts", line: 1, endLine: 5, language: "typescript" }]],
+    ]);
+    const outgoing = new Map<string, SymbolEdge[]>([
+      [
+        "src/index.ts",
+        [
+          {
+            callerId: "src/index.ts::<module>#1",
+            calleeName: "utils",
+            kind: "reexport",
+            sourceModule: "./helpers",
+            localAlias: "utils",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/index.ts", line: 1 },
+          },
+        ],
+      ],
+      [
+        "src/app.ts",
+        [
+          {
+            callerId: "src/app.ts::main#1",
+            calleeName: "secret",
+            kind: "call",
+            sourceModule: "./index",
+            importedName: "secret",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/app.ts", line: 2 },
+          },
+        ],
+      ],
+    ]);
+
+    resolveCallSites(graph, symbolsByFile, outgoing);
+    const appEdge = outgoing.get("src/app.ts")?.[0];
+    expect(appEdge?.confidence).toBe("unresolved");
+    expect(appEdge?.calleeCandidates).toHaveLength(0);
+  });
 });

--- a/tests/unit/graph-symbol-resolution.test.ts
+++ b/tests/unit/graph-symbol-resolution.test.ts
@@ -488,6 +488,140 @@ describe("graph-symbol-resolution", () => {
     expect(edge?.calleeCandidates).toEqual(["src/button.ts::render#1"]);
   });
 
+  it("resolves modules located in dotted directories such as v1.0", () => {
+    const graph: CodeGraph = {
+      nodes: [
+        {
+          filePath: "/project/src/client.ts",
+          relativePath: "src/client.ts",
+          language: "typescript",
+          dependencies: ["src/api/v1.0/service.ts"],
+          imports: [],
+          exports: [],
+          dependents: [],
+        },
+        {
+          filePath: "/project/src/api/v1.0/service.ts",
+          relativePath: "src/api/v1.0/service.ts",
+          language: "typescript",
+          dependencies: [],
+          imports: [],
+          exports: [],
+          dependents: [],
+        },
+      ],
+      edges: [],
+    };
+
+    const symService: SymbolNode = {
+      id: "src/api/v1.0/service.ts::fetchData#1",
+      name: "fetchData",
+      qualifiedName: "fetchData",
+      kind: "function",
+      file: "src/api/v1.0/service.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+
+    const symbolsByFile = new Map<string, SymbolNode[]>([
+      ["src/api/v1.0/service.ts", [symService]],
+      ["src/client.ts", []],
+    ]);
+
+    const outgoing = new Map<string, SymbolEdge[]>([
+      [
+        "src/client.ts",
+        [
+          {
+            callerId: "src/client.ts::main#1",
+            calleeName: "fetchData",
+            kind: "call",
+            sourceModule: "./api/v1.0/service",
+            importedName: "fetchData",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/client.ts", line: 2 },
+          },
+        ],
+      ],
+    ]);
+
+    resolveCallSites(graph, symbolsByFile, outgoing);
+    const edge = outgoing.get("src/client.ts")?.[0];
+    expect(edge?.confidence).toBe("unique");
+    expect(edge?.calleeCandidates).toEqual(["src/api/v1.0/service.ts::fetchData#1"]);
+  });
+
+  it("does not arbitrarily resolve when suffix matches are ambiguous across dependencies", () => {
+    const graph: CodeGraph = {
+      nodes: [
+        {
+          filePath: "/project/src/app.ts",
+          relativePath: "src/app.ts",
+          language: "typescript",
+          dependencies: ["packages/pkg-a/utils.ts", "packages/pkg-b/utils.ts"],
+          imports: [],
+          exports: [],
+          dependents: [],
+        },
+        { filePath: "/project/packages/pkg-a/utils.ts", relativePath: "packages/pkg-a/utils.ts", language: "typescript", dependencies: [], imports: [], exports: [], dependents: [] },
+        { filePath: "/project/packages/pkg-b/utils.ts", relativePath: "packages/pkg-b/utils.ts", language: "typescript", dependencies: [], imports: [], exports: [], dependents: [] },
+      ],
+      edges: [],
+    };
+
+    const symA: SymbolNode = {
+      id: "packages/pkg-a/utils.ts::helper#1",
+      name: "helper",
+      qualifiedName: "helper",
+      kind: "function",
+      file: "packages/pkg-a/utils.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+    const symB: SymbolNode = {
+      id: "packages/pkg-b/utils.ts::helper#1",
+      name: "helper",
+      qualifiedName: "helper",
+      kind: "function",
+      file: "packages/pkg-b/utils.ts",
+      line: 1,
+      endLine: 5,
+      language: "typescript",
+    };
+
+    const symbolsByFile = new Map<string, SymbolNode[]>([
+      ["packages/pkg-a/utils.ts", [symA]],
+      ["packages/pkg-b/utils.ts", [symB]],
+      ["src/app.ts", []],
+    ]);
+
+    const outgoing = new Map<string, SymbolEdge[]>([
+      [
+        "src/app.ts",
+        [
+          {
+            callerId: "src/app.ts::main#1",
+            calleeName: "helper",
+            kind: "call",
+            sourceModule: "utils",
+            importedName: "helper",
+            calleeCandidates: [],
+            confidence: "unresolved",
+            callSite: { file: "src/app.ts", line: 2 },
+          },
+        ],
+      ],
+    ]);
+
+    resolveCallSites(graph, symbolsByFile, outgoing);
+    const edge = outgoing.get("src/app.ts")?.[0];
+    expect(edge?.confidence).toBe("unresolved");
+    expect(edge?.calleeCandidates).toHaveLength(0);
+  });
+
   it("computeUnresolvedPct returns 0 when no edges", () => {
     expect(computeUnresolvedPct(new Map())).toBe(0);
   });

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -883,5 +883,48 @@ const direct = run();
       const runCalls = out.rawCalls.filter((c) => c.calleeName === "run" && c.kind === "call");
       expect(runCalls).toHaveLength(1);
     });
+
+    it("shadows imported references when local variable, destructuring, or catch binding exists", () => {
+      const src = `
+import { config, logger, error } from "./lib";
+
+function run() {
+  const config = loadLocal();
+  const { logger } = getContext();
+  try {
+    doWork(config, logger);
+  } catch (error) {
+    handle(error);
+  }
+}
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/shadow.ts");
+      const configRefs = out.rawCalls.filter((c) => c.calleeName === "config" && c.kind === "value_reference");
+      const loggerRefs = out.rawCalls.filter((c) => c.calleeName === "logger" && c.kind === "value_reference");
+      const errorRefs = out.rawCalls.filter((c) => c.calleeName === "error" && c.kind === "value_reference");
+      expect(configRefs).toHaveLength(0);
+      expect(loggerRefs).toHaveLength(0);
+      expect(errorRefs).toHaveLength(0);
+    });
+
+    it("does not suppress imported reference outside a nested block scope", () => {
+      const src = `
+import { data } from "./data";
+
+function process(condition: boolean) {
+  if (condition) {
+    const data = "local";
+    console.log(data);
+  }
+  return data;
+}
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/block-scope.ts");
+      const dataRefs = out.rawCalls.filter((c) => c.calleeName === "data" && c.kind === "value_reference");
+      // Outside the if-block, `return data` must emit an imported value_reference
+      expect(dataRefs).toHaveLength(1);
+      expect(dataRefs[0].callSite.line).toBe(9);
+      expect(dataRefs[0].sourceModule).toBe("./data");
+    });
   });
 });

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -108,6 +108,48 @@ export function processOffer(offer: JobOfferSnapshot): UserProfile {
       );
       expect(processOfferCall).toBeDefined();
     });
+
+    it("resolves aliased imports to their original exported names", () => {
+      const src = `
+import { calculateSum as sum, UserConfig as Config, API_KEY as KEY } from "./utils";
+
+export function execute(cfg: Config): number {
+  const secret = KEY;
+  return sum(1, 2);
+}
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/client.ts");
+      const calleeNames = out.rawCalls.map((c) => c.calleeName);
+      expect(calleeNames).toContain("calculateSum");
+      expect(calleeNames).toContain("UserConfig");
+      expect(calleeNames).toContain("API_KEY");
+      expect(calleeNames).not.toContain("sum");
+      expect(calleeNames).not.toContain("Config");
+      expect(calleeNames).not.toContain("KEY");
+
+      const executeCalls = out.rawCalls.filter((c) => c.callerId.includes("::execute#"));
+      const executeCallees = executeCalls.map((c) => c.calleeName);
+      expect(executeCallees).toContain("calculateSum");
+      expect(executeCallees).toContain("UserConfig");
+      expect(executeCallees).toContain("API_KEY");
+    });
+
+    it("resolves namespace imports to the accessed exported symbols", () => {
+      const src = `
+import * as Utils from "./utils";
+
+export function run(config: Utils.DatabaseConfig): number {
+  const defaultVal = Utils.DEFAULT_LIMIT;
+  return Utils.add(defaultVal, 10);
+}
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/caller.ts");
+      const runCalls = out.rawCalls.filter((c) => c.callerId.includes("::run#"));
+      const runCallees = runCalls.map((c) => c.calleeName);
+      expect(runCallees).toContain("DatabaseConfig");
+      expect(runCallees).toContain("DEFAULT_LIMIT");
+      expect(runCallees).toContain("add");
+    });
   });
 
   describe("Python", () => {

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -813,6 +813,16 @@ export const { port = getDefaultPort(), host: serverHost = "localhost" } = confi
       expect(names).not.toContain("config");
     });
 
+    it("does not classify an object binding as a function because its initializer contains one", () => {
+      const src = `
+export const config = { handler: () => "ok" };
+export const direct = () => "ok";
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/config.ts");
+      expect(out.symbols.find((symbol) => symbol.name === "config")?.kind).toBe("variable");
+      expect(out.symbols.find((symbol) => symbol.name === "direct")?.kind).toBe("function");
+    });
+
     it("does not attach bare import provenance to member method calls", () => {
       const src = `
 import { run } from "./runner";
@@ -859,6 +869,24 @@ export { computeTotal };
       const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/math.ts");
       const valueRefs = out.rawCalls.filter((c) => c.kind === "value_reference" && c.calleeName === "computeTotal");
       expect(valueRefs).toHaveLength(0);
+    });
+
+    it("marks only the module-scope binding named by a local export specifier", () => {
+      const src = `
+function outer() {
+  function Thing() {}
+}
+function Thing() {}
+export { Thing as PublicThing };
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/things.ts");
+      const things = out.symbols.filter((symbol) => symbol.name === "Thing");
+      expect(things).toHaveLength(2);
+
+      const exported = things.filter((symbol) => symbol.isExported);
+      expect(exported).toHaveLength(1);
+      expect(exported[0]).toMatchObject({ line: 5, exportedAs: "PublicThing" });
+      expect(things.find((symbol) => symbol.line === 3)?.isExported).toBe(false);
     });
 
     it("skips non-computed member properties and shadowed parameters", () => {
@@ -925,6 +953,25 @@ function process(condition: boolean) {
       expect(dataRefs).toHaveLength(1);
       expect(dataRefs[0].callSite.line).toBe(9);
       expect(dataRefs[0].sourceModule).toBe("./data");
+    });
+
+    it("does not let a nested function's var shadow an outer imported reference", () => {
+      const src = `
+import { dep } from "./dep";
+
+function outer() {
+  function inner() { var dep = 1; return dep; }
+  return dep;
+}
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/nested-var.ts");
+      const depRefs = out.rawCalls.filter(
+        (call) => call.calleeName === "dep" && call.kind === "value_reference",
+      );
+      expect(depRefs).toHaveLength(1);
+      expect(depRefs[0].callSite.line).toBe(6);
+      expect(depRefs[0].sourceModule).toBe("./dep");
+      expect(depRefs[0].callerId).toContain("::outer#");
     });
   });
 });

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -835,5 +835,29 @@ export function main(obj: any): void {
       expect(bareCall?.sourceModule).toBe("./runner");
       expect(bareCall?.importedName).toBe("run");
     });
+
+    it("extracts namespace re-export with export * as ns from './dep'", () => {
+      const src = `
+export * as utils from "./utils";
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/index.ts");
+      const reexport = out.rawCalls.find((c) => c.kind === "reexport");
+      expect(reexport).toBeDefined();
+      expect(reexport?.calleeName).toBe("utils");
+      expect(reexport?.localAlias).toBe("utils");
+      expect(reexport?.sourceModule).toBe("./utils");
+    });
+
+    it("does not emit self-referential value_reference for locally exported declaration lines", () => {
+      const src = `
+export function computeTotal(a: number, b: number): number {
+  return a + b;
+}
+export { computeTotal };
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/math.ts");
+      const valueRefs = out.rawCalls.filter((c) => c.kind === "value_reference" && c.calleeName === "computeTotal");
+      expect(valueRefs).toHaveLength(0);
+    });
   });
 });

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -846,6 +846,7 @@ export * as utils from "./utils";
       expect(reexport?.calleeName).toBe("utils");
       expect(reexport?.localAlias).toBe("utils");
       expect(reexport?.sourceModule).toBe("./utils");
+      expect(reexport?.importedName).toBeUndefined();
     });
 
     it("does not emit self-referential value_reference for locally exported declaration lines", () => {
@@ -858,6 +859,29 @@ export { computeTotal };
       const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/math.ts");
       const valueRefs = out.rawCalls.filter((c) => c.kind === "value_reference" && c.calleeName === "computeTotal");
       expect(valueRefs).toHaveLength(0);
+    });
+
+    it("skips non-computed member properties and shadowed parameters", () => {
+      const src = `
+import { config, run } from "./lib";
+
+function execute(config: string) {
+  const result = obj.run;
+  console.log(config);
+}
+
+const direct = run();
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/caller.ts");
+      // obj.run is a member property, not a value reference to imported run
+      const runRefs = out.rawCalls.filter((c) => c.calleeName === "run" && c.kind === "value_reference");
+      expect(runRefs).toHaveLength(0);
+      // config inside execute is shadowed by parameter `config: string`
+      const configRefs = out.rawCalls.filter((c) => c.calleeName === "config" && c.kind === "value_reference");
+      expect(configRefs).toHaveLength(0);
+      // direct call to run() is preserved as call
+      const runCalls = out.rawCalls.filter((c) => c.calleeName === "run" && c.kind === "call");
+      expect(runCalls).toHaveLength(1);
     });
   });
 });

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -65,6 +65,49 @@ const helper = function () { return 42; };
       expect(names).toContain("validate");
       expect(names).toContain("helper");
     });
+
+    it("extracts interfaces, type aliases, enums, and plain constants (issue #132)", () => {
+      const src = `
+export interface UserProfile { id: string; name: string; }
+export type JobOfferSnapshot = { id: string; score: number; };
+export enum OfferStatus { Active, Expired }
+export const STALE_EVALUATION_WHERE = "status = 'stale'";
+export let retryCount = 3;
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/types.ts");
+      const syms = new Map(out.symbols.map((s) => [s.name, s]));
+      expect(syms.get("UserProfile")?.kind).toBe("interface");
+      expect(syms.get("JobOfferSnapshot")?.kind).toBe("type");
+      expect(syms.get("OfferStatus")?.kind).toBe("enum");
+      expect(syms.get("STALE_EVALUATION_WHERE")?.kind).toBe("variable");
+      expect(syms.get("retryCount")?.kind).toBe("variable");
+    });
+
+    it("extracts import, re-export, and type reference edges (issue #132)", () => {
+      const src = `
+import { JobOfferSnapshot, STALE_EVALUATION_WHERE } from "./types";
+import type { UserProfile } from "./user";
+import DefaultService from "./service";
+export { OfferStatus } from "./enums";
+
+export function processOffer(offer: JobOfferSnapshot): UserProfile {
+  const query = STALE_EVALUATION_WHERE;
+  return { id: "1", name: query };
+}
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/worker.ts");
+      const calleeNames = out.rawCalls.map((c) => c.calleeName);
+      expect(calleeNames).toContain("JobOfferSnapshot");
+      expect(calleeNames).toContain("STALE_EVALUATION_WHERE");
+      expect(calleeNames).toContain("UserProfile");
+      expect(calleeNames).toContain("DefaultService");
+      expect(calleeNames).toContain("OfferStatus");
+
+      const processOfferCall = out.rawCalls.find(
+        (c) => c.calleeName === "JobOfferSnapshot" && c.callerId.includes("::processOffer#"),
+      );
+      expect(processOfferCall).toBeDefined();
+    });
   });
 
   describe("Python", () => {

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -11,8 +11,8 @@ import {
 } from "../../src/services/graph-symbols.js";
 import { logger } from "../../src/services/logger.js";
 
-beforeAll(() => {
-  ensureDynamicLanguages();
+beforeAll(async () => {
+  await ensureDynamicLanguages();
 });
 
 describe("graph-symbols", () => {
@@ -800,17 +800,40 @@ enum Color { red, green }
     });
   });
 
-  describe("Regex fallback (Svelte, Vue, unknown)", () => {
-    it("handles unknown language without throwing", () => {
-      const src = "some random text\nwith no recognizable structure";
-      const out = extractSymbolsAndCalls(
-        src,
-        "unknown" as unknown as Lang,
-        ".xyz",
-        "data.xyz",
-      );
-      expect(out.symbols.some((s) => s.name === "<module>")).toBe(true);
-      expect(out.rawCalls).toEqual([]);
+  describe("Destructuring & Call Provenance", () => {
+    it("extracts only left binding from object_assignment_pattern, ignoring default value expression", () => {
+      const src = `
+export const { port = getDefaultPort(), host: serverHost = "localhost" } = config;
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/config.ts");
+      const names = out.symbols.map((s) => s.name);
+      expect(names).toContain("port");
+      expect(names).toContain("serverHost");
+      expect(names).not.toContain("getDefaultPort");
+      expect(names).not.toContain("config");
+    });
+
+    it("does not attach bare import provenance to member method calls", () => {
+      const src = `
+import { run } from "./runner";
+export function main(obj: any): void {
+  obj.run();
+  run();
+}
+`;
+      const out = extractSymbolsAndCalls(src, Lang.TypeScript, ".ts", "src/app.ts");
+      const runCalls = out.rawCalls.filter((c) => c.kind === "call" && c.calleeName === "run");
+      expect(runCalls).toHaveLength(2);
+
+      const memberCall = runCalls.find((c) => c.callSite.line === 4);
+      expect(memberCall).toBeDefined();
+      expect(memberCall?.sourceModule).toBeUndefined();
+      expect(memberCall?.importedName).toBeUndefined();
+
+      const bareCall = runCalls.find((c) => c.callSite.line === 5);
+      expect(bareCall).toBeDefined();
+      expect(bareCall?.sourceModule).toBe("./runner");
+      expect(bareCall?.importedName).toBe("run");
     });
   });
 });

--- a/tests/unit/index-profile-indexer.test.ts
+++ b/tests/unit/index-profile-indexer.test.ts
@@ -384,4 +384,21 @@ describe("code-index effective profile compatibility", () => {
       indexer.hashContent("   \n\t\n"),
     );
   });
+
+  it("invokes exactly one full graph rebuild on a file update without double rebuilding", async () => {
+    const indexer = await loadIndexer();
+    const { legacyIndexProfile } = await import("../../src/services/index-profile.js");
+    const { rebuildGraph } = await import("../../src/services/code-graph.js");
+    const project = await createProject("notes.txt", "new changed content");
+    collectionInfo = { pointsCount: 1, status: "green" };
+    storedProfile = legacyIndexProfile("code");
+    storedHashes = new Map([["notes.txt", indexer.hashContent("old source")]]);
+
+    vi.mocked(rebuildGraph).mockClear();
+    const result = await indexer.updateProjectIndex(project);
+
+    expect(result.updated).toBe(1);
+    expect(vi.mocked(rebuildGraph)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(rebuildGraph)).toHaveBeenCalledWith(project, { skipSymbolGraph: false });
+  });
 });

--- a/tests/unit/symbol-graph-contract.test.ts
+++ b/tests/unit/symbol-graph-contract.test.ts
@@ -75,24 +75,28 @@ vi.mock("../../src/services/qdrant.js", async (importOriginal) => {
   };
 });
 
-import { projectIdFromPath } from "../../src/config.js";
+import { projectIdFromPath, symgraphFileCollectionName } from "../../src/config.js";
 import { rebuildGraph } from "../../src/services/code-graph.js";
 import { getImpactRadius, getSymbolContext } from "../../src/services/graph-impact.js";
 import { getClient } from "../../src/services/qdrant.js";
 import { getSymbolGraphCache, resetSymbolGraphCacheRegistry } from "../../src/services/symbol-graph-cache.js";
 import { applyRemoval, updateChangedFilesSymbolGraph } from "../../src/services/symbol-graph-incremental.js";
 import {
+  cleanStaleGenerations,
+  coordinateProject,
   deleteFilePayload,
   listStoredGenerations,
   loadFilePayload,
   loadNameShard,
   loadReverseShard,
   loadSymbolGraphMeta,
+  registerStagingGeneration,
   resetSymbolGraphCollectionCache,
   reverseShardKeyForCallee,
   StorageReadError,
   saveReverseShard,
   saveSymbolGraphMeta,
+  unregisterStagingGeneration,
 } from "../../src/services/symbol-graph-store.js";
 import { handleGraphTool } from "../../src/tools/graph-tools.js";
 import type { SymbolGraphMeta, SymbolRef } from "../../src/types.js";
@@ -581,5 +585,122 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     expect(gen3).not.toBe(gen2);
     // Superseded gen2 has been safely retired
     expect(await listStoredGenerations(projId)).toEqual([gen3]);
+  });
+
+  it("protects newly staged build from being swept by concurrent startup cleanup", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "file1.ts"), `export function alpha() { return 1; }`);
+
+    // 1. Initial build -> gen1
+    const { cache: cache1 } = await runPipeline();
+    const gen1 = cache1.meta.generation;
+    expect(gen1).toBeDefined();
+
+    // 2. Simulate new build staging gen2
+    const stagedGen = "staged-gen-xyz";
+    registerStagingGeneration(projId, stagedGen);
+    // Write points for stagedGen into file collection
+    const qdrant = getClient();
+    const collName = symgraphFileCollectionName(projId);
+    await qdrant.createCollection(collName);
+    await qdrant.upsert(collName, {
+      points: [
+        {
+          id: "point-staged-1",
+          vector: [0],
+          payload: { projectId: projId, generation: stagedGen, file: "src/file1.ts" },
+        },
+      ],
+    });
+
+    // 3. Concurrent startup cleanup runs for projId while gen1 is still active
+    // cleanStaleGenerations should respect stagedGen for projId
+    await cleanStaleGenerations(projId, gen1!);
+
+    // Verify point for stagedGen was NOT deleted
+    const stored = await qdrant.retrieve(collName, { ids: ["point-staged-1"] });
+    expect(stored.length).toBe(1);
+    expect(stored[0]?.payload?.generation).toBe(stagedGen);
+
+    // Also verify coordinateProject queues operations sequentially
+    let cleanupRan = false;
+    let buildCompleted = false;
+
+    // Simulate build holding coordinateProject lock
+    const buildCoord = coordinateProject(projId, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      buildCompleted = true;
+    });
+
+    // Startup cleanup tries to run concurrently for the same project
+    const startupCoord = coordinateProject(projId, async () => {
+      // Must only run after build completes
+      expect(buildCompleted).toBe(true);
+      cleanupRan = true;
+    });
+
+    await Promise.all([buildCoord, startupCoord]);
+    expect(cleanupRan).toBe(true);
+
+    unregisterStagingGeneration(projId, stagedGen);
+  });
+
+  it("preserves old generation in storage while active reader holds cache during activation and rebuild", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "first.ts"), `export function first() { return 1; }`);
+    fs.writeFileSync(path.join(tmpDir, "src", "second.ts"), `export function second() { return 2; }`);
+
+    // 1. Initial build -> gen1
+    const { cache: oldCache } = await runPipeline();
+    const gen1 = oldCache.meta.generation;
+    expect(gen1).toBeDefined();
+
+    // Ensure LRU does NOT contain second.ts initially
+    oldCache.fileDataLru.delete("src/second.ts");
+
+    // 2. Reader acquires lease on oldCache
+    const releaseReader = oldCache.acquireReader();
+
+    // 3. New build occurs and activates gen2 while reader is still active
+    fs.writeFileSync(path.join(tmpDir, "src", "first.ts"), `export function first() { return 100; }`);
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "second.ts"),
+      `export function second() { return 200; }\nexport function secondGen2Extra() { return 201; }`,
+    );
+    await rebuildGraph(tmpDir);
+
+    const meta2 = await loadSymbolGraphMeta(projId);
+    const gen2 = meta2?.generation;
+    expect(gen2).toBeDefined();
+    expect(gen2).not.toBe(gen1);
+
+    // Because oldCache has an active reader lease for gen1,
+    // gen1 points were NOT deleted by cleanStaleGenerations during rebuildGraph!
+    // Reader now lazily loads second.ts from storage via oldCache:
+    const lazyPayload = await oldCache.getFilePayload("src/second.ts");
+    expect(lazyPayload).not.toBeNull();
+    // oldCache still sees gen1 content (does not contain secondGen2Extra from gen2)
+    expect(lazyPayload?.symbols.some((s) => s.name === "second")).toBe(true);
+    expect(lazyPayload?.symbols.some((s) => s.name === "secondGen2Extra")).toBe(false);
+
+    // Verify a fresh cache on gen2 sees gen2 content
+    const newCache = await getSymbolGraphCache(projId);
+    const newPayload = await newCache?.getFilePayload("src/second.ts");
+    expect(newPayload?.symbols.some((s) => s.name === "secondGen2Extra")).toBe(true);
+
+    // Generations in storage still include gen1 because lease was held
+    let storedGens = await listStoredGenerations(projId);
+    expect(storedGens).toContain(gen1);
+    expect(storedGens).toContain(gen2);
+
+    // 4. Reader finishes and releases the lease
+    releaseReader();
+
+    // Give deferred deletion a microtick
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // After release, deferred cleanup removes gen1 from storage
+    storedGens = await listStoredGenerations(projId);
+    expect(storedGens).toEqual([gen2]);
   });
 });

--- a/tests/unit/symbol-graph-contract.test.ts
+++ b/tests/unit/symbol-graph-contract.test.ts
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// In-memory Qdrant point store mock
+interface StoredPoint {
+  id: string;
+  vector: number[];
+  payload: Record<string, unknown>;
+}
+const store = new Map<string, Map<string, StoredPoint>>();
+
+vi.mock("../../src/services/qdrant.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/services/qdrant.js")>();
+  return {
+    ...actual,
+    getClient: () => ({
+      getCollections: async () => ({
+        collections: Array.from(store.keys()).map((name) => ({ name })),
+      }),
+      createCollection: async (name: string) => {
+        if (!store.has(name)) store.set(name, new Map());
+      },
+      upsert: async (name: string, body: { points: StoredPoint[] }) => {
+        const coll = store.get(name) ?? new Map<string, StoredPoint>();
+        for (const p of body.points) coll.set(String(p.id), p);
+        store.set(name, coll);
+      },
+      retrieve: async (name: string, opts: { ids: Array<string | number> }) => {
+        const coll = store.get(name) ?? new Map<string, StoredPoint>();
+        return opts.ids.map((id) => coll.get(String(id))).filter((p): p is StoredPoint => p !== undefined);
+      },
+      delete: async (name: string, opts: { points: Array<string | number> }) => {
+        const coll = store.get(name);
+        if (coll) for (const id of opts.points) coll.delete(String(id));
+      },
+    }),
+    saveGraphData: async () => {},
+    loadGraphData: async () => null,
+    deleteGraphData: async () => {},
+    describeQdrantError: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  };
+});
+
+import { projectIdFromPath } from "../../src/config.js";
+import { rebuildGraph } from "../../src/services/code-graph.js";
+import { getImpactRadius, getSymbolContext } from "../../src/services/graph-impact.js";
+import { getSymbolGraphCache, resetSymbolGraphCacheRegistry } from "../../src/services/symbol-graph-cache.js";
+import {
+  resetSymbolGraphCollectionCache,
+  StorageReadError,
+  saveSymbolGraphMeta,
+} from "../../src/services/symbol-graph-store.js";
+
+describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
+  let tmpDir: string;
+  let projId: string;
+
+  beforeEach(() => {
+    store.clear();
+    resetSymbolGraphCollectionCache();
+    resetSymbolGraphCacheRegistry();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-contract-"));
+    projId = projectIdFromPath(tmpDir);
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup error
+    }
+  });
+
+  /** Run the complete pipeline on the current fixture directory on disk */
+  async function runPipeline() {
+    const fileGraph = await rebuildGraph(tmpDir);
+    const cache = await getSymbolGraphCache(projId);
+    if (!cache) throw new Error("Failed to load symbol graph cache");
+    return { fileGraph, cache };
+  }
+
+  it("extracts and disambiguates destructuring variable declarations", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "config.ts"),
+      `
+      const sourceObj = { host: "localhost", port: 8080, flags: ["a", "b"] };
+      export const { host, port: serverPort, flags: [firstFlag] } = sourceObj;
+      export const simpleVal = 42;
+      `,
+    );
+
+    const { cache } = await runPipeline();
+    const payload = await cache.getFilePayload("src/config.ts");
+    expect(payload).toBeDefined();
+    const syms = payload?.symbols ?? [];
+    const names = syms.map((s) => s.name);
+
+    expect(names).toContain("host");
+    expect(names).toContain("serverPort");
+    expect(names).toContain("firstFlag");
+    expect(names).toContain("simpleVal");
+    // Ensure the whole destructuring pattern was not extracted as a symbol name
+    expect(names.some((n) => n.includes("{") || n.includes("}") || n.includes(":"))).toBe(false);
+  });
+
+  it("resolves multi-module duplicate symbol names preserving module identity", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "serviceA.ts"),
+      `export function processData(x: number): number { return x * 2; }`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "serviceB.ts"),
+      `export function processData(x: number): number { return x + 10; }`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "app.ts"),
+      `
+      import { processData } from "./serviceA";
+      export function main(): void {
+        processData(5);
+      }
+      `,
+    );
+
+    const { cache } = await runPipeline();
+
+    // Querying processData in serviceA must only report app.ts
+    const impactA = await getImpactRadius(cache, "processData", 2, { file: "src/serviceA.ts" });
+    expect(impactA.status).toBe("ok");
+    expect(impactA.totalFiles).toBe(1);
+    expect(impactA.filesByDepth.get(1)).toEqual(["src/app.ts"]);
+
+    // Querying processData in serviceB must report 0 dependents
+    const impactB = await getImpactRadius(cache, "processData", 2, { file: "src/serviceB.ts" });
+    expect(impactB.status).toBe("ok");
+    expect(impactB.totalFiles).toBe(0);
+  });
+
+  it("resolves default exports correctly", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "logger.ts"),
+      `
+      export default class Logger {
+        log(msg: string): void { console.log(msg); }
+      }
+      `,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "consumer.ts"),
+      `
+      import Logger from "./logger";
+      export function run(): void {
+        const l = new Logger();
+      }
+      `,
+    );
+
+    const { cache } = await runPipeline();
+    const impact = await getImpactRadius(cache, "Logger");
+    expect(impact.status).toBe("ok");
+    expect(impact.totalFiles).toBe(1);
+    expect(impact.filesByDepth.get(1)).toEqual(["src/consumer.ts"]);
+  });
+
+  it("resolves multi-level barrel files and re-exports transitively", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "engine.ts"),
+      `export function startEngine(): string { return "vroom"; }`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "barrel1.ts"),
+      `export { startEngine } from "./engine";`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "barrel2.ts"),
+      `export * from "./barrel1";`,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "car.ts"),
+      `
+      import { startEngine } from "./barrel2";
+      export function drive(): void {
+        startEngine();
+      }
+      `,
+    );
+
+    const { cache } = await runPipeline();
+    const impact = await getImpactRadius(cache, "startEngine");
+    expect(impact.status).toBe("ok");
+    expect(impact.totalFiles).toBeGreaterThanOrEqual(1);
+    expect(impact.filesByDepth.get(1)).toContain("src/car.ts");
+    expect(impact.filesByDepth.get(1)).toContain("src/barrel1.ts");
+  });
+
+  it("traverses same-file calls and aggregates blast radius", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "math.ts"),
+      `
+      export function internalAdd(a: number, b: number): number { return a + b; }
+      export function publicSum(arr: number[]): number {
+        return internalAdd(arr[0] || 0, arr[1] || 0);
+      }
+      `,
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "calculator.ts"),
+      `
+      import { publicSum } from "./math";
+      export function calculate(): number {
+        return publicSum([1, 2]);
+      }
+      `,
+    );
+
+    const { cache } = await runPipeline();
+    const impact = await getImpactRadius(cache, "internalAdd", 3);
+    expect(impact.status).toBe("ok");
+    expect(impact.totalFiles).toBe(2);
+    // Hop 1: same file math.ts (via publicSum)
+    expect(impact.filesByDepth.get(1)).toEqual(["src/math.ts"]);
+    // Hop 2: calculator.ts (via calculate calling publicSum)
+    expect(impact.filesByDepth.get(2)).toEqual(["src/calculator.ts"]);
+  });
+
+  it("provides 360 context including caller kind and same-file callers", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "src", "target.ts"),
+      `
+      export function execute(): void {}
+      export function wrapper(): void {
+        execute();
+      }
+      `,
+    );
+
+    const { cache } = await runPipeline();
+    const ctx = await getSymbolContext(cache, "execute");
+    expect(ctx).toHaveLength(1);
+    expect(ctx[0].symbol.name).toBe("execute");
+    expect(ctx[0].callers).toHaveLength(1);
+    expect(ctx[0].callers[0].file).toBe("src/target.ts");
+    expect(ctx[0].callers[0].kind).toBe("call");
+  });
+
+  it("handles schema v1 graphs safely with graph_upgrade_required", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "dummy.ts"), `export function dummy() {}`);
+
+    const { cache } = await runPipeline();
+    cache.meta.schemaVersion = 1;
+    await saveSymbolGraphMeta(projId, cache.meta);
+
+    const impact = await getImpactRadius(cache, "dummy");
+    expect(impact.status).toBe("graph_upgrade_required");
+    expect(impact.totalFiles).toBe(0);
+  });
+
+  it("propagates storage read failures as storage_error (fail-closed)", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "dummy.ts"), `export function dummy() {}`);
+
+    const { cache } = await runPipeline();
+
+    // Mock loadReverseShard to throw StorageReadError
+    vi.spyOn(cache, "getReverseSymbolIndex").mockRejectedValueOnce(
+      new StorageReadError("Mock Qdrant shard connection failure"),
+    );
+
+    const impact = await getImpactRadius(cache, "dummy");
+    expect(impact.status).toBe("storage_error");
+    expect(impact.message).toContain("Mock Qdrant shard connection failure");
+  });
+});

--- a/tests/unit/symbol-graph-contract.test.ts
+++ b/tests/unit/symbol-graph-contract.test.ts
@@ -57,6 +57,7 @@ import {
   saveSymbolGraphMeta,
 } from "../../src/services/symbol-graph-store.js";
 import { handleGraphTool } from "../../src/tools/graph-tools.js";
+import type { SymbolGraphMeta } from "../../src/types.js";
 
 describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
   let tmpDir: string;

--- a/tests/unit/symbol-graph-contract.test.ts
+++ b/tests/unit/symbol-graph-contract.test.ts
@@ -53,17 +53,21 @@ import { rebuildGraph } from "../../src/services/code-graph.js";
 import { getImpactRadius, getSymbolContext } from "../../src/services/graph-impact.js";
 import { getClient } from "../../src/services/qdrant.js";
 import { getSymbolGraphCache, resetSymbolGraphCacheRegistry } from "../../src/services/symbol-graph-cache.js";
-import { updateChangedFilesSymbolGraph } from "../../src/services/symbol-graph-incremental.js";
+import { applyRemoval, updateChangedFilesSymbolGraph } from "../../src/services/symbol-graph-incremental.js";
 import {
   deleteFilePayload,
   loadFilePayload,
+  loadNameShard,
+  loadReverseShard,
   loadSymbolGraphMeta,
   resetSymbolGraphCollectionCache,
+  reverseShardKeyForCallee,
   StorageReadError,
+  saveReverseShard,
   saveSymbolGraphMeta,
 } from "../../src/services/symbol-graph-store.js";
 import { handleGraphTool } from "../../src/tools/graph-tools.js";
-import type { SymbolGraphMeta } from "../../src/types.js";
+import type { SymbolGraphMeta, SymbolRef } from "../../src/types.js";
 
 describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
   let tmpDir: string;
@@ -316,25 +320,193 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
   it("throws StorageReadError from loadFilePayload and deleteFilePayload on retrieval/deletion errors", async () => {
     fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
     fs.writeFileSync(path.join(tmpDir, "src", "dummy.ts"), `export function dummy() {}`);
-    const { fileGraph } = await runPipeline();
+    const { cache } = await runPipeline();
 
     const qdrant = getClient();
     vi.spyOn(qdrant, "retrieve").mockRejectedValueOnce(new Error("Network timeout"));
-    await expect(loadFilePayload(projId, "src/dummy.ts")).rejects.toThrow(StorageReadError);
+    await expect(loadFilePayload(projId, "src/dummy.ts", cache.meta.generation)).rejects.toThrow(StorageReadError);
 
     vi.spyOn(qdrant, "delete").mockRejectedValueOnce(new Error("Disk IO error"));
-    await expect(deleteFilePayload(projId, "src/dummy.ts")).rejects.toThrow(StorageReadError);
+    await expect(deleteFilePayload(projId, "src/dummy.ts", cache.meta.generation)).rejects.toThrow(StorageReadError);
+  });
 
-    // Incremental update propagates storage failures on file payload retrieval
-    const meta = await loadSymbolGraphMeta(projId);
-    expect(meta).toBeDefined();
-    if (!meta) throw new Error("Expected meta to be defined");
-    vi.spyOn(qdrant, "retrieve")
-      .mockResolvedValueOnce([{ id: "meta", vector: [0], payload: { meta } }])
-      .mockRejectedValueOnce(new Error("Qdrant payload load error"));
+  it("rejects schema-v1 incremental updates before any mutation and returns fullRebuildRequired", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "dummy.ts"), `export function dummy() {}`);
+    const { fileGraph, cache } = await runPipeline();
+    cache.meta.schemaVersion = 1;
+    await saveSymbolGraphMeta(projId, cache.meta);
 
-    await expect(
-      updateChangedFilesSymbolGraph(projId, tmpDir, fileGraph, ["src/dummy.ts"], []),
-    ).rejects.toThrow(StorageReadError);
+    // Snapshot current store points
+    const storeMap = new Map<string, string>();
+    for (const [collName, coll] of store.entries()) {
+      for (const [ptId, pt] of coll.entries()) {
+        storeMap.set(`${collName}::${ptId}`, JSON.stringify(pt));
+      }
+    }
+
+    const result = await updateChangedFilesSymbolGraph(
+      projId,
+      tmpDir,
+      fileGraph,
+      ["src/dummy.ts"],
+      [],
+    );
+
+    expect(result.fullRebuildRequired).toBe(true);
+    expect(result.filesChanged).toBe(0);
+    expect(result.filesRemoved).toBe(0);
+
+    // Verify no points were mutated or partially converted
+    for (const [collName, coll] of store.entries()) {
+      for (const [ptId, pt] of coll.entries()) {
+        expect(storeMap.get(`${collName}::${ptId}`)).toBe(JSON.stringify(pt));
+      }
+    }
+  });
+
+  it("returns fullRebuildRequired for changed or removed files before mutating storage", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "a.ts"), `export function foo() {}`);
+    fs.writeFileSync(path.join(tmpDir, "src", "b.ts"), `import { foo } from "./a"; export function bar() { foo(); }`);
+    const { fileGraph } = await runPipeline();
+
+    const changeResult = await updateChangedFilesSymbolGraph(projId, tmpDir, fileGraph, ["src/a.ts"], []);
+    expect(changeResult.fullRebuildRequired).toBe(true);
+
+    const removeResult = await updateChangedFilesSymbolGraph(projId, tmpDir, fileGraph, [], ["src/b.ts"]);
+    expect(removeResult.fullRebuildRequired).toBe(true);
+  });
+
+  it("produces identical impact results on adding, changing, and removing cross-file references as a clean build", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "callee.ts"), `export function target() { return 1; }`);
+    fs.writeFileSync(path.join(tmpDir, "src", "caller.ts"), `import { target } from "./callee"; export function use() { target(); }`);
+
+    // 1. Initial build: caller -> callee
+    const { cache: cache1 } = await runPipeline();
+    const impact1 = await getImpactRadius(cache1, "target", 2, { file: "src/callee.ts" });
+    expect(impact1.status).toBe("ok");
+    expect(impact1.totalFiles).toBe(1);
+    expect(impact1.filesByDepth.get(1)).toEqual(["src/caller.ts"]);
+
+    // 2. Add another caller: caller2 -> callee
+    fs.writeFileSync(path.join(tmpDir, "src", "caller2.ts"), `import { target } from "./callee"; export function use2() { target(); }`);
+    const { cache: cache2 } = await runPipeline();
+    const impact2 = await getImpactRadius(cache2, "target", 2, { file: "src/callee.ts" });
+    expect(impact2.status).toBe("ok");
+    expect(impact2.totalFiles).toBe(2);
+    expect(impact2.filesByDepth.get(1)).toEqual(expect.arrayContaining(["src/caller.ts", "src/caller2.ts"]));
+
+    // 3. Change caller2 to call something else
+    fs.writeFileSync(path.join(tmpDir, "src", "caller2.ts"), `export function use2() { return 2; }`);
+    const { cache: cache3 } = await runPipeline();
+    const impact3 = await getImpactRadius(cache3, "target", 2, { file: "src/callee.ts" });
+    expect(impact3.status).toBe("ok");
+    expect(impact3.totalFiles).toBe(1);
+    expect(impact3.filesByDepth.get(1)).toEqual(["src/caller.ts"]);
+
+    // 4. Remove caller.ts
+    fs.unlinkSync(path.join(tmpDir, "src", "caller.ts"));
+    const { cache: cache4 } = await runPipeline();
+    const impact4 = await getImpactRadius(cache4, "target", 2, { file: "src/callee.ts" });
+    expect(impact4.status).toBe("ok");
+    expect(impact4.totalFiles).toBe(0);
+    expect(impact4.filesByDepth.get(1)).toBeUndefined();
+  });
+
+  it("uses canonical reverse-shard keys so incremental edge removal completely clears reverse entries", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "callee.ts"), `export function target() {}`);
+    fs.writeFileSync(path.join(tmpDir, "src", "caller.ts"), `import { target } from "./callee"; export function run() { target(); }`);
+
+    const { cache } = await runPipeline();
+    const calleePayload = await loadFilePayload(projId, "src/callee.ts", cache.meta.generation);
+    const callerPayload = await loadFilePayload(projId, "src/caller.ts", cache.meta.generation);
+    const targetSym = calleePayload?.symbols.find((s) => s.name === "target");
+    const runSym = callerPayload?.symbols.find((s) => s.name === "run");
+    expect(targetSym).toBeDefined();
+    expect(runSym).toBeDefined();
+    if (!targetSym || !runSym || !callerPayload) throw new Error("Expected symbols and payload");
+
+    const calleeId = targetSym.id;
+    const bucket = reverseShardKeyForCallee(calleeId);
+
+    // Verify reverse shard after full build
+    const shardBefore = await loadReverseShard(projId, bucket, cache.meta.generation);
+    expect(shardBefore).toBeDefined();
+    expect(shardBefore?.[calleeId]).toEqual(expect.arrayContaining([runSym.id]));
+
+    // Use applyRemoval on caller payload with same canonical reverseShardKeyForCallee
+    const dirtyReverseShards = new Map<number, Record<string, string[]>>();
+    const dirtyNameShards = new Map<string, Record<string, SymbolRef[]>>();
+    async function getNameShard(key: string) {
+      let shard = dirtyNameShards.get(key);
+      if (!shard) {
+        shard = (await loadNameShard(projId, key, cache.meta.generation)) ?? {};
+        dirtyNameShards.set(key, shard);
+      }
+      return shard;
+    }
+    async function getReverseShard(b: number) {
+      let shard = dirtyReverseShards.get(b);
+      if (!shard) {
+        shard = (await loadReverseShard(projId, b, cache.meta.generation)) ?? {};
+        dirtyReverseShards.set(b, shard);
+      }
+      return shard;
+    }
+
+    await applyRemoval(projId, callerPayload, getNameShard, getReverseShard);
+    for (const [b, shard] of dirtyReverseShards) {
+      await saveReverseShard(projId, b, shard, cache.meta.generation);
+    }
+
+    // Verify reverse shard has exact entry removed
+    const shardAfter = await loadReverseShard(projId, bucket, cache.meta.generation);
+    expect(shardAfter?.[calleeId]).toBeUndefined();
+  });
+
+  it("keeps old generation completely readable if staged build fails mid-way (atomic activation)", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "initial.ts"), `export function alpha() { return 1; }`);
+
+    // 1. Full build succeeds -> Generation 1
+    const { cache: cache1 } = await runPipeline();
+    const meta1 = cache1.meta;
+    expect(meta1.generation).toBeDefined();
+
+    const payload1 = await loadFilePayload(projId, "src/initial.ts", meta1.generation);
+    expect(payload1).not.toBeNull();
+    expect(payload1?.symbols.some((s) => s.name === "alpha")).toBe(true);
+
+    // 2. Introduce new file for build 2, but inject failure during saveReverseShard
+    fs.writeFileSync(path.join(tmpDir, "src", "initial.ts"), `export function alpha() { return 2; }\nexport function beta() { return alpha(); }`);
+
+    const qdrant = getClient();
+    const originalUpsert = qdrant.upsert.bind(qdrant);
+    let injectedFail = true;
+    vi.spyOn(qdrant, "upsert").mockImplementation(async (collName, body) => {
+      // If writing to index collection on new generation, inject failure
+      if (injectedFail && collName.includes("symgraph_index")) {
+        throw new Error("Mid-build disk crash on shard write");
+      }
+      return originalUpsert(collName, body);
+    });
+
+    await rebuildGraph(tmpDir);
+    injectedFail = false;
+
+    // 3. Readers check: meta must still point to generation 1
+    const currentMeta = await loadSymbolGraphMeta(projId);
+    expect(currentMeta?.generation).toBe(meta1.generation);
+    expect(currentMeta?.symbolCount).toBe(meta1.symbolCount);
+
+    // Reading payloads or shards through store or cache resolves to Generation 1 (complete old generation)
+    const readPayload = await loadFilePayload(projId, "src/initial.ts");
+    expect(readPayload).not.toBeNull();
+    expect(readPayload?.symbols.some((s) => s.name === "alpha")).toBe(true);
+    // Should NOT have beta from failed generation
+    expect(readPayload?.symbols.some((s) => s.name === "beta")).toBe(false);
   });
 });

--- a/tests/unit/symbol-graph-contract.test.ts
+++ b/tests/unit/symbol-graph-contract.test.ts
@@ -30,9 +30,36 @@ const clientInstance = {
     const coll = store.get(name) ?? new Map<string, StoredPoint>();
     return opts.ids.map((id) => coll.get(String(id))).filter((p): p is StoredPoint => p !== undefined);
   },
-  delete: async (name: string, opts: { points: Array<string | number> }) => {
+  delete: async (name: string, opts: { points?: Array<string | number>; filter?: { must?: Array<{ key?: string; match?: { value?: string; except?: string[] } }> } }) => {
     const coll = store.get(name);
-    if (coll) for (const id of opts.points) coll.delete(String(id));
+    if (!coll) return;
+    if (opts.points) {
+      for (const id of opts.points) coll.delete(String(id));
+    }
+    if (opts.filter?.must) {
+      for (const cond of opts.filter.must) {
+        if (cond.key === "generation" && cond.match) {
+          if (cond.match.value !== undefined) {
+            for (const [id, pt] of Array.from(coll.entries())) {
+              if (pt.payload?.generation === cond.match.value) coll.delete(id);
+            }
+          } else if (cond.match.except !== undefined) {
+            for (const [id, pt] of Array.from(coll.entries())) {
+              if (pt.payload?.generation && !cond.match.except.includes(pt.payload.generation as string)) {
+                coll.delete(id);
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  scroll: async (name: string) => {
+    const coll = store.get(name) ?? new Map<string, StoredPoint>();
+    return {
+      points: Array.from(coll.values()),
+      next_page_offset: null,
+    };
   },
 };
 
@@ -56,6 +83,7 @@ import { getSymbolGraphCache, resetSymbolGraphCacheRegistry } from "../../src/se
 import { applyRemoval, updateChangedFilesSymbolGraph } from "../../src/services/symbol-graph-incremental.js";
 import {
   deleteFilePayload,
+  listStoredGenerations,
   loadFilePayload,
   loadNameShard,
   loadReverseShard,
@@ -270,22 +298,25 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     expect(toolOutput).toContain("← src/target.ts:4 (call)");
   });
 
-  it("handles schema v1 graphs safely with graph_upgrade_required", async () => {
+  it("supports schema v1 graphs safely without requiring rebuild before impact queries are usable", async () => {
     fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
     fs.writeFileSync(path.join(tmpDir, "src", "dummy.ts"), `export function dummy() {}`);
+    fs.writeFileSync(path.join(tmpDir, "src", "caller.ts"), `import { dummy } from "./dummy.js";\nexport function run() { dummy(); }`);
 
     const { cache } = await runPipeline();
     cache.meta.schemaVersion = 1;
     await saveSymbolGraphMeta(projId, cache.meta);
 
     const impact = await getImpactRadius(cache, "dummy");
-    expect(impact.status).toBe("graph_upgrade_required");
-    expect(impact.totalFiles).toBe(0);
+    expect(impact.status).toBe("ok");
+    expect(impact.totalFiles).toBe(1);
+    expect(impact.filesByDepth.get(1)).toEqual(["src/caller.ts"]);
   });
 
-  it("normalizes metadata without schemaVersion to 1 and triggers graph_upgrade_required", async () => {
+  it("normalizes metadata without schemaVersion to 1 and keeps impact queries usable", async () => {
     fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
     fs.writeFileSync(path.join(tmpDir, "src", "dummy.ts"), `export function dummy() {}`);
+    fs.writeFileSync(path.join(tmpDir, "src", "caller.ts"), `import { dummy } from "./dummy.js";\nexport function run() { dummy(); }`);
 
     const { cache } = await runPipeline();
     const { schemaVersion: _, ...legacyMeta } = cache.meta;
@@ -298,7 +329,9 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
 
     cache.meta = loaded;
     const impact = await getImpactRadius(cache, "dummy");
-    expect(impact.status).toBe("graph_upgrade_required");
+    expect(impact.status).toBe("ok");
+    expect(impact.totalFiles).toBe(1);
+    expect(impact.filesByDepth.get(1)).toEqual(["src/caller.ts"]);
   });
 
   it("propagates storage read failures as storage_error (fail-closed)", async () => {
@@ -508,5 +541,40 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     expect(readPayload?.symbols.some((s) => s.name === "alpha")).toBe(true);
     // Should NOT have beta from failed generation
     expect(readPayload?.symbols.some((s) => s.name === "beta")).toBe(false);
+
+    // Points from the failed staged build are cleaned up immediately
+    const storedGens = await listStoredGenerations(projId);
+    expect(storedGens).toEqual([meta1.generation]);
+  });
+
+  it("bounds storage across repeated successful rebuilds by retiring superseded generations", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "sample.ts"), `export function one() { return 1; }`);
+
+    // Build 1
+    const { cache: cache1 } = await runPipeline();
+    const gen1 = cache1.meta.generation;
+    expect(gen1).toBeDefined();
+    expect(await listStoredGenerations(projId)).toEqual([gen1]);
+
+    // Build 2
+    fs.writeFileSync(path.join(tmpDir, "src", "sample.ts"), `export function two() { return 2; }`);
+    await rebuildGraph(tmpDir);
+    const meta2 = await loadSymbolGraphMeta(projId);
+    const gen2 = meta2?.generation;
+    expect(gen2).toBeDefined();
+    expect(gen2).not.toBe(gen1);
+    // Superseded gen1 has been safely retired
+    expect(await listStoredGenerations(projId)).toEqual([gen2]);
+
+    // Build 3
+    fs.writeFileSync(path.join(tmpDir, "src", "sample.ts"), `export function three() { return 3; }`);
+    await rebuildGraph(tmpDir);
+    const meta3 = await loadSymbolGraphMeta(projId);
+    const gen3 = meta3?.generation;
+    expect(gen3).toBeDefined();
+    expect(gen3).not.toBe(gen2);
+    // Superseded gen2 has been safely retired
+    expect(await listStoredGenerations(projId)).toEqual([gen3]);
   });
 });

--- a/tests/unit/symbol-graph-contract.test.ts
+++ b/tests/unit/symbol-graph-contract.test.ts
@@ -14,31 +14,33 @@ interface StoredPoint {
 }
 const store = new Map<string, Map<string, StoredPoint>>();
 
+const clientInstance = {
+  getCollections: async () => ({
+    collections: Array.from(store.keys()).map((name) => ({ name })),
+  }),
+  createCollection: async (name: string) => {
+    if (!store.has(name)) store.set(name, new Map());
+  },
+  upsert: async (name: string, body: { points: StoredPoint[] }) => {
+    const coll = store.get(name) ?? new Map<string, StoredPoint>();
+    for (const p of body.points) coll.set(String(p.id), p);
+    store.set(name, coll);
+  },
+  retrieve: async (name: string, opts: { ids: Array<string | number> }) => {
+    const coll = store.get(name) ?? new Map<string, StoredPoint>();
+    return opts.ids.map((id) => coll.get(String(id))).filter((p): p is StoredPoint => p !== undefined);
+  },
+  delete: async (name: string, opts: { points: Array<string | number> }) => {
+    const coll = store.get(name);
+    if (coll) for (const id of opts.points) coll.delete(String(id));
+  },
+};
+
 vi.mock("../../src/services/qdrant.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/services/qdrant.js")>();
   return {
     ...actual,
-    getClient: () => ({
-      getCollections: async () => ({
-        collections: Array.from(store.keys()).map((name) => ({ name })),
-      }),
-      createCollection: async (name: string) => {
-        if (!store.has(name)) store.set(name, new Map());
-      },
-      upsert: async (name: string, body: { points: StoredPoint[] }) => {
-        const coll = store.get(name) ?? new Map<string, StoredPoint>();
-        for (const p of body.points) coll.set(String(p.id), p);
-        store.set(name, coll);
-      },
-      retrieve: async (name: string, opts: { ids: Array<string | number> }) => {
-        const coll = store.get(name) ?? new Map<string, StoredPoint>();
-        return opts.ids.map((id) => coll.get(String(id))).filter((p): p is StoredPoint => p !== undefined);
-      },
-      delete: async (name: string, opts: { points: Array<string | number> }) => {
-        const coll = store.get(name);
-        if (coll) for (const id of opts.points) coll.delete(String(id));
-      },
-    }),
+    getClient: () => clientInstance,
     saveGraphData: async () => {},
     loadGraphData: async () => null,
     deleteGraphData: async () => {},
@@ -49,8 +51,12 @@ vi.mock("../../src/services/qdrant.js", async (importOriginal) => {
 import { projectIdFromPath } from "../../src/config.js";
 import { rebuildGraph } from "../../src/services/code-graph.js";
 import { getImpactRadius, getSymbolContext } from "../../src/services/graph-impact.js";
+import { getClient } from "../../src/services/qdrant.js";
 import { getSymbolGraphCache, resetSymbolGraphCacheRegistry } from "../../src/services/symbol-graph-cache.js";
+import { updateChangedFilesSymbolGraph } from "../../src/services/symbol-graph-incremental.js";
 import {
+  deleteFilePayload,
+  loadFilePayload,
   loadSymbolGraphMeta,
   resetSymbolGraphCollectionCache,
   StorageReadError,
@@ -305,5 +311,30 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     const impact = await getImpactRadius(cache, "dummy");
     expect(impact.status).toBe("storage_error");
     expect(impact.message).toContain("Mock Qdrant shard connection failure");
+  });
+
+  it("throws StorageReadError from loadFilePayload and deleteFilePayload on retrieval/deletion errors", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "dummy.ts"), `export function dummy() {}`);
+    const { fileGraph } = await runPipeline();
+
+    const qdrant = getClient();
+    vi.spyOn(qdrant, "retrieve").mockRejectedValueOnce(new Error("Network timeout"));
+    await expect(loadFilePayload(projId, "src/dummy.ts")).rejects.toThrow(StorageReadError);
+
+    vi.spyOn(qdrant, "delete").mockRejectedValueOnce(new Error("Disk IO error"));
+    await expect(deleteFilePayload(projId, "src/dummy.ts")).rejects.toThrow(StorageReadError);
+
+    // Incremental update propagates storage failures on file payload retrieval
+    const meta = await loadSymbolGraphMeta(projId);
+    expect(meta).toBeDefined();
+    if (!meta) throw new Error("Expected meta to be defined");
+    vi.spyOn(qdrant, "retrieve")
+      .mockResolvedValueOnce([{ id: "meta", vector: [0], payload: { meta } }])
+      .mockRejectedValueOnce(new Error("Qdrant payload load error"));
+
+    await expect(
+      updateChangedFilesSymbolGraph(projId, tmpDir, fileGraph, ["src/dummy.ts"], []),
+    ).rejects.toThrow(StorageReadError);
   });
 });

--- a/tests/unit/symbol-graph-contract.test.ts
+++ b/tests/unit/symbol-graph-contract.test.ts
@@ -613,9 +613,8 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
       ],
     });
 
-    // 3. Concurrent startup cleanup runs for projId while gen1 is still active
-    // cleanStaleGenerations should respect stagedGen for projId
-    await cleanStaleGenerations(projId, gen1!);
+    if (!gen1) throw new Error("Expected gen1 to be defined");
+    await cleanStaleGenerations(projId, gen1);
 
     // Verify point for stagedGen was NOT deleted
     const stored = await qdrant.retrieve(collName, { ids: ["point-staged-1"] });

--- a/tests/unit/symbol-graph-contract.test.ts
+++ b/tests/unit/symbol-graph-contract.test.ts
@@ -687,11 +687,20 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     // Because oldCache has an active reader lease for gen1,
     // gen1 points were NOT deleted by cleanStaleGenerations during rebuildGraph!
     // Reader now lazily loads second.ts from storage via oldCache:
-    const lazyPayload = await oldCache.getFilePayload("src/second.ts");
+    const lazyPayload = await oldCache.getFilePayload(
+      "src/second.ts",
+      releaseReader.token,
+    );
     expect(lazyPayload).not.toBeNull();
     // oldCache still sees gen1 content (does not contain secondGen2Extra from gen2)
     expect(lazyPayload?.symbols.some((s) => s.name === "second")).toBe(true);
     expect(lazyPayload?.symbols.some((s) => s.name === "secondGen2Extra")).toBe(false);
+
+    // A separate operation cannot borrow the first operation's lease merely
+    // because the old cache still has an active reader.
+    await expect(oldCache.getFilePayload("src/first.ts")).rejects.toThrow(
+      SymbolGraphGenerationChangedError,
+    );
 
     // Verify a fresh cache on gen2 sees gen2 content
     const newCache = await getSymbolGraphCache(projId);
@@ -706,12 +715,11 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     // 4. Reader finishes and releases the lease
     releaseReader();
 
-    // Give deferred deletion a microtick
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
     // After release, deferred cleanup removes gen1 from storage
-    storedGens = await listStoredGenerations(projId);
-    expect(storedGens).toEqual([gen2]);
+    await vi.waitFor(async () => {
+      storedGens = await listStoredGenerations(projId);
+      expect(storedGens).toEqual([gen2]);
+    });
   });
 
   it("keeps a generation-less legacy graph readable through first v2 activation", async () => {
@@ -756,7 +764,10 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
 
     // The committed pointer now names v2, but a query already holding the
     // legacy lease still reads generation-less payloads until it releases.
-    const legacyRead = await legacyCache.getFilePayload("src/sample.ts");
+    const legacyRead = await legacyCache.getFilePayload(
+      "src/sample.ts",
+      releaseLegacyReader.token,
+    );
     expect(legacyRead?.symbols.some((symbol) => symbol.name === "legacy")).toBe(true);
     expect(legacyRead?.symbols.some((symbol) => symbol.name === "current")).toBe(false);
 
@@ -770,8 +781,9 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     );
 
     releaseLegacyReader();
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(await listStoredGenerations(projId)).toEqual([currentGeneration]);
+    await vi.waitFor(async () => {
+      expect(await listStoredGenerations(projId)).toEqual([currentGeneration]);
+    });
   });
 
   it("rejects a stale cache lease while its generation is being deleted", async () => {

--- a/tests/unit/symbol-graph-contract.test.ts
+++ b/tests/unit/symbol-graph-contract.test.ts
@@ -30,7 +30,7 @@ const clientInstance = {
     const coll = store.get(name) ?? new Map<string, StoredPoint>();
     return opts.ids.map((id) => coll.get(String(id))).filter((p): p is StoredPoint => p !== undefined);
   },
-  delete: async (name: string, opts: { points?: Array<string | number>; filter?: { must?: Array<{ key?: string; match?: { value?: string; except?: string[] } }> } }) => {
+  delete: async (name: string, opts: { points?: Array<string | number>; filter?: { must?: Array<{ key?: string; match?: { value?: string; except?: string[] }; is_empty?: { key: string } }> } }) => {
     const coll = store.get(name);
     if (!coll) return;
     if (opts.points) {
@@ -38,6 +38,13 @@ const clientInstance = {
     }
     if (opts.filter?.must) {
       for (const cond of opts.filter.must) {
+        if (cond.is_empty?.key === "generation") {
+          for (const [id, pt] of Array.from(coll.entries())) {
+            if (pt.payload?.generation === undefined || pt.payload.generation === null) {
+              coll.delete(id);
+            }
+          }
+        }
         if (cond.key === "generation" && cond.match) {
           if (cond.match.value !== undefined) {
             for (const [id, pt] of Array.from(coll.entries())) {
@@ -85,6 +92,7 @@ import {
   cleanStaleGenerations,
   coordinateProject,
   deleteFilePayload,
+  LEGACY_SYMBOL_GRAPH_GENERATION,
   listStoredGenerations,
   loadFilePayload,
   loadNameShard,
@@ -94,12 +102,14 @@ import {
   resetSymbolGraphCollectionCache,
   reverseShardKeyForCallee,
   StorageReadError,
+  SymbolGraphGenerationChangedError,
+  saveFilePayload,
   saveReverseShard,
   saveSymbolGraphMeta,
   unregisterStagingGeneration,
 } from "../../src/services/symbol-graph-store.js";
 import { handleGraphTool } from "../../src/tools/graph-tools.js";
-import type { SymbolGraphMeta, SymbolRef } from "../../src/types.js";
+import type { SymbolGraphFilePayload, SymbolGraphMeta, SymbolRef } from "../../src/types.js";
 
 describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
   let tmpDir: string;
@@ -272,9 +282,10 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     const { cache } = await runPipeline();
     const impact = await getImpactRadius(cache, "internalAdd", 3);
     expect(impact.status).toBe("ok");
-    expect(impact.totalFiles).toBe(2);
-    // Hop 1: same file math.ts (via publicSum)
-    expect(impact.filesByDepth.get(1)).toEqual(["src/math.ts"]);
+    expect(impact.totalFiles).toBe(1);
+    // Hop 1 has only the same-file helper, so the defining file is not
+    // counted again as an impacted file.
+    expect(impact.filesByDepth.get(1)).toBeUndefined();
     // Hop 2: calculator.ts (via calculate calling publicSum)
     expect(impact.filesByDepth.get(2)).toEqual(["src/calculator.ts"]);
   });
@@ -701,5 +712,110 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     // After release, deferred cleanup removes gen1 from storage
     storedGens = await listStoredGenerations(projId);
     expect(storedGens).toEqual([gen2]);
+  });
+
+  it("keeps a generation-less legacy graph readable through first v2 activation", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "sample.ts"), `export function legacy() { return 1; }`);
+
+    const legacyPayload: SymbolGraphFilePayload = {
+      file: "src/sample.ts",
+      language: "typescript",
+      contentHash: "legacy-hash",
+      symbols: [{
+        id: "src/sample.ts::legacy#1",
+        name: "legacy",
+        qualifiedName: "legacy",
+        kind: "function",
+        isExported: true,
+        file: "src/sample.ts",
+        line: 1,
+        endLine: 1,
+        language: "typescript",
+      }],
+      outgoingCalls: [],
+    };
+    const legacyMeta: SymbolGraphMeta = {
+      projectId: projId,
+      symbolCount: 1,
+      edgeCount: 0,
+      fileCount: 1,
+      unresolvedEdgePct: 0,
+      builtAt: Date.now(),
+      schemaVersion: 1,
+    };
+    await saveFilePayload(projId, legacyPayload);
+    await saveSymbolGraphMeta(projId, legacyMeta);
+
+    const legacyCache = await getSymbolGraphCache(projId);
+    if (!legacyCache) throw new Error("Expected legacy cache");
+    const releaseLegacyReader = legacyCache.acquireReader();
+
+    fs.writeFileSync(path.join(tmpDir, "src", "sample.ts"), `export function current() { return 2; }`);
+    await rebuildGraph(tmpDir);
+
+    // The committed pointer now names v2, but a query already holding the
+    // legacy lease still reads generation-less payloads until it releases.
+    const legacyRead = await legacyCache.getFilePayload("src/sample.ts");
+    expect(legacyRead?.symbols.some((symbol) => symbol.name === "legacy")).toBe(true);
+    expect(legacyRead?.symbols.some((symbol) => symbol.name === "current")).toBe(false);
+
+    const currentCache = await getSymbolGraphCache(projId);
+    const currentGeneration = currentCache?.meta.generation;
+    expect(currentGeneration).toBeDefined();
+    const currentRead = await currentCache?.getFilePayload("src/sample.ts");
+    expect(currentRead?.symbols.some((symbol) => symbol.name === "current")).toBe(true);
+    expect(await listStoredGenerations(projId)).toEqual(
+      expect.arrayContaining([LEGACY_SYMBOL_GRAPH_GENERATION, currentGeneration]),
+    );
+
+    releaseLegacyReader();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(await listStoredGenerations(projId)).toEqual([currentGeneration]);
+  });
+
+  it("rejects a stale cache lease while its generation is being deleted", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "sample.ts"), `export function first() { return 1; }`);
+
+    const { cache: oldCache } = await runPipeline();
+    const oldGeneration = oldCache.meta.generation;
+    if (!oldGeneration) throw new Error("Expected the initial generation");
+
+    let signalDeletionStarted: () => void = () => {};
+    const deletionStarted = new Promise<void>((resolve) => {
+      signalDeletionStarted = resolve;
+    });
+    let allowDeletion: () => void = () => {};
+    const deletionGate = new Promise<void>((resolve) => {
+      allowDeletion = resolve;
+    });
+    let blocked = false;
+    const originalDelete = clientInstance.delete.bind(clientInstance);
+    const deleteSpy = vi.spyOn(clientInstance, "delete").mockImplementation(async (name, opts) => {
+      const generation = opts.filter?.must?.find((condition) => condition.key === "generation")?.match?.value;
+      if (!blocked && generation === oldGeneration) {
+        blocked = true;
+        signalDeletionStarted();
+        await deletionGate;
+      }
+      return originalDelete(name, opts);
+    });
+
+    fs.writeFileSync(path.join(tmpDir, "src", "sample.ts"), `export function second() { return 2; }`);
+    const rebuild = rebuildGraph(tmpDir);
+    try {
+      await deletionStarted;
+      expect(() => oldCache.acquireReader()).toThrow(SymbolGraphGenerationChangedError);
+    } finally {
+      allowDeletion();
+      await rebuild;
+      deleteSpy.mockRestore();
+    }
+
+    const currentCache = await getSymbolGraphCache(projId);
+    expect(currentCache?.meta.generation).not.toBe(oldGeneration);
+    const payload = await currentCache?.getFilePayload("src/sample.ts");
+    expect(payload?.symbols.some((symbol) => symbol.name === "second")).toBe(true);
   });
 });

--- a/tests/unit/symbol-graph-contract.test.ts
+++ b/tests/unit/symbol-graph-contract.test.ts
@@ -110,6 +110,7 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     try {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     } catch {
@@ -519,7 +520,7 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     const qdrant = getClient();
     const originalUpsert = qdrant.upsert.bind(qdrant);
     let injectedFail = true;
-    vi.spyOn(qdrant, "upsert").mockImplementation(async (collName, body) => {
+    const spy = vi.spyOn(qdrant, "upsert").mockImplementation(async (collName, body) => {
       // If writing to index collection on new generation, inject failure
       if (injectedFail && collName.includes("symgraph_index")) {
         throw new Error("Mid-build disk crash on shard write");
@@ -527,7 +528,11 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
       return originalUpsert(collName, body);
     });
 
-    await rebuildGraph(tmpDir);
+    try {
+      await rebuildGraph(tmpDir);
+    } finally {
+      spy.mockRestore();
+    }
     injectedFail = false;
 
     // 3. Readers check: meta must still point to generation 1

--- a/tests/unit/symbol-graph-contract.test.ts
+++ b/tests/unit/symbol-graph-contract.test.ts
@@ -51,10 +51,12 @@ import { rebuildGraph } from "../../src/services/code-graph.js";
 import { getImpactRadius, getSymbolContext } from "../../src/services/graph-impact.js";
 import { getSymbolGraphCache, resetSymbolGraphCacheRegistry } from "../../src/services/symbol-graph-cache.js";
 import {
+  loadSymbolGraphMeta,
   resetSymbolGraphCollectionCache,
   StorageReadError,
   saveSymbolGraphMeta,
 } from "../../src/services/symbol-graph-store.js";
+import { handleGraphTool } from "../../src/tools/graph-tools.js";
 
 describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
   let tmpDir: string;
@@ -64,7 +66,7 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     store.clear();
     resetSymbolGraphCollectionCache();
     resetSymbolGraphCacheRegistry();
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-contract-"));
+    tmpDir = path.resolve(fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-contract-")));
     projId = projectIdFromPath(tmpDir);
   });
 
@@ -252,6 +254,9 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     expect(ctx[0].callers).toHaveLength(1);
     expect(ctx[0].callers[0].file).toBe("src/target.ts");
     expect(ctx[0].callers[0].kind).toBe("call");
+
+    const toolOutput = await handleGraphTool("codebase_symbol", { name: "execute", projectPath: tmpDir });
+    expect(toolOutput).toContain("← src/target.ts:4 (call)");
   });
 
   it("handles schema v1 graphs safely with graph_upgrade_required", async () => {
@@ -265,6 +270,24 @@ describe("symbol-graph-contract (End-to-End Pipeline on Disk)", () => {
     const impact = await getImpactRadius(cache, "dummy");
     expect(impact.status).toBe("graph_upgrade_required");
     expect(impact.totalFiles).toBe(0);
+  });
+
+  it("normalizes metadata without schemaVersion to 1 and triggers graph_upgrade_required", async () => {
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "dummy.ts"), `export function dummy() {}`);
+
+    const { cache } = await runPipeline();
+    const { schemaVersion: _, ...legacyMeta } = cache.meta;
+    await saveSymbolGraphMeta(projId, legacyMeta as SymbolGraphMeta);
+
+    const loaded = await loadSymbolGraphMeta(projId);
+    expect(loaded).toBeDefined();
+    if (!loaded) throw new Error("Expected loaded meta to be defined");
+    expect(loaded.schemaVersion).toBe(1);
+
+    cache.meta = loaded;
+    const impact = await getImpactRadius(cache, "dummy");
+    expect(impact.status).toBe("graph_upgrade_required");
   });
 
   it("propagates storage read failures as storage_error (fail-closed)", async () => {

--- a/tests/unit/symbol-graph-multipart-shards.test.ts
+++ b/tests/unit/symbol-graph-multipart-shards.test.ts
@@ -70,6 +70,7 @@ import {
   loadNameShard,
   loadReverseShard,
   resetSymbolGraphCollectionCache,
+  StorageReadError,
   SymbolGraphPointTooLargeError,
   saveNameShard,
   saveReverseShard,
@@ -198,7 +199,7 @@ describe("multi-part symbol shards (#99)", () => {
     expect(continuation).toBeDefined();
     coll?.delete(String(continuation?.id));
 
-    await expect(loadNameShard(PROJ, "m")).resolves.toBeNull();
+    await expect(loadNameShard(PROJ, "m")).rejects.toThrow(StorageReadError);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("missing continuation parts"),
       expect.objectContaining({ shardKey: "m" }),
@@ -223,8 +224,7 @@ describe("multi-part symbol shards (#99)", () => {
     failUpsertAt = upsertCount + 2;
     await expect(saveNameShard(PROJ, "w", newRecord)).rejects.toThrow();
 
-    const loaded = await loadNameShard(PROJ, "w");
-    expect(loaded).toBeNull(); // never a silent old/new key mixture
+    await expect(loadNameShard(PROJ, "w")).rejects.toThrow(StorageReadError);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("different write"),
       expect.objectContaining({ shardKey: "w" }),
@@ -249,7 +249,7 @@ describe("multi-part symbol shards (#99)", () => {
       const { write, ...restPayload } = p.payload as Record<string, unknown>;
       coll?.set(String(p.id), { ...p, payload: restPayload });
     }
-    await expect(loadNameShard(PROJ, "x")).resolves.toBeNull();
+    await expect(loadNameShard(PROJ, "x")).rejects.toThrow(StorageReadError);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("malformed header"),
       expect.objectContaining({ shardKey: "x" }),
@@ -265,7 +265,7 @@ describe("multi-part symbol shards (#99)", () => {
       ...(continuation as StoredPoint),
       payload: { ...(continuation as StoredPoint).payload, part: 99 },
     });
-    await expect(loadNameShard(PROJ, "y")).resolves.toBeNull();
+    await expect(loadNameShard(PROJ, "y")).rejects.toThrow(StorageReadError);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("different write or is malformed"),
       expect.objectContaining({ shardKey: "y" }),

--- a/tests/unit/symbol-graph-multipart-shards.test.ts
+++ b/tests/unit/symbol-graph-multipart-shards.test.ts
@@ -272,6 +272,25 @@ describe("multi-part symbol shards (#99)", () => {
     );
   });
 
+  it("refuses a shard with invalid declared parts count (0, 1, or non-numeric)", async () => {
+    await saveNameShard(PROJ, "k", { sym: refsFor("sym", 1) });
+    const coll = store.get(INDEX_COLL);
+    const primary = pointsInIndex()[0];
+    expect(primary).toBeDefined();
+
+    // 1. parts: 0
+    coll?.set(String(primary.id), { ...primary, payload: { ...primary.payload, parts: 0, write: "w1" } });
+    await expect(loadNameShard(PROJ, "k")).rejects.toThrow(StorageReadError);
+
+    // 2. parts: 1 (only multipart >= 2 is valid when declared)
+    coll?.set(String(primary.id), { ...primary, payload: { ...primary.payload, parts: 1, write: "w1" } });
+    await expect(loadNameShard(PROJ, "k")).rejects.toThrow(StorageReadError);
+
+    // 3. parts: "two" (non-numeric)
+    coll?.set(String(primary.id), { ...primary, payload: { ...primary.payload, parts: "two", write: "w1" } });
+    await expect(loadNameShard(PROJ, "k")).rejects.toThrow(StorageReadError);
+  });
+
   it("throws a named error when one ENTRY alone exceeds a part budget", async () => {
     // One symbol name with an absurd number of references — the only shape
     // entry-level splitting cannot place. Must fail loudly by name.


### PR DESCRIPTION
Fixes #132

### Problem
`codebase_impact` returned `Total impacted files: 0` for non-function exports (`const`, `type`, `interface`, `enum`) on TypeScript/JavaScript projects, claiming no dependents exist.

Root causes:
1. `extractFromTsLike` only extracted functions and classes. Plain `const`, `let`, `var`, `type` aliases, `interface`, and `enum` declarations were not indexed as symbols.
2. The edge model only recorded `call_expression` nodes, ignoring imports, re-exports, and type references.
3. Symbol-mode impact analysis resolved symbol names to defining files and traversed a `calleeFile -> callerFiles` reverse index instead of tracking exact symbol IDs. Absent symbols produced an empty seed set and returned an unsafe 0 without reporting `not_found`.

### Solution
1. **Symbol extraction (`src/services/graph-symbols.ts`, `src/types.ts`)**:
   - Added `"type"` to `SymbolKind`.
   - Extracted TypeScript/JavaScript `interface`, `type`, `enum`, and plain `const`/`let`/`var` declarations.
   - Extracted reference edges from `import` statements, `export` re-exports, and `type_identifier` usages (filtering TS standard primitives).
2. **Exact symbol traversal & fail-closed states (`src/services/graph-impact.ts`)**:
   - Updated `getImpactRadius` to filter caller payloads by exact `calleeCandidates.includes(sym.id)` during symbol-mode traversal.
   - Added explicit status handling (`ok`, `not_found`, `ambiguous`, `unsupported_or_incomplete`).
   - If a symbol is unknown, returns `not_found`. If defined across multiple files without qualification, returns `ambiguous` with candidate locations.
3. **Status & diagnostics (`src/tools/graph-tools.ts`, `src/services/code-graph.ts`)**:
   - Formatted `codebase_impact` output to distinguish genuine 0-dependent symbols from missing/ambiguous symbols.
   - Separated ast-grep built-in grammars from dynamically loaded grammars in `codebase_graph_status`.
   - Bumped graph `schemaVersion` to `2`.
4. **Tests (`tests/unit/`, `tests/integration/`)**:
   - Unit tests for TS declarations, imports, and type references in `graph-symbols.test.ts`.
   - Unit tests for symbol isolation within the same file, ambiguity, and not-found handling in `graph-impact.test.ts`.
   - Integration tests in `tools.test.ts`.

### Why this approach
- **Safety**: A blast-radius tool must not return false negatives before refactors. Unknown symbols must fail closed (`not_found` / `ambiguous`).
- **Precision**: Different symbols in the same file must have independent blast radiuses rather than sharing the file's aggregate callers.
- **Performance**: Filtering primitive type names prevents generating millions of useless unresolved edges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Code graphs recognize interfaces, type aliases, enums, variables, imports, re-exports, and type references.
  - Impact analysis supports precise symbol- and file-level tracking, disambiguation by file or symbol ID, and richer caller/callee context.
  - Results identify symbol kinds, export status, and call relationships.
  - Symbol resolution follows default exports, aliases, wildcard exports, and multi-level re-exports.

- **Bug Fixes**
  - Improved blast-radius accuracy for same-file and ambiguous symbols.
  - Reports distinguish missing targets, zero references, incomplete analysis, and storage errors.
  - File changes now trigger a complete graph rebuild.
  - Improved recovery from interrupted or corrupted graph data and legacy graph formats.
  - Improved consistency during graph updates and handling of stale cached results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->