### PR TITLE
fix(ignore): recognise Python environments by their marker, anchored to where they stand

### DIFF
--- a/src/services/ignore.ts
+++ b/src/services/ignore.ts
@@ -81,10 +81,25 @@ const DEFAULT_IGNORE_PATTERNS = [
  * version, so an environment at `env?/` was scanned despite its marker
  * (review finding), while `\[`, `\*`, `\!`, `\#` and `\\` happened to work.
  * A prefix compare has no syntax to get wrong.
+ *
+ * The one thing the pattern route allowed that a bare prefix would not: a
+ * negation written later — `!tests/fixtures/sample-venv/**` in
+ * `.socraticodeignore`, for a checked-in fixture that any tool parsing
+ * `pyvenv.cfg` has — re-included the environment. That precedence is kept
+ * (review finding): a path an explicit negation claims is not excluded by a
+ * discovered prefix either. `unignored` is what the package answers exactly
+ * when a negative rule spoke last and no positive one stands over it.
  */
 export interface IgnoreFilter {
   /** Whether the path, relative to the project root, is excluded. */
   ignores(relativePath: string): boolean;
+  /**
+   * Whether the path, with or without its trailing slash, is the root of an
+   * environment the walk discovered. The watcher asks this of a directory
+   * event, since an environment moved away arrives as one event on the
+   * directory and nothing on the marker inside it.
+   */
+  isEnvironmentRoot(relativePath: string): boolean;
 }
 
 /**
@@ -139,8 +154,13 @@ export function createIgnoreFilter(projectPath: string): IgnoreFilter {
   }
 
   return {
-    ignores: (relativePath) =>
-      isUnderAnEnvironment(relativePath, environments) || ig.ignores(relativePath),
+    ignores: (relativePath) => {
+      const byPattern = ig.test(relativePath);
+      if (byPattern.unignored) return false;
+      return byPattern.ignored || isUnderAnEnvironment(relativePath, environments);
+    },
+    isEnvironmentRoot: (relativePath) =>
+      environments.includes(relativePath.endsWith("/") ? relativePath : `${relativePath}/`),
   };
 }
 
@@ -209,6 +229,24 @@ function isDirectory(candidate: string): boolean {
 }
 
 /**
+ * Whether the directory is an environment: it carries a marker, in the shape
+ * its tool writes it. Two markers, because two tools build these directories —
+ * `pyvenv.cfg` for a PEP 405 virtualenv, `conda-meta/` for a conda
+ * environment. Both hold installed libraries and neither is source.
+ *
+ * The shape matters. Merely existing is not enough: a source directory holding
+ * a file named `conda-meta` would otherwise disappear whole, and a discarded
+ * source file costs far more than a kept one.
+ *
+ * Shared with the watcher, which asks it of a directory that has just
+ * appeared: an environment moved into place arrives as one event on the
+ * directory, and nothing on the marker inside it.
+ */
+export function isEnvironmentDirectory(dirPath: string): boolean {
+  return isFile(path.join(dirPath, "pyvenv.cfg")) || isDirectory(path.join(dirPath, "conda-meta"));
+}
+
+/**
  * Walk the subdirectories once, collecting what the tree itself says should be
  * ignored: the rules of every nested .gitignore, and every environment
  * directory holding installed libraries.
@@ -220,8 +258,10 @@ function isDirectory(candidate: string): boolean {
  * They are matched at the project root only now, and the proof covers what that
  * anchoring gives up: a virtualenv nested deeper, whatever it is called.
  *
- * The extra cost is one `existsSync` per directory visited, in a walk that was
- * already making one for `.gitignore`.
+ * The extra cost is up to two `lstat` per directory visited — `pyvenv.cfg`,
+ * then `conda-meta` — in a walk that was already making an `existsSync` for
+ * `.gitignore`. Measured on a 1,916-directory registry cache: 121 ms for the
+ * whole filter against 125 ms on `main`, inside the noise.
  */
 function scanNestedIgnoreSources(
   rootPath: string,
@@ -244,17 +284,9 @@ function scanNestedIgnoreSources(
     const dirPath = path.join(currentPath, dirName);
 
     // Checked before the skip list below, which would otherwise walk past a
-    // `venv/` without ever looking inside it.
-    //
-    // Two markers, because two tools build these directories: `pyvenv.cfg` for
-    // a PEP 405 virtualenv, `conda-meta/` for a conda environment. Both hold
-    // installed libraries and neither is source.
-    //
-    // Each marker is checked in the shape its tool actually writes — a file for
-    // one, a directory for the other. Merely existing is not enough: a source
-    // directory holding a file named `conda-meta` would otherwise disappear
-    // whole, and a discarded source file costs far more than a kept one.
-    if (isFile(path.join(dirPath, "pyvenv.cfg")) || isDirectory(path.join(dirPath, "conda-meta"))) {
+    // `venv/` without ever looking inside it. See `isEnvironmentDirectory` for
+    // the two markers and why their shape matters.
+    if (isEnvironmentDirectory(dirPath)) {
       const relDir = path.relative(rootPath, dirPath).split(path.sep).join("/");
       // Kept as the literal prefix it is, never as a pattern — see
       // `IgnoreFilter`. A prefix is anchored by nature: `toolbox/` here is the

--- a/src/services/ignore.ts
+++ b/src/services/ignore.ts
@@ -145,6 +145,25 @@ export function createIgnoreFilter(projectPath: string): IgnoreFilter {
 }
 
 /**
+ * Whether a change at this path can change what the filter answers: it is one
+ * of the environment markers the walk looks for, or lies inside one.
+ *
+ * The rules a filter carries are read off the tree once, when it is built, and
+ * an environment is recognised by a file or directory that may appear or
+ * vanish while the tree is being watched. A watcher that ran every event
+ * through its filter first never saw either: a new `pyvenv.cfg` is not an
+ * indexable file, and the one being deleted sits under a directory the stale
+ * filter still excludes (review finding). The name is enough here — the event
+ * only schedules a reconciliation, and the rebuilt filter reads the shape.
+ * `conda-meta` is matched as any segment, since the directory's creation
+ * arrives with the files inside it.
+ */
+export function isEnvironmentMarker(relativePath: string): boolean {
+  const segments = relativePath.split(path.sep).join("/").split("/");
+  return segments[segments.length - 1] === "pyvenv.cfg" || segments.includes("conda-meta");
+}
+
+/**
  * Whether the path is one of the discovered environment directories or lies
  * beneath one. `environments` holds each as `dir/` relative to the root, so
  * `env?/lib/dep.py` and the directory itself, asked as `env?/` or `env?`, all

--- a/src/services/ignore.ts
+++ b/src/services/ignore.ts
@@ -159,8 +159,13 @@ export function createIgnoreFilter(projectPath: string): IgnoreFilter {
       if (byPattern.unignored) return false;
       return byPattern.ignored || isUnderAnEnvironment(relativePath, environments);
     },
-    isEnvironmentRoot: (relativePath) =>
-      environments.includes(relativePath.endsWith("/") ? relativePath : `${relativePath}/`),
+    // Normalised here, as `shouldIgnore` normalises for `ignores`: a caller on
+    // Windows hands over `backend\env`, and the roots are kept with `/`
+    // (review finding).
+    isEnvironmentRoot: (relativePath) => {
+      const normalized = relativePath.split(path.sep).join("/");
+      return environments.includes(normalized.endsWith("/") ? normalized : `${normalized}/`);
+    },
   };
 }
 

--- a/src/services/ignore.ts
+++ b/src/services/ignore.ts
@@ -18,8 +18,20 @@ const DEFAULT_IGNORE_PATTERNS = [
   "__pycache__",
   "*.pyc",
   ".venv",
-  "venv",
-  "env",
+  // Anchored, unlike the rest: `venv` and `env` are a virtualenv's names at the
+  // root of a project, and ordinary module names anywhere below it. Unanchored
+  // they matched at any depth and quietly deleted source — `clap_complete/src/env/`
+  // is compiled by cargo and listed in its dep-info, yet was not even a node of
+  // the graph, while `pub mod engine;` two lines above it drew its edges; the
+  // same for `tracing-subscriber/src/filter/env/`. In a 245-crate registry
+  // sample they are the only two, which is the point: the loss is total for the
+  // crate it hits and invisible everywhere else.
+  //
+  // A virtualenv nested deeper stays out by the two routes that already cover
+  // it: `.venv`, the common spelling, is still matched at any depth, and a
+  // checked-in project lists its own in `.gitignore`, which this filter reads.
+  "/venv",
+  "/env",
   ".tox",
   "target",
   "_build",
@@ -86,12 +98,15 @@ export function createIgnoreFilter(projectPath: string): Ignore {
       const content = fs.readFileSync(rootGitignore, "utf-8");
       ig.add(content);
     }
-
-    // Find and process nested .gitignore files
-    findNestedGitignores(projectPath, projectPath, ig);
   } else {
     logger.debug("Skipping .gitignore processing (RESPECT_GITIGNORE=false)");
   }
+
+  // The same walk finds the nested .gitignore files and the virtualenvs, and it
+  // runs whether or not .gitignore is respected: a virtualenv is not a project
+  // preference, it is a directory of installed libraries that no reading of the
+  // tree should call source.
+  scanNestedIgnoreSources(projectPath, projectPath, ig, respectGitignore);
 
   // .socraticodeignore
   const socraticodeignorePath = path.join(projectPath, ".socraticodeignore");
@@ -106,10 +121,38 @@ export function createIgnoreFilter(projectPath: string): Ignore {
 }
 
 /**
- * Recursively find .gitignore files in subdirectories and add their rules
- * with proper relative path prefixing.
+ * A literal path as a gitignore pattern that matches it and nothing else.
+ *
+ * The syntax reads `*`, `?` and `[` as wildcards, so a directory honestly named
+ * `env[3]` became a character class and matched none of its own files. A
+ * leading `!` or `#` changes what the whole line means, and both are legal in a
+ * directory name.
  */
-function findNestedGitignores(rootPath: string, currentPath: string, ig: Ignore): void {
+function escapeIgnorePattern(literal: string): string {
+  return literal.replace(/[[\]*?\\!#]/g, (character) => `\\${character}`);
+}
+
+/**
+ * Walk the subdirectories once, collecting what the tree itself says should be
+ * ignored: the rules of every nested .gitignore, and every environment
+ * directory holding installed libraries.
+ *
+ * A virtualenv is recognised by the `pyvenv.cfg` PEP 405 puts at its root, not
+ * by its directory's name. The name alone cannot do it: `venv` and `env` are
+ * also ordinary module names, and matching them at any depth deleted real
+ * source — `clap_complete/src/env/`, which cargo compiles, was not even a node.
+ * They are matched at the project root only now, and the proof covers what that
+ * anchoring gives up: a virtualenv nested deeper, whatever it is called.
+ *
+ * The extra cost is one `existsSync` per directory visited, in a walk that was
+ * already making one for `.gitignore`.
+ */
+function scanNestedIgnoreSources(
+  rootPath: string,
+  currentPath: string,
+  ig: Ignore,
+  readGitignores: boolean,
+): void {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(currentPath, { withFileTypes: true });
@@ -121,6 +164,23 @@ function findNestedGitignores(rootPath: string, currentPath: string, ig: Ignore)
     if (!entry.isDirectory()) continue;
 
     const dirName = entry.name;
+    const dirPath = path.join(currentPath, dirName);
+
+    // Checked before the skip list below, which would otherwise walk past a
+    // `venv/` without ever looking inside it.
+    //
+    // Two markers, because two tools build these directories: `pyvenv.cfg` for
+    // a PEP 405 virtualenv, `conda-meta/` for a conda environment. Both hold
+    // installed libraries and neither is source.
+    if (
+      fs.existsSync(path.join(dirPath, "pyvenv.cfg")) ||
+      fs.existsSync(path.join(dirPath, "conda-meta"))
+    ) {
+      const relDir = path.relative(rootPath, dirPath).split(path.sep).join("/");
+      if (relDir) ig.add(`${escapeIgnorePattern(relDir)}/`);
+      continue;
+    }
+
     // Skip directories we know should be ignored
     if (dirName === "node_modules" || dirName === ".git" || dirName === ".svn" ||
         dirName === ".hg" || dirName === "dist" || dirName === "build" ||
@@ -129,10 +189,9 @@ function findNestedGitignores(rootPath: string, currentPath: string, ig: Ignore)
       continue;
     }
 
-    const dirPath = path.join(currentPath, dirName);
     const gitignorePath = path.join(dirPath, ".gitignore");
 
-    if (fs.existsSync(gitignorePath)) {
+    if (readGitignores && fs.existsSync(gitignorePath)) {
       const content = fs.readFileSync(gitignorePath, "utf-8");
       const relDir = path.relative(rootPath, dirPath).split(path.sep).join("/");
 
@@ -157,7 +216,7 @@ function findNestedGitignores(rootPath: string, currentPath: string, ig: Ignore)
     }
 
     // Recurse into subdirectory
-    findNestedGitignores(rootPath, dirPath, ig);
+    scanNestedIgnoreSources(rootPath, dirPath, ig, readGitignores);
   }
 }
 

--- a/src/services/ignore.ts
+++ b/src/services/ignore.ts
@@ -204,15 +204,44 @@ function scanNestedIgnoreSources(
     // whole, and a discarded source file costs far more than a kept one.
     if (isFile(path.join(dirPath, "pyvenv.cfg")) || isDirectory(path.join(dirPath, "conda-meta"))) {
       const relDir = path.relative(rootPath, dirPath).split(path.sep).join("/");
-      if (relDir) ig.add(`${escapeIgnorePattern(relDir)}/`);
+      // Anchored with a leading slash, because a gitignore pattern carrying no
+      // slash of its own matches that name at **every** depth. An environment
+      // sitting directly under the root produces exactly such a pattern — its
+      // relative path is a bare name — so a root-level `toolbox/` was deleting
+      // `packages/app/toolbox/` too, in any language.
+      //
+      // It also undid this file's own reason for existing: with a root-level
+      // `env/` present, the pattern `env/` came back and excluded
+      // `clap_complete/src/env/mod.rs` again, which is the case the anchoring
+      // of the defaults above was written to keep. Verified against the
+      // installed `ignore` package: `env/` matches that path, `/env/` does not,
+      // and both still catch `env/lib/dep.py` at the root.
+      if (relDir) ig.add(`/${escapeIgnorePattern(relDir)}/`);
       continue;
     }
 
-    // Skip directories we know should be ignored
+    // Skip directories we know should be ignored.
+    //
+    // `venv` is not among them by name any more, and that is the same decision
+    // as anchoring the default patterns rather than a separate one. Skipping it
+    // wherever it stood stopped this walk at any directory so called, so it never reached
+    // the marker of a real environment nested under one:
+    // `crates/venv/backend/env/` had its installed libraries indexed, because
+    // the walk turned back two levels above the `pyvenv.cfg` that would have
+    // excluded them, and a nested `.gitignore` below it stopped being read.
+    //
+    // `.venv` stays: the default patterns ignore that spelling at every depth,
+    // so descending into it would look for a marker in a directory already
+    // gone. The same argument holds for `venv` and `env` directly under the
+    // root, which `/venv` and `/env` above already exclude — a virtualenv old
+    // enough to have written no `pyvenv.cfg` would otherwise be walked to its
+    // `site-packages` reading `.gitignore` files for nothing. Only at the root:
+    // one level down those names are ordinary modules again.
     if (dirName === "node_modules" || dirName === ".git" || dirName === ".svn" ||
         dirName === ".hg" || dirName === "dist" || dirName === "build" ||
-        dirName === "__pycache__" || dirName === ".venv" || dirName === "venv" ||
-        dirName === "target" || dirName === ".gradle" || dirName === ".next") {
+        dirName === "__pycache__" || dirName === ".venv" ||
+        dirName === "target" || dirName === ".gradle" || dirName === ".next" ||
+        (currentPath === rootPath && (dirName === "venv" || dirName === "env"))) {
       continue;
     }
 

--- a/src/services/ignore.ts
+++ b/src/services/ignore.ts
@@ -69,12 +69,32 @@ const DEFAULT_IGNORE_PATTERNS = [
 ];
 
 /**
+ * What `createIgnoreFilter` answers with: one question, on a path relative to
+ * the project root and written with forward slashes.
+ *
+ * Two kinds of rule stand behind it. Patterns — the defaults, `.gitignore`
+ * files and `.socraticodeignore` — are gitignore syntax and go to the `ignore`
+ * package. The environments the walk *discovers* are not patterns, they are
+ * directories that exist, and they are kept as the literal prefixes they are.
+ * Writing one as a pattern meant escaping it, and the escape is only as good as
+ * the package's reading of it: `\?` is not understood by the installed
+ * version, so an environment at `env?/` was scanned despite its marker
+ * (review finding), while `\[`, `\*`, `\!`, `\#` and `\\` happened to work.
+ * A prefix compare has no syntax to get wrong.
+ */
+export interface IgnoreFilter {
+  /** Whether the path, relative to the project root, is excluded. */
+  ignores(relativePath: string): boolean;
+}
+
+/**
  * Build an ignore filter for a project directory.
  *
  * Combines (in order):
  *   1. Built-in defaults (node_modules, .git, dist, build, lock files, etc.)
  *   2. .gitignore files (root + nested) — unless RESPECT_GITIGNORE=false
- *   3. .socraticodeignore — optional project-specific exclusions
+ *   3. Python and conda environments found by their markers, as literal prefixes
+ *   4. .socraticodeignore — optional project-specific exclusions
  *
  * Set env RESPECT_GITIGNORE=false to skip .gitignore processing entirely.
  *
@@ -82,8 +102,9 @@ const DEFAULT_IGNORE_PATTERNS = [
  * build a filter per artifact on every staleness check, so an info line here
  * would fire once per artifact per context search.
  */
-export function createIgnoreFilter(projectPath: string): Ignore {
+export function createIgnoreFilter(projectPath: string): IgnoreFilter {
   const ig = ignore();
+  const environments: string[] = [];
 
   // Default patterns
   ig.add(DEFAULT_IGNORE_PATTERNS);
@@ -106,7 +127,7 @@ export function createIgnoreFilter(projectPath: string): Ignore {
   // runs whether or not .gitignore is respected: a virtualenv is not a project
   // preference, it is a directory of installed libraries that no reading of the
   // tree should call source.
-  scanNestedIgnoreSources(projectPath, projectPath, ig, respectGitignore);
+  scanNestedIgnoreSources(projectPath, projectPath, ig, environments, respectGitignore);
 
   // .socraticodeignore
   const socraticodeignorePath = path.join(projectPath, ".socraticodeignore");
@@ -117,19 +138,22 @@ export function createIgnoreFilter(projectPath: string): Ignore {
     logger.debug("Loaded .socraticodeignore rules");
   }
 
-  return ig;
+  return {
+    ignores: (relativePath) =>
+      isUnderAnEnvironment(relativePath, environments) || ig.ignores(relativePath),
+  };
 }
 
 /**
- * A literal path as a gitignore pattern that matches it and nothing else.
- *
- * The syntax reads `*`, `?` and `[` as wildcards, so a directory honestly named
- * `env[3]` became a character class and matched none of its own files. A
- * leading `!` or `#` changes what the whole line means, and both are legal in a
- * directory name.
+ * Whether the path is one of the discovered environment directories or lies
+ * beneath one. `environments` holds each as `dir/` relative to the root, so
+ * `env?/lib/dep.py` and the directory itself, asked as `env?/` or `env?`, all
+ * answer true, and `env?.d/x.py` does not.
  */
-function escapeIgnorePattern(literal: string): string {
-  return literal.replace(/[[\]*?\\!#]/g, (character) => `\\${character}`);
+function isUnderAnEnvironment(relativePath: string, environments: string[]): boolean {
+  return environments.some(
+    (dir) => relativePath.startsWith(dir) || relativePath === dir.slice(0, -1),
+  );
 }
 
 /**
@@ -184,6 +208,7 @@ function scanNestedIgnoreSources(
   rootPath: string,
   currentPath: string,
   ig: Ignore,
+  environments: string[],
   readGitignores: boolean,
 ): void {
   let entries: fs.Dirent[];
@@ -212,19 +237,12 @@ function scanNestedIgnoreSources(
     // whole, and a discarded source file costs far more than a kept one.
     if (isFile(path.join(dirPath, "pyvenv.cfg")) || isDirectory(path.join(dirPath, "conda-meta"))) {
       const relDir = path.relative(rootPath, dirPath).split(path.sep).join("/");
-      // Anchored with a leading slash, because a gitignore pattern carrying no
-      // slash of its own matches that name at **every** depth. An environment
-      // sitting directly under the root produces exactly such a pattern — its
-      // relative path is a bare name — so a root-level `toolbox/` was deleting
+      // Kept as the literal prefix it is, never as a pattern — see
+      // `IgnoreFilter`. A prefix is anchored by nature: `toolbox/` here is the
+      // directory under the root and nothing else, where the pattern
+      // `toolbox/` once matched that name at every depth and deleted
       // `packages/app/toolbox/` too, in any language.
-      //
-      // It also undid this file's own reason for existing: with a root-level
-      // `env/` present, the pattern `env/` came back and excluded
-      // `clap_complete/src/env/mod.rs` again, which is the case the anchoring
-      // of the defaults above was written to keep. Verified against the
-      // installed `ignore` package: `env/` matches that path, `/env/` does not,
-      // and both still catch `env/lib/dep.py` at the root.
-      if (relDir) ig.add(`/${escapeIgnorePattern(relDir)}/`);
+      if (relDir) environments.push(`${relDir}/`);
       continue;
     }
 
@@ -280,14 +298,14 @@ function scanNestedIgnoreSources(
     }
 
     // Recurse into subdirectory
-    scanNestedIgnoreSources(rootPath, dirPath, ig, readGitignores);
+    scanNestedIgnoreSources(rootPath, dirPath, ig, environments, readGitignores);
   }
 }
 
 /**
  * Check if a relative path should be ignored.
  */
-export function shouldIgnore(ig: Ignore, relativePath: string): boolean {
+export function shouldIgnore(ig: IgnoreFilter, relativePath: string): boolean {
   const normalized = relativePath.split(path.sep).join("/");
   return ig.ignores(normalized);
 }

--- a/src/services/ignore.ts
+++ b/src/services/ignore.ts
@@ -138,10 +138,18 @@ function escapeIgnorePattern(literal: string): string {
  * The `throwIfNoEntry` option only covers a missing entry; an unreadable parent
  * directory still throws EACCES, and the `existsSync` this replaced threw for
  * nothing at all. A marker we cannot stat is simply not a marker.
+ *
+ * `lstat`, not `stat`: a symbolic link is answered as a link, never as what it
+ * points to. That is the same rule the walk applies one level up — a
+ * `readdirSync` entry that is a link is not a directory to it, so a linked
+ * `venv/` is never entered — and the two questions should not disagree. A link
+ * named `pyvenv.cfg` in a source directory otherwise excluded that whole
+ * directory (review finding); and no tool writes its marker as a link, so
+ * nothing real is given up.
  */
 function statOrNull(candidate: string): fs.Stats | null {
   try {
-    return fs.statSync(candidate, { throwIfNoEntry: false }) ?? null;
+    return fs.lstatSync(candidate, { throwIfNoEntry: false }) ?? null;
   } catch {
     return null;
   }

--- a/src/services/ignore.ts
+++ b/src/services/ignore.ts
@@ -133,6 +133,31 @@ function escapeIgnorePattern(literal: string): string {
 }
 
 /**
+ * What the path is, or null when the question cannot be answered.
+ *
+ * The `throwIfNoEntry` option only covers a missing entry; an unreadable parent
+ * directory still throws EACCES, and the `existsSync` this replaced threw for
+ * nothing at all. A marker we cannot stat is simply not a marker.
+ */
+function statOrNull(candidate: string): fs.Stats | null {
+  try {
+    return fs.statSync(candidate, { throwIfNoEntry: false }) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether the path is a file, answering false for a directory or nothing. */
+function isFile(candidate: string): boolean {
+  return statOrNull(candidate)?.isFile() ?? false;
+}
+
+/** Whether the path is a directory, answering false for a file or nothing. */
+function isDirectory(candidate: string): boolean {
+  return statOrNull(candidate)?.isDirectory() ?? false;
+}
+
+/**
  * Walk the subdirectories once, collecting what the tree itself says should be
  * ignored: the rules of every nested .gitignore, and every environment
  * directory holding installed libraries.
@@ -172,10 +197,12 @@ function scanNestedIgnoreSources(
     // Two markers, because two tools build these directories: `pyvenv.cfg` for
     // a PEP 405 virtualenv, `conda-meta/` for a conda environment. Both hold
     // installed libraries and neither is source.
-    if (
-      fs.existsSync(path.join(dirPath, "pyvenv.cfg")) ||
-      fs.existsSync(path.join(dirPath, "conda-meta"))
-    ) {
+    //
+    // Each marker is checked in the shape its tool actually writes — a file for
+    // one, a directory for the other. Merely existing is not enough: a source
+    // directory holding a file named `conda-meta` would otherwise disappear
+    // whole, and a discarded source file costs far more than a kept one.
+    if (isFile(path.join(dirPath, "pyvenv.cfg")) || isDirectory(path.join(dirPath, "conda-meta"))) {
       const relDir = path.relative(rootPath, dirPath).split(path.sep).join("/");
       if (relDir) ig.add(`${escapeIgnorePattern(relDir)}/`);
       continue;

--- a/src/services/watcher.ts
+++ b/src/services/watcher.ts
@@ -13,7 +13,7 @@ import {
 } from "../constants.js";
 import { invalidateGraphCache } from "./code-graph.js";
 import { detectExtensionFromSource, readFileHead } from "./extensionless.js";
-import { createIgnoreFilter, shouldIgnore } from "./ignore.js";
+import { createIgnoreFilter, isEnvironmentMarker, shouldIgnore } from "./ignore.js";
 import {
   profileExtensionLanguageMap,
   resolveEffectiveIndexProfile,
@@ -165,7 +165,13 @@ export async function startWatching(
     return false;
   }
 
-  const ig = createIgnoreFilter(resolvedPath);
+  // Replaceable, not built once: the filter's rules are read off the tree —
+  // nested .gitignore files, and the markers a Python or conda environment is
+  // recognised by — and the tree changes under a watcher. It is rebuilt after
+  // each successful update, so the events that follow are judged by what the
+  // tree holds now; a marker appearing or vanishing is let through to schedule
+  // that update in the first place (see the event filter below).
+  let ig = createIgnoreFilter(resolvedPath);
   const ignoreGlobs = buildIgnoreGlobs();
 
   // Reset error count
@@ -192,6 +198,11 @@ export async function startWatching(
             onProgress?.(
               `Auto-update: ${result.added} added, ${result.updated} updated, ${result.removed} removed`,
             );
+
+            // The update read the tree as it is now; the filter should too. An
+            // environment created since the last build is excluded from here
+            // on, and one removed stops hiding the source files in its place.
+            ig = createIgnoreFilter(resolvedPath);
 
             // Note: code graph rebuild is now handled inside updateProjectIndex itself
           } catch (err) {
@@ -288,6 +299,14 @@ export async function startWatching(
                 // never triggers the async head-read (matches getIndexableFiles).
                 const relative = path.relative(resolvedPath, event.path);
                 if (!relative || relative.startsWith("..")) return null;
+                // An environment marker is neither indexable nor, once the
+                // environment exists, outside the filter — so it has to be
+                // recognised before either check. Its creation, change or
+                // removal changes what the filter should answer, and the
+                // reconciliation it schedules is what removes the files of a
+                // new environment from the index, or brings back the source
+                // files of a directory that has stopped being one.
+                if (isEnvironmentMarker(relative)) return event;
                 if (shouldIgnore(ig, relative)) return null;
                 if (await isIndexableFile(event.path, effectiveExtensionLanguageMap)) return event;
                 // A previously-indexed extensionless file edited into readable

--- a/src/services/watcher.ts
+++ b/src/services/watcher.ts
@@ -270,6 +270,10 @@ export async function startWatching(
         resolvedPath,
         setTimeout(async () => {
           debounceTimers.delete(resolvedPath);
+          // stopWatching invalidates this closure before awaiting the native
+          // unsubscribe, so a timer already queued cannot start work while
+          // that asynchronous shutdown is still pending.
+          if (!watcherActive) return;
           updateRunning = true;
           try {
             onProgress?.(`Detected changes, updating index for ${resolvedPath}...`);

--- a/src/services/watcher.ts
+++ b/src/services/watcher.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import type { AsyncSubscription, Event } from "@parcel/watcher";
@@ -13,7 +14,13 @@ import {
 } from "../constants.js";
 import { invalidateGraphCache } from "./code-graph.js";
 import { detectExtensionFromSource, readFileHead } from "./extensionless.js";
-import { createIgnoreFilter, isEnvironmentMarker, shouldIgnore } from "./ignore.js";
+import {
+  createIgnoreFilter,
+  type IgnoreFilter,
+  isEnvironmentDirectory,
+  isEnvironmentMarker,
+  shouldIgnore,
+} from "./ignore.js";
 import {
   profileExtensionLanguageMap,
   resolveEffectiveIndexProfile,
@@ -101,6 +108,57 @@ export async function isIndexableFile(
       });
     }
     return true;
+  }
+}
+
+/**
+ * Whether this event means an environment has appeared or vanished — which is
+ * to say, whether the ignore filter's answer for the tree has changed.
+ *
+ * Three shapes reach here, because the native watcher reports them
+ * differently. A marker written or deleted in place (`env/pyvenv.cfg`,
+ * `env/conda-meta/history`) is an event on the marker. An environment moved
+ * away (`mv env env.old`) is one event on the directory, `delete env`, and
+ * nothing on the marker inside it — FSEvents and inotify both report the
+ * renamed directory only — so a directory the filter knows as an environment
+ * root counts too. And one moved into place is one `create` on a directory the
+ * filter has never heard of, which is asked for its marker on disk.
+ *
+ * An event is let through only where the filter and the disk disagree: a
+ * marker present in a directory already excluded, or gone from one never
+ * excluded, changes nothing, and dropping it is what keeps `conda install` —
+ * which rewrites `conda-meta/` on every run — from reconciling the whole tree
+ * (review finding).
+ *
+ * The disk is consulted only where the name alone cannot answer: a marker or
+ * a known root, and a created path without an extension, which is the same
+ * rule `isIndexableFile` applies — a `.png` never costs a stat here either. An
+ * environment directory carrying a dot in its name and moved into place is
+ * the case this leaves to the next unrelated change.
+ */
+export function environmentChanged(event: Event, relative: string, ig: IgnoreFilter): boolean {
+  if (isEnvironmentMarker(relative) || ig.isEnvironmentRoot(relative)) {
+    const excluded = shouldIgnore(ig, relative);
+    return excluded !== (lstatOrNull(event.path) !== null);
+  }
+  if (event.type !== "create" || path.extname(event.path) !== "") return false;
+  return (
+    lstatOrNull(event.path)?.isDirectory() === true &&
+    isEnvironmentDirectory(event.path) &&
+    !shouldIgnore(ig, `${relative}/`)
+  );
+}
+
+/**
+ * Synchronous on purpose: the question is asked of a handful of paths per
+ * batch, and an answer that arrives through the event loop is one the debounce
+ * cannot be made to wait for.
+ */
+function lstatOrNull(filePath: string): fs.Stats | null {
+  try {
+    return fs.lstatSync(filePath, { throwIfNoEntry: false }) ?? null;
+  } catch {
+    return null;
   }
 }
 
@@ -299,14 +357,14 @@ export async function startWatching(
                 // never triggers the async head-read (matches getIndexableFiles).
                 const relative = path.relative(resolvedPath, event.path);
                 if (!relative || relative.startsWith("..")) return null;
-                // An environment marker is neither indexable nor, once the
-                // environment exists, outside the filter — so it has to be
-                // recognised before either check. Its creation, change or
-                // removal changes what the filter should answer, and the
-                // reconciliation it schedules is what removes the files of a
-                // new environment from the index, or brings back the source
-                // files of a directory that has stopped being one.
-                if (isEnvironmentMarker(relative)) return event;
+                // An environment appearing or vanishing changes what the
+                // filter should answer, and the reconciliation it schedules is
+                // what removes a new environment's files from the index, or
+                // brings back the source files of a directory that has stopped
+                // being one. Neither event passes the checks below on its own
+                // — a marker is not indexable, and once the environment exists
+                // its directory is excluded — so they are recognised first.
+                if (environmentChanged(event, relative, ig)) return event;
                 if (shouldIgnore(ig, relative)) return null;
                 if (await isIndexableFile(event.path, effectiveExtensionLanguageMap)) return event;
                 // A previously-indexed extensionless file edited into readable

--- a/src/services/watcher.ts
+++ b/src/services/watcher.ts
@@ -148,13 +148,27 @@ export function environmentEvent(
 ): "changed" | "touches" | null {
   if (isEnvironmentMarker(relative) || ig.isEnvironmentRoot(relative)) {
     const excluded = shouldIgnore(ig, relative);
-    return excluded !== (lstatOrNull(event.path) !== null) ? "changed" : "touches";
+    return excluded !== isEnvironmentDirectory(environmentRootOf(event.path, relative))
+      ? "changed"
+      : "touches";
   }
   if (event.type !== "create") return null;
   if (lstatOrNull(event.path)?.isDirectory() !== true || !isEnvironmentDirectory(event.path)) {
     return null;
   }
   return shouldIgnore(ig, `${relative}/`) ? "touches" : "changed";
+}
+
+/** Resolve a marker event back to the environment directory it describes. */
+function environmentRootOf(eventPath: string, relative: string): string {
+  const segments = relative.split(path.sep).join("/").split("/");
+  const condaMetaIndex = segments.indexOf("conda-meta");
+  if (condaMetaIndex !== -1) {
+    let root = eventPath;
+    for (let i = condaMetaIndex; i < segments.length; i++) root = path.dirname(root);
+    return root;
+  }
+  return segments[segments.length - 1] === "pyvenv.cfg" ? path.dirname(eventPath) : eventPath;
 }
 
 /**

--- a/src/services/watcher.ts
+++ b/src/services/watcher.ts
@@ -112,8 +112,10 @@ export async function isIndexableFile(
 }
 
 /**
- * Whether this event means an environment has appeared or vanished — which is
- * to say, whether the ignore filter's answer for the tree has changed.
+ * What this event says about an environment: that one has appeared or vanished
+ * (`"changed"` — the ignore filter's answer for the tree is now wrong), that it
+ * is about an environment but agrees with what the filter already says
+ * (`"touches"`), or that it is an ordinary event (`null`).
  *
  * Three shapes reach here, because the native watcher reports them
  * differently. A marker written or deleted in place (`env/pyvenv.cfg`,
@@ -124,11 +126,13 @@ export async function isIndexableFile(
  * root counts too. And one moved into place is one `create` on a directory the
  * filter has never heard of, which is asked for its marker on disk.
  *
- * An event is let through only where the filter and the disk disagree: a
- * marker present in a directory already excluded, or gone from one never
- * excluded, changes nothing, and dropping it is what keeps `conda install` —
- * which rewrites `conda-meta/` on every run — from reconciling the whole tree
- * (review finding).
+ * Agreement between the filter and the disk is `"touches"`, and on its own it
+ * schedules nothing: a marker present in a directory already excluded, or gone
+ * from one never excluded, changes nothing, and dropping it is what keeps
+ * `conda install` — which rewrites `conda-meta/` on every run — from
+ * reconciling the whole tree (review finding). It is told apart from an
+ * ordinary event all the same, because agreement is only trustworthy while the
+ * filter describes the tree: see the caller, where an update is running.
  *
  * Every created path is asked whether it is a directory, before anything is
  * read off its name: a directory may carry a dot — `backend/venv.3.12` moved
@@ -137,17 +141,20 @@ export async function isIndexableFile(
  * (review finding). One `lstat` per created path is the price, in a callback
  * that already stats every extensionless one.
  */
-export function environmentChanged(event: Event, relative: string, ig: IgnoreFilter): boolean {
+export function environmentEvent(
+  event: Event,
+  relative: string,
+  ig: IgnoreFilter,
+): "changed" | "touches" | null {
   if (isEnvironmentMarker(relative) || ig.isEnvironmentRoot(relative)) {
     const excluded = shouldIgnore(ig, relative);
-    return excluded !== (lstatOrNull(event.path) !== null);
+    return excluded !== (lstatOrNull(event.path) !== null) ? "changed" : "touches";
   }
-  if (event.type !== "create") return false;
-  return (
-    lstatOrNull(event.path)?.isDirectory() === true &&
-    isEnvironmentDirectory(event.path) &&
-    !shouldIgnore(ig, `${relative}/`)
-  );
+  if (event.type !== "create") return null;
+  if (lstatOrNull(event.path)?.isDirectory() !== true || !isEnvironmentDirectory(event.path)) {
+    return null;
+  }
+  return shouldIgnore(ig, `${relative}/`) ? "touches" : "changed";
 }
 
 /**
@@ -233,6 +240,16 @@ export async function startWatching(
   let ig = createIgnoreFilter(resolvedPath);
   const ignoreGlobs = buildIgnoreGlobs();
 
+  // While an update runs, `ig` is the state the tree had when it started, and
+  // an environment event arriving in that window cannot be judged against it:
+  // a marker created and then deleted mid-update looks like agreement — the
+  // stale filter excludes nothing, the disk holds nothing — while the update
+  // itself scanned with the marker in place and dropped the environment's
+  // files. So any environment event in that window is remembered, and exactly
+  // one reconciliation follows the update that was running (review finding).
+  let updateRunning = false;
+  let environmentMovedUnderUpdate = false;
+
   // Reset error count
   watcherErrorCounts.set(resolvedPath, 0);
 
@@ -247,6 +264,8 @@ export async function startWatching(
         resolvedPath,
         setTimeout(async () => {
           debounceTimers.delete(resolvedPath);
+          updateRunning = true;
+          environmentMovedUnderUpdate = false;
           try {
             onProgress?.(`Detected changes, updating index for ${resolvedPath}...`);
 
@@ -274,6 +293,17 @@ export async function startWatching(
             if (message.includes("ECONNREFUSED") || message.includes("fetch failed") || message.includes("Request Timeout")) {
               logger.warn("Infrastructure appears down, pausing watcher updates for 30s", { projectPath: resolvedPath });
               await new Promise((resolve) => setTimeout(resolve, 30_000));
+            }
+          } finally {
+            updateRunning = false;
+            // One follow-up for everything that moved under the update, and
+            // only when something did: the filter it will be judged against is
+            // the one just rebuilt, so this second pass sees the tree as it
+            // stands. It runs after a failed update too — the reversal is
+            // still unreconciled there.
+            if (environmentMovedUnderUpdate) {
+              environmentMovedUnderUpdate = false;
+              scheduleUpdate();
             }
           }
         }, DEBOUNCE_MS),
@@ -365,7 +395,16 @@ export async function startWatching(
                 // being one. Neither event passes the checks below on its own
                 // — a marker is not indexable, and once the environment exists
                 // its directory is excluded — so they are recognised first.
-                if (environmentChanged(event, relative, ig)) return event;
+                const environment = environmentEvent(event, relative, ig);
+                if (environment !== null && updateRunning) {
+                  // `ig` describes the tree the running update started from, so
+                  // neither answer can be trusted here — including "nothing
+                  // changed". Remembered, and reconciled once when that update
+                  // ends.
+                  environmentMovedUnderUpdate = true;
+                  return null;
+                }
+                if (environment === "changed") return event;
                 if (shouldIgnore(ig, relative)) return null;
                 if (await isIndexableFile(event.path, effectiveExtensionLanguageMap)) return event;
                 // A previously-indexed extensionless file edited into readable

--- a/src/services/watcher.ts
+++ b/src/services/watcher.ts
@@ -130,18 +130,19 @@ export async function isIndexableFile(
  * which rewrites `conda-meta/` on every run — from reconciling the whole tree
  * (review finding).
  *
- * The disk is consulted only where the name alone cannot answer: a marker or
- * a known root, and a created path without an extension, which is the same
- * rule `isIndexableFile` applies — a `.png` never costs a stat here either. An
- * environment directory carrying a dot in its name and moved into place is
- * the case this leaves to the next unrelated change.
+ * Every created path is asked whether it is a directory, before anything is
+ * read off its name: a directory may carry a dot — `backend/venv.3.12` moved
+ * into place is one `create` on it and nothing else — and a first cut that
+ * skipped the stat for a path with an extension dropped exactly that event
+ * (review finding). One `lstat` per created path is the price, in a callback
+ * that already stats every extensionless one.
  */
 export function environmentChanged(event: Event, relative: string, ig: IgnoreFilter): boolean {
   if (isEnvironmentMarker(relative) || ig.isEnvironmentRoot(relative)) {
     const excluded = shouldIgnore(ig, relative);
     return excluded !== (lstatOrNull(event.path) !== null);
   }
-  if (event.type !== "create" || path.extname(event.path) !== "") return false;
+  if (event.type !== "create") return false;
   return (
     lstatOrNull(event.path)?.isDirectory() === true &&
     isEnvironmentDirectory(event.path) &&

--- a/src/services/watcher.ts
+++ b/src/services/watcher.ts
@@ -241,14 +241,14 @@ export async function startWatching(
   const ignoreGlobs = buildIgnoreGlobs();
 
   // While an update runs, `ig` is the state the tree had when it started, and
-  // an environment event arriving in that window cannot be judged against it:
-  // a marker created and then deleted mid-update looks like agreement — the
-  // stale filter excludes nothing, the disk holds nothing — while the update
-  // itself scanned with the marker in place and dropped the environment's
-  // files. So any environment event in that window is remembered, and exactly
-  // one reconciliation follows the update that was running (review finding).
+  // an environment event arriving in that window cannot be judged against it.
+  // Remember every update request instead of starting a competing update: the
+  // index lock makes that competing call a no-op, and it could otherwise clear
+  // the environment event that requires reconciliation. Exactly one update is
+  // scheduled after the active one finishes (review finding).
+  let watcherActive = true;
   let updateRunning = false;
-  let environmentMovedUnderUpdate = false;
+  let updateRequestedWhileRunning = false;
 
   // Reset error count
   watcherErrorCounts.set(resolvedPath, 0);
@@ -257,6 +257,12 @@ export async function startWatching(
 
   try {
     const scheduleUpdate = () => {
+      if (!watcherActive) return;
+      if (updateRunning) {
+        updateRequestedWhileRunning = true;
+        return;
+      }
+
       const existing = debounceTimers.get(resolvedPath);
       if (existing) clearTimeout(existing);
 
@@ -265,7 +271,6 @@ export async function startWatching(
         setTimeout(async () => {
           debounceTimers.delete(resolvedPath);
           updateRunning = true;
-          environmentMovedUnderUpdate = false;
           try {
             onProgress?.(`Detected changes, updating index for ${resolvedPath}...`);
 
@@ -296,13 +301,11 @@ export async function startWatching(
             }
           } finally {
             updateRunning = false;
-            // One follow-up for everything that moved under the update, and
-            // only when something did: the filter it will be judged against is
-            // the one just rebuilt, so this second pass sees the tree as it
-            // stands. It runs after a failed update too — the reversal is
-            // still unreconciled there.
-            if (environmentMovedUnderUpdate) {
-              environmentMovedUnderUpdate = false;
+            // One follow-up for all requests received during this update. It
+            // runs after a failed update too, where the changes are likewise
+            // unreconciled.
+            if (updateRequestedWhileRunning) {
+              updateRequestedWhileRunning = false;
               scheduleUpdate();
             }
           }
@@ -310,7 +313,7 @@ export async function startWatching(
       );
     };
 
-    const subscription = await watcher.subscribe(
+    const nativeSubscription = await watcher.subscribe(
       resolvedPath,
       async (err: Error | null, events: Event[]) => {
         if (err) {
@@ -401,7 +404,7 @@ export async function startWatching(
                   // neither answer can be trusted here — including "nothing
                   // changed". Remembered, and reconciled once when that update
                   // ends.
-                  environmentMovedUnderUpdate = true;
+                  updateRequestedWhileRunning = true;
                   return null;
                 }
                 if (environment === "changed") return event;
@@ -444,6 +447,16 @@ export async function startWatching(
         ignore: ignoreGlobs,
       },
     );
+
+    const subscription: AsyncSubscription = {
+      unsubscribe: async () => {
+        // Invalidate this closure before awaiting the native unsubscribe. An
+        // active update may finish during that await and must not schedule a
+        // deferred reconciliation after the watcher has stopped.
+        watcherActive = false;
+        await nativeSubscription.unsubscribe();
+      },
+    };
 
     subscriptions.set(resolvedPath, subscription);
     externalWatchCache.delete(resolvedPath);

--- a/tests/unit/ignore.test.ts
+++ b/tests/unit/ignore.test.ts
@@ -205,19 +205,37 @@ describe("ignore", () => {
       expect(shouldIgnore(ig, "real-env/lib/dep.py")).toBe(true);
     });
 
-    it("matches an environment directory whose name reads as a wildcard", () => {
-      // gitignore syntax reads `[` as a character class, so a directory
-      // honestly named `env[3]` produced a pattern matching none of its own
-      // files, and the environment stayed in the tree.
-      fixture = createFixtureProject("ignore-venv-brackets");
-      fs.mkdirSync(path.join(fixture.root, "sub", "env[3]", "lib"), { recursive: true });
+    // A discovered environment is a directory that exists, and it is kept as a
+    // literal prefix rather than written as a gitignore pattern. The pattern
+    // route needed an escape for every character the syntax reads specially,
+    // and the escape was only as good as the installed package's reading of
+    // it: `\?` is not understood by `ignore` 7, so `env?/` was scanned despite
+    // its marker (review finding) while the other five happened to work. One
+    // case per character the old helper claimed to cover — and a neighbour the
+    // wildcard reading would have matched, to show the compare is literal.
+    it.each([
+      ["?", "env?", "envx"],
+      ["*", "env*", "envxyz"],
+      ["[]", "env[3]", "env3"],
+      ["!", "!env", "env"],
+      ["#", "#env", "env"],
+      ["\\", "env\\x", "envx"],
+    ])("matches an environment directory whose name carries %s literally", (_, name, neighbour) => {
+      fixture = createFixtureProject("ignore-venv-metacharacter");
+      fs.mkdirSync(path.join(fixture.root, "sub", name, "lib"), { recursive: true });
       fs.writeFileSync(
-        path.join(fixture.root, "sub", "env[3]", "pyvenv.cfg"),
+        path.join(fixture.root, "sub", name, "pyvenv.cfg"),
         "home = /usr\nversion = 3.12.0\n",
       );
+      fs.mkdirSync(path.join(fixture.root, "sub", neighbour), { recursive: true });
 
       const ig = createIgnoreFilter(fixture.root);
-      expect(shouldIgnore(ig, "sub/env[3]/lib/dep.py")).toBe(true);
+      expect(shouldIgnore(ig, `sub/${name}/lib/dep.py`)).toBe(true);
+      expect(shouldIgnore(ig, `sub/${name}/`)).toBe(true);
+      expect(shouldIgnore(ig, `sub/${neighbour}/main.py`)).toBe(false);
+      // A directory whose name merely begins with the environment's is not
+      // beneath it.
+      expect(shouldIgnore(ig, `sub/${name}.d/main.py`)).toBe(false);
     });
 
     it("keeps a nested module named env, which carries no pyvenv.cfg", () => {

--- a/tests/unit/ignore.test.ts
+++ b/tests/unit/ignore.test.ts
@@ -531,6 +531,9 @@ describe("ignore", () => {
       const ig = createIgnoreFilter(fixture.root);
       expect(ig.isEnvironmentRoot("backend/env")).toBe(true);
       expect(ig.isEnvironmentRoot("backend/env/")).toBe(true);
+      // In the separator the platform's `path.relative` writes (review
+      // finding: on Windows that is `\`, and the roots are kept with `/`).
+      expect(ig.isEnvironmentRoot(["backend", "env"].join(path.sep))).toBe(true);
       expect(ig.isEnvironmentRoot("backend")).toBe(false);
       expect(ig.isEnvironmentRoot("backend/env/lib")).toBe(false);
     });

--- a/tests/unit/ignore.test.ts
+++ b/tests/unit/ignore.test.ts
@@ -144,6 +144,31 @@ describe("ignore", () => {
       expect(shouldIgnore(ig, "tools/env/lib/dep.py")).toBe(true);
     });
 
+    it("keeps a source directory holding a file named conda-meta", () => {
+      // Each marker only counts in the shape its own tool writes it. Conda
+      // writes a directory; a plain file of that name is somebody's source
+      // tree, and reading mere existence made the whole directory vanish —
+      // cargo compiled `src/engine/mod.rs` while the graph had no such node.
+      fixture = createFixtureProject("ignore-conda-marker-is-a-file");
+      fs.mkdirSync(path.join(fixture.root, "src", "engine"), { recursive: true });
+      fs.writeFileSync(path.join(fixture.root, "src", "engine", "conda-meta"), "not a directory\n");
+
+      const ig = createIgnoreFilter(fixture.root);
+      expect(shouldIgnore(ig, "src/engine/mod.rs")).toBe(false);
+    });
+
+    it("keeps a source directory holding a directory named pyvenv.cfg", () => {
+      // The mirror image: PEP 405 writes a file, so a directory of that name is
+      // not a virtualenv either. Stated as its own case because the two markers
+      // are read by two separate calls, and one can be corrected without the
+      // other.
+      fixture = createFixtureProject("ignore-pyvenv-marker-is-a-directory");
+      fs.mkdirSync(path.join(fixture.root, "src", "cfg", "pyvenv.cfg"), { recursive: true });
+
+      const ig = createIgnoreFilter(fixture.root);
+      expect(shouldIgnore(ig, "src/cfg/loader.rs")).toBe(false);
+    });
+
     it("matches an environment directory whose name reads as a wildcard", () => {
       // gitignore syntax reads `[` as a character class, so a directory
       // honestly named `env[3]` produced a pattern matching none of its own

--- a/tests/unit/ignore.test.ts
+++ b/tests/unit/ignore.test.ts
@@ -3,7 +3,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createIgnoreFilter, shouldIgnore } from "../../src/services/ignore.js";
 import { createFixtureProject, type FixtureProject } from "../helpers/fixtures.js";
 
@@ -196,6 +196,54 @@ describe("ignore", () => {
       expect(shouldIgnore(ig, "crate/src/env/shells.rs")).toBe(false);
     });
 
+    it("does not delete same-named source elsewhere when the environment is at the root", () => {
+      // A gitignore pattern with no slash of its own matches at every depth, and
+      // an environment directly under the root produces exactly that — its
+      // relative path is a bare name. So a root-level `toolbox/` was excluding
+      // `packages/app/toolbox/` too, in any language.
+      //
+      // Every other fixture here sits two levels deep, where the pattern is
+      // anchored by accident and this cannot show. A root-level one is what
+      // catches it, which is why this test exists rather than an assertion
+      // added to one above.
+      fixture = createFixtureProject("ignore-root-env-anchoring");
+      fs.mkdirSync(path.join(fixture.root, "toolbox", "conda-meta"), { recursive: true });
+      fs.mkdirSync(path.join(fixture.root, "packages", "app", "toolbox"), { recursive: true });
+
+      const ig = createIgnoreFilter(fixture.root);
+
+      // The environment itself still goes.
+      expect(shouldIgnore(ig, "toolbox/lib/python3.12/site-packages/dep.py")).toBe(true);
+      // The source that merely shares its name does not.
+      expect(shouldIgnore(ig, "packages/app/toolbox/helper.ts")).toBe(false);
+      expect(shouldIgnore(ig, "packages/app/toolbox/index.ts")).toBe(false);
+    });
+
+    it("excludes an environment nested under a directory named venv", () => {
+      // The walk used to skip any directory called `venv` by name, and turned
+      // back before reaching the marker of a real environment underneath: the
+      // installed libraries of `crates/venv/backend/env/` were indexed, because
+      // the `pyvenv.cfg` that would have excluded them was two levels below the
+      // point the walk gave up.
+      //
+      // It is the same decision as anchoring the default pattern — what makes
+      // an environment is its marker and not its name — and holding one without
+      // the other left the rule true in the list and false in the walk.
+      fixture = createFixtureProject("ignore-env-under-venv");
+      fs.mkdirSync(path.join(fixture.root, "crates", "venv", "backend", "env"), { recursive: true });
+      fs.writeFileSync(
+        path.join(fixture.root, "crates", "venv", "backend", "env", "pyvenv.cfg"),
+        "home = /usr\nversion = 3.12.0\n",
+      );
+
+      const ig = createIgnoreFilter(fixture.root);
+
+      expect(shouldIgnore(ig, "crates/venv/backend/env/lib/dep.py")).toBe(true);
+      // And the source around it stays, which is the half a broader skip would
+      // have taken with it.
+      expect(shouldIgnore(ig, "crates/venv/backend/main.rs")).toBe(false);
+    });
+
     it("keeps a nested directory named venv, which carries no pyvenv.cfg", () => {
       // The twin of the test above, and it was missing: `env` and `venv` were
       // anchored together in one change, and only `env` had a proof. Putting
@@ -212,6 +260,38 @@ describe("ignore", () => {
       const ig = createIgnoreFilter(fixture.root);
       expect(shouldIgnore(ig, "pkg/internal/venv/loader.go")).toBe(false);
       expect(shouldIgnore(ig, "pkg/internal/venv/loader_test.go")).toBe(false);
+    });
+
+    it("does not walk a root-level venv the defaults already exclude", () => {
+      // Review finding. `/venv` and `/env` exclude those names at the root
+      // whether or not a marker is inside, so descending into one looks for a
+      // marker in a directory already gone — and a virtualenv old enough to
+      // have written no `pyvenv.cfg` was walked down to its `site-packages`,
+      // reading `.gitignore` files for nothing. The filter cannot show the
+      // difference; which directories were read can.
+      fixture = createFixtureProject("ignore-root-venv-not-walked");
+      const sitePackages = path.join(fixture.root, "venv", "lib", "python3.12", "site-packages");
+      fs.mkdirSync(sitePackages, { recursive: true });
+      fs.writeFileSync(path.join(sitePackages, ".gitignore"), "*.pyc\n");
+      // A sibling module of the same name one level down is still walked.
+      fs.mkdirSync(path.join(fixture.root, "pkg", "venv"), { recursive: true });
+
+      const read: string[] = [];
+      const readdir = fs.readdirSync;
+      const spy = vi.spyOn(fs, "readdirSync").mockImplementation(((dir: fs.PathLike, opts?: unknown) => {
+        read.push(String(dir));
+        return (readdir as (d: fs.PathLike, o?: unknown) => unknown)(dir, opts);
+      }) as typeof fs.readdirSync);
+      try {
+        const ig = createIgnoreFilter(fixture.root);
+        expect(shouldIgnore(ig, "venv/lib/python3.12/site-packages/dep.py")).toBe(true);
+        expect(shouldIgnore(ig, "pkg/venv/loader.go")).toBe(false);
+      } finally {
+        spy.mockRestore();
+      }
+
+      expect(read.some((dir) => dir.startsWith(path.join(fixture.root, "venv")))).toBe(false);
+      expect(read).toContain(path.join(fixture.root, "pkg", "venv"));
     });
 
     it("finds a virtualenv even with RESPECT_GITIGNORE=false", () => {

--- a/tests/unit/ignore.test.ts
+++ b/tests/unit/ignore.test.ts
@@ -107,6 +107,86 @@ describe("ignore", () => {
       expect(ig.ignores("packages/sub/data.bak")).toBe(true);
     });
 
+    it("ignores a virtualenv at the project root", () => {
+      fixture = createFixtureProject("ignore-venv-root");
+      const ig = createIgnoreFilter(fixture.root);
+
+      expect(shouldIgnore(ig, "venv/lib/python3.12/site-packages/dep.py")).toBe(true);
+      expect(shouldIgnore(ig, "env/lib/python3.12/site-packages/dep.py")).toBe(true);
+    });
+
+    it("ignores a virtualenv nested anywhere, by its pyvenv.cfg", () => {
+      // `venv` and `env` match at the project root only, because at any depth
+      // they also delete real source: `clap_complete/src/env/` is compiled by
+      // cargo and was not even a node of the graph. What the anchoring gives
+      // up is covered by the proof instead of the name — PEP 405 puts a
+      // `pyvenv.cfg` at the root of every virtualenv.
+      fixture = createFixtureProject("ignore-venv-nested");
+      fs.mkdirSync(path.join(fixture.root, "backend", "venv", "lib"), { recursive: true });
+      fs.writeFileSync(
+        path.join(fixture.root, "backend", "venv", "pyvenv.cfg"),
+        "home = /usr\nversion = 3.12.0\n",
+      );
+
+      const ig = createIgnoreFilter(fixture.root);
+      expect(shouldIgnore(ig, "backend/venv/lib/dep.py")).toBe(true);
+    });
+
+    it("ignores a nested conda environment, by its conda-meta directory", () => {
+      // The other tool that builds one of these. A conda environment carries no
+      // `pyvenv.cfg`, so recognising only that marker left `tools/env/` — a
+      // directory of installed libraries — read as source once `env` stopped
+      // matching at any depth.
+      fixture = createFixtureProject("ignore-conda-nested");
+      fs.mkdirSync(path.join(fixture.root, "tools", "env", "conda-meta"), { recursive: true });
+
+      const ig = createIgnoreFilter(fixture.root);
+      expect(shouldIgnore(ig, "tools/env/lib/dep.py")).toBe(true);
+    });
+
+    it("matches an environment directory whose name reads as a wildcard", () => {
+      // gitignore syntax reads `[` as a character class, so a directory
+      // honestly named `env[3]` produced a pattern matching none of its own
+      // files, and the environment stayed in the tree.
+      fixture = createFixtureProject("ignore-venv-brackets");
+      fs.mkdirSync(path.join(fixture.root, "sub", "env[3]", "lib"), { recursive: true });
+      fs.writeFileSync(
+        path.join(fixture.root, "sub", "env[3]", "pyvenv.cfg"),
+        "home = /usr\nversion = 3.12.0\n",
+      );
+
+      const ig = createIgnoreFilter(fixture.root);
+      expect(shouldIgnore(ig, "sub/env[3]/lib/dep.py")).toBe(true);
+    });
+
+    it("keeps a nested module named env, which carries no pyvenv.cfg", () => {
+      // The case the anchoring exists for: in Rust `env` is an ordinary module
+      // name. `pub mod env;` sits two lines below `pub mod engine;` in
+      // clap_complete, and only the second one used to draw its edges.
+      fixture = createFixtureProject("ignore-nested-env-module");
+      fs.mkdirSync(path.join(fixture.root, "crate", "src", "env"), { recursive: true });
+
+      const ig = createIgnoreFilter(fixture.root);
+      expect(shouldIgnore(ig, "crate/src/env/mod.rs")).toBe(false);
+      expect(shouldIgnore(ig, "crate/src/env/shells.rs")).toBe(false);
+    });
+
+    it("finds a virtualenv even with RESPECT_GITIGNORE=false", () => {
+      // A virtualenv is not a project preference: it is a directory of
+      // installed libraries, and turning .gitignore off is no reason to start
+      // reading them as source.
+      process.env.RESPECT_GITIGNORE = "false";
+      fixture = createFixtureProject("ignore-venv-no-gitignore");
+      fs.mkdirSync(path.join(fixture.root, "backend", "venv", "lib"), { recursive: true });
+      fs.writeFileSync(
+        path.join(fixture.root, "backend", "venv", "pyvenv.cfg"),
+        "home = /usr\nversion = 3.12.0\n",
+      );
+
+      const ig = createIgnoreFilter(fixture.root);
+      expect(shouldIgnore(ig, "backend/venv/lib/dep.py")).toBe(true);
+    });
+
     it("reads .socraticodeignore if present", () => {
       fixture = createFixtureProject("ignore-socraticode");
 

--- a/tests/unit/ignore.test.ts
+++ b/tests/unit/ignore.test.ts
@@ -196,6 +196,24 @@ describe("ignore", () => {
       expect(shouldIgnore(ig, "crate/src/env/shells.rs")).toBe(false);
     });
 
+    it("keeps a nested directory named venv, which carries no pyvenv.cfg", () => {
+      // The twin of the test above, and it was missing: `env` and `venv` were
+      // anchored together in one change, and only `env` had a proof. Putting
+      // `venv` back to matching at any depth left the whole battery green — so
+      // half of that change was undoable in silence.
+      //
+      // `venv` is a plainer directory name than it looks: a Go package, a
+      // fixture directory, a docs folder. The rule is the same either way —
+      // what makes a virtualenv is the `pyvenv.cfg` PEP 405 puts at its root,
+      // not the name — and the test above proves the recognition still works.
+      fixture = createFixtureProject("ignore-nested-venv-directory");
+      fs.mkdirSync(path.join(fixture.root, "pkg", "internal", "venv"), { recursive: true });
+
+      const ig = createIgnoreFilter(fixture.root);
+      expect(shouldIgnore(ig, "pkg/internal/venv/loader.go")).toBe(false);
+      expect(shouldIgnore(ig, "pkg/internal/venv/loader_test.go")).toBe(false);
+    });
+
     it("finds a virtualenv even with RESPECT_GITIGNORE=false", () => {
       // A virtualenv is not a project preference: it is a directory of
       // installed libraries, and turning .gitignore off is no reason to start

--- a/tests/unit/ignore.test.ts
+++ b/tests/unit/ignore.test.ts
@@ -169,6 +169,42 @@ describe("ignore", () => {
       expect(shouldIgnore(ig, "src/cfg/loader.rs")).toBe(false);
     });
 
+    it("keeps a source directory whose pyvenv.cfg is a symbolic link", () => {
+      // Review finding. A link is answered as a link, never as what it points
+      // to — the rule the walk already applies to directories, where a linked
+      // `venv/` is never entered. Read through `stat`, a link named
+      // `pyvenv.cfg` pointing at a real one made the source directory around
+      // it vanish whole.
+      fixture = createFixtureProject("ignore-pyvenv-marker-is-a-symlink");
+      fs.mkdirSync(path.join(fixture.root, "real-env"), { recursive: true });
+      fs.writeFileSync(path.join(fixture.root, "real-env", "pyvenv.cfg"), "home = /usr\n");
+      fs.mkdirSync(path.join(fixture.root, "src", "tool"), { recursive: true });
+      fs.symlinkSync(
+        path.join(fixture.root, "real-env", "pyvenv.cfg"),
+        path.join(fixture.root, "src", "tool", "pyvenv.cfg"),
+      );
+
+      const ig = createIgnoreFilter(fixture.root);
+      expect(shouldIgnore(ig, "src/tool/main.rs")).toBe(false);
+      // The real environment the link points at is still found where it is.
+      expect(shouldIgnore(ig, "real-env/lib/dep.py")).toBe(true);
+    });
+
+    it("keeps a source directory whose conda-meta is a symbolic link", () => {
+      // Its twin, since the two markers are read by two separate calls.
+      fixture = createFixtureProject("ignore-conda-marker-is-a-symlink");
+      fs.mkdirSync(path.join(fixture.root, "real-env", "conda-meta"), { recursive: true });
+      fs.mkdirSync(path.join(fixture.root, "src", "engine"), { recursive: true });
+      fs.symlinkSync(
+        path.join(fixture.root, "real-env", "conda-meta"),
+        path.join(fixture.root, "src", "engine", "conda-meta"),
+      );
+
+      const ig = createIgnoreFilter(fixture.root);
+      expect(shouldIgnore(ig, "src/engine/mod.rs")).toBe(false);
+      expect(shouldIgnore(ig, "real-env/lib/dep.py")).toBe(true);
+    });
+
     it("matches an environment directory whose name reads as a wildcard", () => {
       // gitignore syntax reads `[` as a character class, so a directory
       // honestly named `env[3]` produced a pattern matching none of its own

--- a/tests/unit/ignore.test.ts
+++ b/tests/unit/ignore.test.ts
@@ -4,7 +4,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createIgnoreFilter, shouldIgnore } from "../../src/services/ignore.js";
+import { createIgnoreFilter, isEnvironmentMarker, shouldIgnore } from "../../src/services/ignore.js";
 import { createFixtureProject, type FixtureProject } from "../helpers/fixtures.js";
 
 describe("ignore", () => {
@@ -496,6 +496,23 @@ describe("ignore", () => {
       const ig = createIgnoreFilter(fixture.root);
       // The fixture .gitignore includes "coverage/"
       expect(shouldIgnore(ig, "coverage/lcov.info")).toBe(true);
+    });
+  });
+
+  describe("isEnvironmentMarker", () => {
+    it("names the two markers, at any depth and in either separator", () => {
+      // What the watcher lets through ahead of its filter: a change here can
+      // change what the filter should answer, and nothing else can.
+      expect(isEnvironmentMarker("env/pyvenv.cfg")).toBe(true);
+      expect(isEnvironmentMarker("crates/venv/backend/env/pyvenv.cfg")).toBe(true);
+      expect(isEnvironmentMarker("tools/env/conda-meta")).toBe(true);
+      expect(isEnvironmentMarker("tools/env/conda-meta/history")).toBe(true);
+      expect(isEnvironmentMarker(["tools", "env", "conda-meta"].join(path.sep))).toBe(true);
+      // A file merely named after one, or a source file inside an environment,
+      // is an ordinary event.
+      expect(isEnvironmentMarker("docs/pyvenv.cfg.md")).toBe(false);
+      expect(isEnvironmentMarker("env/lib/dep.py")).toBe(false);
+      expect(isEnvironmentMarker("src/main.py")).toBe(false);
     });
   });
 });

--- a/tests/unit/ignore.test.ts
+++ b/tests/unit/ignore.test.ts
@@ -499,6 +499,43 @@ describe("ignore", () => {
     });
   });
 
+  describe("a negation against a discovered environment", () => {
+    it("re-includes it, as the pattern route used to", () => {
+      // Review finding. Kept as a bare prefix, a discovered environment had no
+      // override left: a checked-in fixture venv — any tool that parses
+      // `pyvenv.cfg` has one — could no longer be brought back by a negation
+      // in `.socraticodeignore`, where the pattern route honoured it. An
+      // explicit negation still wins.
+      fixture = createFixtureProject("ignore-negation-over-environment");
+      const venv = path.join(fixture.root, "tests", "fixtures", "sample-venv");
+      fs.mkdirSync(path.join(venv, "lib"), { recursive: true });
+      fs.writeFileSync(path.join(venv, "pyvenv.cfg"), "home = /usr\n");
+      fs.writeFileSync(
+        path.join(fixture.root, ".socraticodeignore"),
+        "!tests/fixtures/sample-venv/\n!tests/fixtures/sample-venv/**\n",
+      );
+      // A second environment, with no negation, stays excluded.
+      fs.mkdirSync(path.join(fixture.root, "backend", "env", "lib"), { recursive: true });
+      fs.writeFileSync(path.join(fixture.root, "backend", "env", "pyvenv.cfg"), "home = /usr\n");
+
+      const ig = createIgnoreFilter(fixture.root);
+      expect(shouldIgnore(ig, "tests/fixtures/sample-venv/lib/probe.py")).toBe(false);
+      expect(shouldIgnore(ig, "backend/env/lib/dep.py")).toBe(true);
+    });
+
+    it("names the roots it discovered, and nothing else", () => {
+      fixture = createFixtureProject("ignore-environment-roots");
+      fs.mkdirSync(path.join(fixture.root, "backend", "env"), { recursive: true });
+      fs.writeFileSync(path.join(fixture.root, "backend", "env", "pyvenv.cfg"), "home = /usr\n");
+
+      const ig = createIgnoreFilter(fixture.root);
+      expect(ig.isEnvironmentRoot("backend/env")).toBe(true);
+      expect(ig.isEnvironmentRoot("backend/env/")).toBe(true);
+      expect(ig.isEnvironmentRoot("backend")).toBe(false);
+      expect(ig.isEnvironmentRoot("backend/env/lib")).toBe(false);
+    });
+  });
+
   describe("isEnvironmentMarker", () => {
     it("names the two markers, at any depth and in either separator", () => {
       // What the watcher lets through ahead of its filter: a change here can

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -689,6 +689,56 @@ describe("watcher (unit)", () => {
         expect(createIgnoreFilter).toHaveBeenCalledTimes(3);
       });
 
+      it("remembers an environment reversal that arrives with nothing else", async () => {
+        // The twin of the test above, with the ordinary source event left out.
+        // An environment event never reaches `scheduleUpdate` — the filter
+        // answers it and returns null — so the remembering it does for itself
+        // is the only thing that carries the reversal to the follow-up. With
+        // the source event beside it, `scheduleUpdate` sets the same flag and
+        // hides whether that path works at all: found by mutating it away and
+        // watching the suite stay green.
+        const nothing = filterOf(() => false);
+        const envExcluded = filterOf(underEnv, ["backend/env"]);
+        vi.mocked(createIgnoreFilter)
+          .mockReturnValueOnce(nothing)
+          .mockReturnValueOnce(envExcluded)
+          .mockReturnValueOnce(nothing);
+        await startWatching(root);
+
+        let releaseUpdate: () => void = () => {};
+        const updateStarted = new Promise<void>((updateIsRunning) => {
+          mockUpdateProjectIndex.mockImplementationOnce(async () => {
+            updateIsRunning();
+            await new Promise<void>((resolve) => {
+              releaseUpdate = resolve;
+            });
+            return { added: 0, updated: 0, removed: 0, chunksCreated: 0, cancelled: false };
+          });
+        });
+
+        fs.mkdirSync(path.dirname(marker()), { recursive: true });
+        fs.writeFileSync(marker(), "home = /usr\n");
+
+        vi.useFakeTimers();
+        try {
+          mockSubscribeCallback?.(null, [{ path: marker(), type: "create" }]);
+          await vi.advanceTimersByTimeAsync(2100);
+          await updateStarted;
+          expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(1);
+
+          fs.rmSync(marker());
+          mockSubscribeCallback?.(null, [{ path: marker(), type: "delete" }]);
+          await vi.advanceTimersByTimeAsync(2100);
+          expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(1);
+
+          releaseUpdate();
+          await vi.advanceTimersByTimeAsync(2100);
+          expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(2);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
       it("drops a deferred reconciliation when the watcher stops", async () => {
         vi.mocked(createIgnoreFilter).mockReturnValue(filterOf(() => false));
         await startWatching(root);

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -606,6 +606,80 @@ describe("watcher (unit)", () => {
           { path: installed, type: "create" },
         ])).toBe(0);
       });
+
+      it("reconciles once more when an environment reverses while the update runs", async () => {
+        // Review finding. While `updateProjectIndex` runs, the filter is the
+        // one that update started from, so an environment reversing in that
+        // window cannot be judged against it: here the marker is created and
+        // deleted while the first update scans, and to the stale filter the
+        // deletion reads as agreement — it excludes nothing, and the disk now
+        // holds nothing. What the old code did with it depended on the marker:
+        // dropped where it is not an indexable file, and where it is —
+        // `pyvenv.cfg` is — passed on to the debounce, which fired *while the
+        // first update was still running*. That second update takes the index
+        // lock's "already indexing" path, returns zeros and reconciles
+        // nothing, so the intermediate state stood until some later event.
+        // Either way the reversal was lost. Now such an event is remembered
+        // and one reconciliation follows the update it arrived under, with the
+        // rebuilt filter to judge it by.
+        const nothing = filterOf(() => false);
+        const envExcluded = filterOf(underEnv, ["backend/env"]);
+        vi.mocked(createIgnoreFilter)
+          .mockReturnValueOnce(nothing)        // at start
+          .mockReturnValueOnce(envExcluded)    // after the update that saw the marker
+          .mockReturnValueOnce(nothing);       // after the follow-up, marker gone again
+        await startWatching(root);
+
+        // The update is held open, so the reversal below lands squarely inside
+        // it rather than before or after.
+        let releaseUpdate: () => void = () => {};
+        const updateStarted = new Promise<void>((updateIsRunning) => {
+          mockUpdateProjectIndex.mockImplementationOnce(async () => {
+            updateIsRunning();
+            await new Promise<void>((resolve) => {
+              releaseUpdate = resolve;
+            });
+            return { added: 0, updated: 0, removed: 0, chunksCreated: 0, cancelled: false };
+          });
+        });
+
+        fs.mkdirSync(path.dirname(marker()), { recursive: true });
+        fs.writeFileSync(marker(), "home = /usr\n");
+
+        vi.useFakeTimers();
+        try {
+          mockSubscribeCallback?.(null, [{ path: marker(), type: "create" }]);
+          await vi.advanceTimersByTimeAsync(2100);
+          await updateStarted;
+          expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(1);
+
+          // The environment goes away again while that update is still
+          // scanning. Judged against the filter it started from, this looks
+          // like nothing happened.
+          fs.rmSync(marker());
+          mockSubscribeCallback?.(null, [{ path: marker(), type: "delete" }]);
+          await vi.advanceTimersByTimeAsync(2100);
+          // No second update while the first still holds the lock: that one
+          // would return zeros and reconcile nothing.
+          expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(1);
+
+          releaseUpdate();
+          await vi.advanceTimersByTimeAsync(2100);
+          expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(2);
+
+          // Exactly one: nothing moved under the second update, so it starts
+          // no third. This has to be asked on the same clock — a timer left
+          // pending when the fake one is put away never fires, and an
+          // unconditional follow-up would go unnoticed.
+          await vi.advanceTimersByTimeAsync(10_000);
+          expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(2);
+        } finally {
+          vi.useRealTimers();
+        }
+
+        // The filter was rebuilt after each of the two updates.
+        expect(createIgnoreFilter).toHaveBeenCalledTimes(3);
+      });
     });
 
     it("ignores files outside the project tree", async () => {

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -632,6 +632,13 @@ describe("watcher (unit)", () => {
           { path: history, type: "update" },
           { path: installed, type: "create" },
         ])).toBe(0);
+
+        // Removing one file or marker does not change the filter while another
+        // valid environment marker remains at the same root.
+        fs.rmSync(history);
+        expect(await updatesAfter([{ path: history, type: "delete" }])).toBe(0);
+        fs.rmSync(marker());
+        expect(await updatesAfter([{ path: marker(), type: "delete" }])).toBe(0);
       });
 
       it("reconciles once more when an environment reverses while the update runs", async () => {

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -294,6 +294,33 @@ describe("watcher (unit)", () => {
       await expect(stopWatching("/nonexistent")).resolves.not.toThrow();
       expect(mockUnsubscribe).not.toHaveBeenCalled();
     });
+
+    it("does not start a queued update while native unsubscribe is pending", async () => {
+      vi.useFakeTimers();
+      let releaseUnsubscribe: () => void = () => {};
+      const unsubscribePending = new Promise<void>((resolve) => {
+        releaseUnsubscribe = resolve;
+      });
+      mockUnsubscribe.mockReturnValueOnce(unsubscribePending);
+
+      try {
+        await startWatching(TEST_PROJECT);
+        mockSubscribeCallback?.(null, [
+          { path: path.join(RESOLVED_PROJECT, "src/app.ts"), type: "update" },
+        ]);
+        await vi.advanceTimersByTimeAsync(0);
+
+        const stopping = stopWatching(TEST_PROJECT);
+        await vi.advanceTimersByTimeAsync(2100);
+        expect(mockUpdateProjectIndex).not.toHaveBeenCalled();
+
+        releaseUnsubscribe();
+        await stopping;
+      } finally {
+        releaseUnsubscribe();
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("stopAllWatchers", () => {

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -35,7 +35,7 @@ vi.mock("../../src/services/ignore.js", async (importOriginal) => ({
   // The marker test is the real one: it is what the watcher relies on to see
   // an environment appear or vanish, and a stub would prove nothing about it.
   ...(await importOriginal<typeof import("../../src/services/ignore.js")>()),
-  createIgnoreFilter: vi.fn(() => ({ ignores: () => false })),
+  createIgnoreFilter: vi.fn(() => ({ ignores: () => false, isEnvironmentRoot: () => false })),
   shouldIgnore: vi.fn(() => false),
 }));
 
@@ -420,86 +420,161 @@ describe("watcher (unit)", () => {
       vi.useRealTimers();
     });
 
-    it("schedules a reconcile when an environment marker appears, though nothing about it is indexable", async () => {
-      // Review finding. A `pyvenv.cfg` is not a source file, and once the
-      // environment exists its directory is excluded by the filter — so an
-      // event on the marker used to fail both checks and schedule nothing,
-      // leaving the environment's installed libraries in the index until some
-      // unrelated change came along. The marker is recognised before either
-      // check. Here the filter excludes everything, which is the harder case.
-      vi.useFakeTimers();
-      vi.mocked(shouldIgnore).mockReturnValue(true);
+    // ── Environments appearing and vanishing under the watcher ──────────
+    //
+    // Review finding: the filter was built once, at start, and the tree
+    // changes under a watcher. These run on a real directory, because the
+    // gate lets an event through only where the filter and the disk disagree
+    // — a stubbed path would prove nothing about that. `backend/env` rather
+    // than a root `env/`, since the native watcher never reports the latter
+    // (it is skipped at the top level, as `/env` is by the defaults).
+    describe("environments", () => {
+      let root: string;
+      const filterOf = (excluded: (relative: string) => boolean, roots: string[] = []) => ({
+        ignores: excluded,
+        isEnvironmentRoot: (relative: string) => roots.includes(relative.replace(/\/$/, "")),
+      });
+      const underEnv = (relative: string) =>
+        relative === "backend/env" || relative.startsWith("backend/env/");
+      const marker = () => path.join(root, "backend", "env", "pyvenv.cfg");
 
-      await startWatching(TEST_PROJECT);
+      beforeEach(() => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-watch-env-"));
+        vi.useFakeTimers();
+        vi.mocked(shouldIgnore).mockImplementation((ig, relative) => ig.ignores(relative));
+      });
 
-      mockSubscribeCallback?.(null, [
-        { path: path.join(RESOLVED_PROJECT, "crates", "venv", "backend", "env", "pyvenv.cfg"), type: "create" },
-      ]);
-      await vi.advanceTimersByTimeAsync(2100);
-      expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(1);
+      afterEach(async () => {
+        vi.useRealTimers();
+        await stopAllWatchers();
+        vi.mocked(shouldIgnore).mockReturnValue(false);
+        vi.mocked(createIgnoreFilter).mockReset().mockImplementation(() => filterOf(() => false));
+        fs.rmSync(root, { recursive: true, force: true });
+      });
 
-      // Conda's marker is a directory, and its creation arrives as the files
-      // inside it.
-      mockSubscribeCallback?.(null, [
-        { path: path.join(RESOLVED_PROJECT, "tools", "env", "conda-meta", "history"), type: "create" },
-      ]);
-      await vi.advanceTimersByTimeAsync(2100);
-      expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(2);
+      const updatesAfter = async (events: Array<{ path: string; type: "create" | "update" | "delete" }>) => {
+        mockSubscribeCallback?.(null, events);
+        await vi.advanceTimersByTimeAsync(2100);
+        return mockUpdateProjectIndex.mock.calls.length;
+      };
 
-      vi.useRealTimers();
-    });
+      it("schedules a reconcile when a marker appears, though nothing about it is indexable", async () => {
+        // A `pyvenv.cfg` is not a source file, so an event on it used to fail
+        // the indexability check and schedule nothing, leaving the
+        // environment's installed libraries in the index until some unrelated
+        // change came along.
+        vi.mocked(createIgnoreFilter).mockReturnValue(filterOf(() => false));
+        await startWatching(root);
 
-    it("rebuilds its filter after each update, in both directions", async () => {
-      // Review finding. The filter was built once, at start, and the tree
-      // changes under a watcher: a virtualenv created afterwards kept
-      // scheduling updates for every file installed into it, and one removed
-      // kept hiding the source files that took its place. After each
-      // successful update the filter is read off the tree again.
-      vi.useFakeTimers();
-      vi.mocked(shouldIgnore).mockImplementation((ig, relative) => ig.ignores(relative));
-      const nothing = { ignores: () => false };
-      const envExcluded = { ignores: (relative: string) => relative.startsWith("env/") };
-      vi.mocked(createIgnoreFilter)
-        .mockReturnValueOnce(nothing)       // at start: no environment yet
-        .mockReturnValueOnce(envExcluded)   // after the update that saw it appear
-        .mockReturnValueOnce(nothing);      // after the update that saw it go
+        fs.mkdirSync(path.dirname(marker()), { recursive: true });
+        fs.writeFileSync(marker(), "home = /usr\n");
+        expect(await updatesAfter([{ path: marker(), type: "create" }])).toBe(1);
 
-      await startWatching(TEST_PROJECT);
-      expect(createIgnoreFilter).toHaveBeenCalledTimes(1);
+        // Conda's marker is a directory, and its creation arrives as the
+        // files inside it.
+        const history = path.join(root, "tools", "env", "conda-meta", "history");
+        fs.mkdirSync(path.dirname(history), { recursive: true });
+        fs.writeFileSync(history, "");
+        expect(await updatesAfter([{ path: history, type: "create" }])).toBe(2);
+      });
 
-      // The environment appears: its marker schedules the update, and the
-      // filter rebuilt after it now excludes the directory.
-      mockSubscribeCallback?.(null, [
-        { path: path.join(RESOLVED_PROJECT, "env", "pyvenv.cfg"), type: "create" },
-      ]);
-      await vi.advanceTimersByTimeAsync(2100);
-      expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(1);
-      expect(createIgnoreFilter).toHaveBeenCalledTimes(2);
+      it("schedules a reconcile when a marker is deleted from a directory the filter excludes", async () => {
+        // Once the environment exists its directory is excluded, so the
+        // marker's deletion used to be dropped by the filter before anything
+        // looked at it — and the source files written in its place stayed
+        // hidden.
+        vi.mocked(createIgnoreFilter).mockReturnValue(filterOf(underEnv, ["backend/env"]));
+        await startWatching(root);
 
-      // A library installed into it no longer schedules anything.
-      mockSubscribeCallback?.(null, [
-        { path: path.join(RESOLVED_PROJECT, "env", "lib", "dep.py"), type: "create" },
-      ]);
-      await vi.advanceTimersByTimeAsync(2100);
-      expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(1);
+        expect(await updatesAfter([{ path: marker(), type: "delete" }])).toBe(1);
+      });
 
-      // The environment goes: the marker's deletion is seen through the
-      // exclusion, the update runs, and the filter rebuilt after it lets the
-      // source files written in its place through again.
-      mockSubscribeCallback?.(null, [
-        { path: path.join(RESOLVED_PROJECT, "env", "pyvenv.cfg"), type: "delete" },
-      ]);
-      await vi.advanceTimersByTimeAsync(2100);
-      expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(2);
-      expect(createIgnoreFilter).toHaveBeenCalledTimes(3);
+      it("rebuilds its filter after each update, in both directions", async () => {
+        const nothing = filterOf(() => false);
+        const envExcluded = filterOf(underEnv, ["backend/env"]);
+        vi.mocked(createIgnoreFilter)
+          .mockReturnValueOnce(nothing)       // at start: no environment yet
+          .mockReturnValueOnce(envExcluded)   // after the update that saw it appear
+          .mockReturnValueOnce(nothing);      // after the update that saw it go
+        await startWatching(root);
+        expect(createIgnoreFilter).toHaveBeenCalledTimes(1);
 
-      mockSubscribeCallback?.(null, [
-        { path: path.join(RESOLVED_PROJECT, "env", "main.py"), type: "create" },
-      ]);
-      await vi.advanceTimersByTimeAsync(2100);
-      expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(3);
+        // The environment appears: its marker schedules the update, and the
+        // filter rebuilt after it excludes the directory.
+        fs.mkdirSync(path.dirname(marker()), { recursive: true });
+        fs.writeFileSync(marker(), "home = /usr\n");
+        expect(await updatesAfter([{ path: marker(), type: "create" }])).toBe(1);
+        expect(createIgnoreFilter).toHaveBeenCalledTimes(2);
 
-      vi.useRealTimers();
+        // A library installed into it no longer schedules anything.
+        const dep = path.join(root, "backend", "env", "lib", "dep.py");
+        fs.mkdirSync(path.dirname(dep), { recursive: true });
+        fs.writeFileSync(dep, "");
+        expect(await updatesAfter([{ path: dep, type: "create" }])).toBe(1);
+
+        // The environment goes: the marker's deletion is seen through the
+        // exclusion, the update runs, and the filter rebuilt after it lets
+        // the source files written in its place through again.
+        fs.rmSync(marker());
+        expect(await updatesAfter([{ path: marker(), type: "delete" }])).toBe(2);
+        expect(createIgnoreFilter).toHaveBeenCalledTimes(3);
+
+        const source = path.join(root, "backend", "env", "main.py");
+        fs.writeFileSync(source, "");
+        expect(await updatesAfter([{ path: source, type: "create" }])).toBe(3);
+      });
+
+      it("sees an environment moved away, which arrives as one event on its directory", async () => {
+        // Review finding. `mv env env.old` is reported by FSEvents and inotify
+        // as `delete env` and nothing on the marker inside it; the directory
+        // is not a marker and the filter excludes it, so the event was
+        // dropped and the filter stayed stale.
+        vi.mocked(createIgnoreFilter).mockReturnValue(filterOf(underEnv, ["backend/env"]));
+        await startWatching(root);
+
+        expect(await updatesAfter([{ path: path.join(root, "backend", "env"), type: "delete" }])).toBe(1);
+      });
+
+      it("sees an environment moved into place, which arrives as one event on a directory it never heard of", async () => {
+        // The other half of a rename: one `create` on the directory, and the
+        // marker inside it produces nothing. The directory is asked for its
+        // marker on disk.
+        vi.mocked(createIgnoreFilter).mockReturnValue(filterOf(() => false));
+        await startWatching(root);
+
+        fs.mkdirSync(path.dirname(marker()), { recursive: true });
+        fs.writeFileSync(marker(), "home = /usr\n");
+        expect(await updatesAfter([{ path: path.join(root, "backend", "env"), type: "create" }])).toBe(1);
+
+        // A plain directory moved into place is not one.
+        const plain = path.join(root, "backend", "lib");
+        fs.mkdirSync(plain, { recursive: true });
+        expect(await updatesAfter([{ path: plain, type: "create" }])).toBe(1);
+      });
+
+      it("drops a marker event that changes nothing the filter answers", async () => {
+        // Review finding. `conda install` rewrites `conda-meta/` on every run,
+        // and `uv venv` rewrites `pyvenv.cfg`; in an environment the filter
+        // already excludes, each of those used to reconcile the whole tree.
+        // Present on disk and excluded by the filter is agreement, and
+        // agreement schedules nothing.
+        vi.mocked(createIgnoreFilter).mockReturnValue(filterOf(underEnv, ["backend/env"]));
+        await startWatching(root);
+
+        fs.mkdirSync(path.dirname(marker()), { recursive: true });
+        fs.writeFileSync(marker(), "home = /usr\n");
+        const history = path.join(root, "backend", "env", "conda-meta", "history");
+        fs.mkdirSync(path.dirname(history), { recursive: true });
+        fs.writeFileSync(history, "");
+        const installed = path.join(root, "backend", "env", "conda-meta", "numpy.json");
+        fs.writeFileSync(installed, "{}");
+
+        expect(await updatesAfter([
+          { path: marker(), type: "update" },
+          { path: history, type: "update" },
+          { path: installed, type: "create" },
+        ])).toBe(0);
+      });
     });
 
     it("ignores files outside the project tree", async () => {

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -31,7 +31,10 @@ vi.mock("../../src/services/logger.js", () => ({
   },
 }));
 
-vi.mock("../../src/services/ignore.js", () => ({
+vi.mock("../../src/services/ignore.js", async (importOriginal) => ({
+  // The marker test is the real one: it is what the watcher relies on to see
+  // an environment appear or vanish, and a stub would prove nothing about it.
+  ...(await importOriginal<typeof import("../../src/services/ignore.js")>()),
   createIgnoreFilter: vi.fn(() => ({ ignores: () => false })),
   shouldIgnore: vi.fn(() => false),
 }));
@@ -75,7 +78,7 @@ vi.mock("../../src/services/lock.js", () => ({
 }));
 
 import { DETECT_HEAD_BYTES } from "../../src/constants.js";
-import { shouldIgnore } from "../../src/services/ignore.js";
+import { createIgnoreFilter, shouldIgnore } from "../../src/services/ignore.js";
 import { logger } from "../../src/services/logger.js";
 // Import after mocks
 import {
@@ -414,6 +417,88 @@ describe("watcher (unit)", () => {
 
       // All events were filtered by shouldIgnore, so no update
       expect(mockUpdateProjectIndex).not.toHaveBeenCalled();
+      vi.useRealTimers();
+    });
+
+    it("schedules a reconcile when an environment marker appears, though nothing about it is indexable", async () => {
+      // Review finding. A `pyvenv.cfg` is not a source file, and once the
+      // environment exists its directory is excluded by the filter — so an
+      // event on the marker used to fail both checks and schedule nothing,
+      // leaving the environment's installed libraries in the index until some
+      // unrelated change came along. The marker is recognised before either
+      // check. Here the filter excludes everything, which is the harder case.
+      vi.useFakeTimers();
+      vi.mocked(shouldIgnore).mockReturnValue(true);
+
+      await startWatching(TEST_PROJECT);
+
+      mockSubscribeCallback?.(null, [
+        { path: path.join(RESOLVED_PROJECT, "crates", "venv", "backend", "env", "pyvenv.cfg"), type: "create" },
+      ]);
+      await vi.advanceTimersByTimeAsync(2100);
+      expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(1);
+
+      // Conda's marker is a directory, and its creation arrives as the files
+      // inside it.
+      mockSubscribeCallback?.(null, [
+        { path: path.join(RESOLVED_PROJECT, "tools", "env", "conda-meta", "history"), type: "create" },
+      ]);
+      await vi.advanceTimersByTimeAsync(2100);
+      expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it("rebuilds its filter after each update, in both directions", async () => {
+      // Review finding. The filter was built once, at start, and the tree
+      // changes under a watcher: a virtualenv created afterwards kept
+      // scheduling updates for every file installed into it, and one removed
+      // kept hiding the source files that took its place. After each
+      // successful update the filter is read off the tree again.
+      vi.useFakeTimers();
+      vi.mocked(shouldIgnore).mockImplementation((ig, relative) => ig.ignores(relative));
+      const nothing = { ignores: () => false };
+      const envExcluded = { ignores: (relative: string) => relative.startsWith("env/") };
+      vi.mocked(createIgnoreFilter)
+        .mockReturnValueOnce(nothing)       // at start: no environment yet
+        .mockReturnValueOnce(envExcluded)   // after the update that saw it appear
+        .mockReturnValueOnce(nothing);      // after the update that saw it go
+
+      await startWatching(TEST_PROJECT);
+      expect(createIgnoreFilter).toHaveBeenCalledTimes(1);
+
+      // The environment appears: its marker schedules the update, and the
+      // filter rebuilt after it now excludes the directory.
+      mockSubscribeCallback?.(null, [
+        { path: path.join(RESOLVED_PROJECT, "env", "pyvenv.cfg"), type: "create" },
+      ]);
+      await vi.advanceTimersByTimeAsync(2100);
+      expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(1);
+      expect(createIgnoreFilter).toHaveBeenCalledTimes(2);
+
+      // A library installed into it no longer schedules anything.
+      mockSubscribeCallback?.(null, [
+        { path: path.join(RESOLVED_PROJECT, "env", "lib", "dep.py"), type: "create" },
+      ]);
+      await vi.advanceTimersByTimeAsync(2100);
+      expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(1);
+
+      // The environment goes: the marker's deletion is seen through the
+      // exclusion, the update runs, and the filter rebuilt after it lets the
+      // source files written in its place through again.
+      mockSubscribeCallback?.(null, [
+        { path: path.join(RESOLVED_PROJECT, "env", "pyvenv.cfg"), type: "delete" },
+      ]);
+      await vi.advanceTimersByTimeAsync(2100);
+      expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(2);
+      expect(createIgnoreFilter).toHaveBeenCalledTimes(3);
+
+      mockSubscribeCallback?.(null, [
+        { path: path.join(RESOLVED_PROJECT, "env", "main.py"), type: "create" },
+      ]);
+      await vi.advanceTimersByTimeAsync(2100);
+      expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(3);
+
       vi.useRealTimers();
     });
 

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -552,6 +552,27 @@ describe("watcher (unit)", () => {
         expect(await updatesAfter([{ path: plain, type: "create" }])).toBe(1);
       });
 
+      it("sees a dot-named environment moved into place", async () => {
+        // Review finding. `backend/venv.3.12` moved in is one `create` on the
+        // directory; a first cut read the dot as a file extension and skipped
+        // the stat, so the event was dropped and the environment's files
+        // stayed indexed until something unrelated changed. Every created
+        // path is asked whether it is a directory first.
+        vi.mocked(createIgnoreFilter).mockReturnValue(filterOf(() => false));
+        await startWatching(root);
+
+        const dotted = path.join(root, "backend", "venv.3.12");
+        fs.mkdirSync(dotted, { recursive: true });
+        fs.writeFileSync(path.join(dotted, "pyvenv.cfg"), "home = /usr\n");
+        expect(await updatesAfter([{ path: dotted, type: "create" }])).toBe(1);
+
+        // A created *file* with an extension still costs one stat and no more:
+        // it is not a directory, and nothing else is asked of it here.
+        const image = path.join(root, "backend", "logo.png");
+        fs.writeFileSync(image, "");
+        expect(await updatesAfter([{ path: image, type: "create" }])).toBe(1);
+      });
+
       it("drops a marker event that changes nothing the filter answers", async () => {
         // Review finding. `conda install` rewrites `conda-meta/` on every run,
         // and `uv venv` rewrites `pyvenv.cfg`; in an environment the filter

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -658,6 +658,14 @@ describe("watcher (unit)", () => {
           // like nothing happened.
           fs.rmSync(marker());
           mockSubscribeCallback?.(null, [{ path: marker(), type: "delete" }]);
+
+          // An ordinary source event in the same window must join the pending
+          // reconciliation rather than start a competing update and clear the
+          // remembered environment reversal.
+          const source = path.join(root, "backend", "app.ts");
+          fs.writeFileSync(source, "export const value = 1;\n");
+          mockSubscribeCallback?.(null, [{ path: source, type: "update" }]);
+
           await vi.advanceTimersByTimeAsync(2100);
           // No second update while the first still holds the lock: that one
           // would return zeros and reconcile nothing.
@@ -679,6 +687,42 @@ describe("watcher (unit)", () => {
 
         // The filter was rebuilt after each of the two updates.
         expect(createIgnoreFilter).toHaveBeenCalledTimes(3);
+      });
+
+      it("drops a deferred reconciliation when the watcher stops", async () => {
+        vi.mocked(createIgnoreFilter).mockReturnValue(filterOf(() => false));
+        await startWatching(root);
+
+        let releaseUpdate: () => void = () => {};
+        const updateStarted = new Promise<void>((updateIsRunning) => {
+          mockUpdateProjectIndex.mockImplementationOnce(async () => {
+            updateIsRunning();
+            await new Promise<void>((resolve) => {
+              releaseUpdate = resolve;
+            });
+            return { added: 0, updated: 0, removed: 0, chunksCreated: 0, cancelled: false };
+          });
+        });
+
+        fs.mkdirSync(path.dirname(marker()), { recursive: true });
+        fs.writeFileSync(marker(), "home = /usr\n");
+
+        vi.useFakeTimers();
+        try {
+          mockSubscribeCallback?.(null, [{ path: marker(), type: "create" }]);
+          await vi.advanceTimersByTimeAsync(2100);
+          await updateStarted;
+
+          fs.rmSync(marker());
+          mockSubscribeCallback?.(null, [{ path: marker(), type: "delete" }]);
+          await stopWatching(root);
+
+          releaseUpdate();
+          await vi.advanceTimersByTimeAsync(10_000);
+          expect(mockUpdateProjectIndex).toHaveBeenCalledTimes(1);
+        } finally {
+          vi.useRealTimers();
+        }
       });
     });
 

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -440,21 +440,31 @@ describe("watcher (unit)", () => {
 
       beforeEach(() => {
         root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-watch-env-"));
-        vi.useFakeTimers();
         vi.mocked(shouldIgnore).mockImplementation((ig, relative) => ig.ignores(relative));
       });
 
       afterEach(async () => {
-        vi.useRealTimers();
         await stopAllWatchers();
         vi.mocked(shouldIgnore).mockReturnValue(false);
         vi.mocked(createIgnoreFilter).mockReset().mockImplementation(() => filterOf(() => false));
         fs.rmSync(root, { recursive: true, force: true });
       });
 
+      // Fake timers live inside this call alone: the debounce is created and
+      // fired here, and nothing else in these tests needs a clock. Installed
+      // in `beforeEach` and restored in `afterEach`, they left vitest's own
+      // hook clock counting on the fake one, and on Node 18 every hook of the
+      // block was reported as timed out after it had already returned (CI
+      // finding); the rest of this file switches them inside the test body
+      // for the same reason.
       const updatesAfter = async (events: Array<{ path: string; type: "create" | "update" | "delete" }>) => {
-        mockSubscribeCallback?.(null, events);
-        await vi.advanceTimersByTimeAsync(2100);
+        vi.useFakeTimers();
+        try {
+          mockSubscribeCallback?.(null, events);
+          await vi.advanceTimersByTimeAsync(2100);
+        } finally {
+          vi.useRealTimers();
+        }
         return mockUpdateProjectIndex.mock.calls.length;
       };
 


### PR DESCRIPTION
Split out of #118 as requested there. `ignore.ts`, `watcher.ts` and their tests; nothing Rust-specific in the diff, though the motivating case came from a Rust tree.

## What changes

`env` and `venv` were ignored by name at every depth. In Rust those are ordinary module names — `clap_complete/src/env/mod.rs` is compiled by cargo and listed in its dep-info, yet was not even a node of the graph, while `pub mod engine;` two lines above it drew its edges. Same for `tracing-subscriber/src/filter/env/`.

They are anchored to the project root now, and what that gives up is covered by proof instead of by name: a virtualenv is found by the `pyvenv.cfg` PEP 405 puts at its root, a conda environment by its `conda-meta/`, each read in the shape its tool writes (a file, a directory — and as what it is, never as what a symlink points to), in the walk that was already reading nested `.gitignore` files.

A discovered environment is kept as the literal prefix it is, not written as a gitignore pattern. The pattern route needed an escape for every character the syntax reads specially, and the escape was only as good as the installed package's reading of it: `ignore` 7 does not understand `\?`, so an environment at `env?/` was scanned despite its marker, while the other five happened to work. The module hands out its own `IgnoreFilter` — `ignores()` and `isEnvironmentRoot()` — with the `ignore` instance behind it; every consumer already went through `createIgnoreFilter` and `shouldIgnore`, so none changes. A negation written later in `.socraticodeignore` still wins over a discovered prefix, as it did over the pattern: that is how a checked-in fixture venv is kept.

The walk no longer skips `venv` by name, so a marker nested under a directory so called is reached (`crates/venv/backend/env/` had its installed libraries indexed); `venv` and `env` are still skipped directly under the root, where `/venv` and `/env` have already excluded them.

## The watcher

The filter's rules are read off the tree, and the tree changes under a watcher. The watcher's filter is replaceable now, rebuilt after each successful update; an environment appearing or vanishing is recognised before the indexability and ignore checks — as a marker event, as a directory event on a known environment root (`mv env env.old` arrives as one `delete env` and nothing on the marker), or as a created directory carrying a marker — and schedules the reconciliation, but only where the filter and the disk disagree, so `conda install` rewriting `conda-meta/` in an environment already excluded does not reconcile the whole tree.

## Measured

Against current `main` (`cacbac4`), node for node: ripgrep and tokio unchanged, clap gains `clap_complete/src/env/mod.rs` and `shells.rs`. Flask, requests, vscode-eslint and this repo were measured the same way in an earlier round and did not move. `ignore` 7.0.6 on the escaped patterns, before the change: `\?` false, the other five true. `@parcel/watcher` resolves a bare `venv`/`env` in its skip list to `<root>/venv`, top level only — the same anchoring — so a nested marker still produces its event. Building the filter on a 1,916-directory tree: 121 ms against 125 ms on `main`.

Each change fails alone under its own mutant; `tsc`, lint and the full suite (1,633 on this branch) green.

#118 is rebased on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detects Python virtual environments and Conda environments, including nested environments.
  * Supports environment names containing special characters and symbolic-link markers.
  * Recognizes environment changes across platforms and triggers updates when environments are created or removed.

* **Bug Fixes**
  * Preserves source directories that share names with common environment directories.
  * Keeps ignore rules current as project files and environments change.
  * Correctly applies ignore-rule overrides and detects environments regardless of ignore settings.
  * Prevents unnecessary updates for environment events that do not change project state.
  * Ensures changes during an update trigger one follow-up reconciliation.
  * Prevents deferred updates after the watcher is stopped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->