### PR TITLE
fix(symbols): read the Rust items that are not functions (#140)

### DIFF
--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -87,6 +87,26 @@ function safeFindAll(node: any, kind: string): any[] {
 }
 
 /**
+ * Several kinds in one traversal. `findAll` walks the whole tree per call, so
+ * asking for n kinds separately reads the file n times.
+ *
+ * The failure mode differs from n calls to {@link safeFindAll}, deliberately:
+ * ast-grep throws on a kind the grammar does not define, so one kind absent
+ * from the grammar loses the whole set here, where separate calls would lose
+ * only that kind. Losing the set is the louder failure, and the caller's tests
+ * name every kind it asks for — a grammar that dropped one would turn a test
+ * red instead of quietly returning fewer symbols.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+function safeFindAllAny(node: any, kinds: string[]): any[] {
+  try {
+    return node.findAll({ rule: { any: kinds.map((kind) => ({ kind })) } });
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Single-node counterpart of {@link safeFindAll}. ast-grep REJECTS a kind the
  * grammar does not define — it throws rather than returning null — so a direct
  * `node.find({rule:{kind}})` written with a `?? find(otherKind)` fallback never
@@ -1738,6 +1758,76 @@ function extractFromRust(
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
   }
 
+  // Everything a Rust file declares that is not a function. Only `function_item`
+  // was read, so every type a crate exposes was absent from the symbol graph:
+  // `codebase_symbol` could not find a struct, an enum or a trait by name, and
+  // resolution — which matches a callee name against the symbols of the files
+  // the file graph says are imported — had nothing to match a type against.
+  //
+  // The name comes from the `name` field, which the grammar gives each of
+  // these: a `type_identifier` for the type-like ones, an `identifier` for the
+  // value-like ones. Searching for a bare `identifier` instead would take the
+  // wrong child — a struct's first `identifier` is its first field.
+  //
+  // `impl_item` and `use_declaration` are not in the table, but for different
+  // reasons, and only one of them means "not read". `safeFindAll` walks the
+  // whole tree, so what an impl *contains* is read: its methods as
+  // `function_item`, and an associated `type` or `const` through this table —
+  // under a bare name, without the implementing type, the way a method's name
+  // is already bare. Two impls of one trait therefore yield two symbols of the
+  // same associated name; the trait's own `type Item;` yields none, being an
+  // `associated_type` rather than a `type_item`. Both are stated in the pull
+  // request as limits rather than fixed here: qualifying a name is a change to
+  // how every language in this file names a member.
+  //
+  // A `use` is genuinely not an item: what it names is declared elsewhere, and
+  // the file graph already carries that edge.
+  //
+  // `isExported` is left unset, as it already is for `fn` above. The resolver
+  // admits a symbol unless that flag is explicitly `false`, so writing `pub`
+  // into it would silently drop every private item from resolution — a change
+  // of behaviour rather than an extraction fix.
+  //
+  // The kinds are the ones this file already gives these shapes elsewhere,
+  // checked by running those extractors rather than by reading them: C++ and C#
+  // yield `struct` for a struct, Scala and PHP yield `trait` for a trait.
+  // (`extractFromSwift` reads as a fifth precedent and is not one — its
+  // `struct` branch keys on `struct_declaration`, which the packaged grammar
+  // never produces, so a Swift struct comes out `class`.) A `union` has no
+  // precedent here; it is a record like a struct and is filed as one.
+  const RUST_ITEM_KINDS = new Map<string, SymbolNode["kind"]>([
+    ["struct_item", "struct"],
+    ["union_item", "struct"],
+    ["enum_item", "enum"],
+    ["trait_item", "trait"],
+    ["type_item", "type"],
+    ["const_item", "variable"],
+    ["static_item", "variable"],
+  ]);
+  // One pass, not one per kind: `findAll` walks the whole tree each time it is
+  // called, so seven calls read the file seven times. Measured on ripgrep's
+  // `crates/core/flags/defs.rs`, seven passes cost +51% over `main` on this
+  // function and one costs +18%.
+  for (const item of safeFindAllAny(root, [...RUST_ITEM_KINDS.keys()])) {
+    const symbolKind = RUST_ITEM_KINDS.get(item.kind());
+    if (!symbolKind) continue;
+    const nameNode = item.field("name");
+    if (!nameNode) continue;
+    const name = nameNode.text();
+    const r = item.range();
+    const startLine = r.start.line + 1;
+    symbols.push({
+      id: makeId(file, name, startLine),
+      name,
+      qualifiedName: name,
+      kind: symbolKind,
+      file,
+      line: startLine,
+      endLine: r.end.line + 1,
+      language,
+    });
+  }
+
   const rawCalls: ExtractedSymbols["rawCalls"] = [];
   for (const node of safeFindAll(root, "call_expression")) {
     const calleeName = extractCalleeNameJs(node.text());
@@ -1763,6 +1853,19 @@ function extractFromRust(
       callSite: { file, line: callLine },
     });
   }
+
+  // In declaration order, because a reader is shown a prefix of this list and
+  // not all of it: `listSymbols` cuts at its limit in payload order. Collected
+  // in two passes — functions, then everything else — the items would all sit
+  // after the functions, and on ripgrep 14.1.1's `crates/core/flags/defs.rs`
+  // (982 symbols, limit 200) not one of them appeared. Sorting by line
+  // also stops the listing from jumping backwards, which is how it read before.
+  // Name breaks a tie, so two items declared on one line keep a fixed order.
+  // That tie-break can move `<module>` off the head of the list — an item named
+  // `_HIDDEN` on line 1 sorts before it — which is harmless: every consumer
+  // that wants the module symbol looks it up by name, none by position.
+  symbols.sort((a, b) => a.line - b.line || a.name.localeCompare(b.name));
+
   return { symbols, rawCalls };
 }
 

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -1740,8 +1740,11 @@ function extractFromRust(
   moduleSym: SymbolNode,
 ): ExtractedSymbols {
   const root = parse("rust" as unknown as Lang, source).root();
-  const symbols: SymbolNode[] = [moduleSym];
   const scopes: ScopeFrame[] = [];
+  // Collected with the byte offset each declaration starts at, because that is
+  // the only key that orders two declarations sharing a line. See the sort at
+  // the end of this function.
+  const declared: Array<{ sym: SymbolNode; offset: number }> = [];
 
   for (const fn of safeFindAll(root, "function_item")) {
     const nameNode = safeFind(fn, "identifier");
@@ -1754,7 +1757,7 @@ function extractFromRust(
       id: makeId(file, name, startLine),
       name, qualifiedName: name, kind: "function", file, line: startLine, endLine, language,
     };
-    symbols.push(sym);
+    declared.push({ sym, offset: r.start.index });
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
   }
 
@@ -1816,15 +1819,18 @@ function extractFromRust(
     const name = nameNode.text();
     const r = item.range();
     const startLine = r.start.line + 1;
-    symbols.push({
-      id: makeId(file, name, startLine),
-      name,
-      qualifiedName: name,
-      kind: symbolKind,
-      file,
-      line: startLine,
-      endLine: r.end.line + 1,
-      language,
+    declared.push({
+      sym: {
+        id: makeId(file, name, startLine),
+        name,
+        qualifiedName: name,
+        kind: symbolKind,
+        file,
+        line: startLine,
+        endLine: r.end.line + 1,
+        language,
+      },
+      offset: r.start.index,
     });
   }
 
@@ -1858,13 +1864,19 @@ function extractFromRust(
   // not all of it: `listSymbols` cuts at its limit in payload order. Collected
   // in two passes — functions, then everything else — the items would all sit
   // after the functions, and on ripgrep 14.1.1's `crates/core/flags/defs.rs`
-  // (982 symbols, limit 200) not one of them appeared. Sorting by line
-  // also stops the listing from jumping backwards, which is how it read before.
-  // Name breaks a tie, so two items declared on one line keep a fixed order.
-  // That tie-break can move `<module>` off the head of the list — an item named
-  // `_HIDDEN` on line 1 sorts before it — which is harmless: every consumer
-  // that wants the module symbol looks it up by name, none by position.
-  symbols.sort((a, b) => a.line - b.line || a.name.localeCompare(b.name));
+  // (982 symbols, limit 200) not one of them appeared.
+  //
+  // The key is the byte offset the declaration starts at, not the line and not
+  // the name. Rust puts no weight on line breaks, so `const A: u8 = 1; const
+  // B: u8 = 2;` is two declarations on one line; ordering those by name would
+  // put a later declaration first, and at the limit boundary that is a listing
+  // that drops the earlier one. An offset is unique per declaration, so the
+  // order is total and is the source's own.
+  //
+  // `<module>` is prepended rather than sorted: it is synthetic, it has no
+  // offset of its own, and it belongs at the head.
+  declared.sort((a, b) => a.offset - b.offset);
+  const symbols: SymbolNode[] = [moduleSym, ...declared.map((d) => d.sym)];
 
   return { symbols, rawCalls };
 }

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -4,6 +4,7 @@
 import { Lang } from "@ast-grep/napi";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { ensureDynamicLanguages } from "../../src/services/code-graph.js";
+import { listSymbols } from "../../src/services/graph-impact.js";
 import {
   extractSymbolsAndCalls,
   rawCallsToUnresolvedEdges,
@@ -299,6 +300,37 @@ pub enum Fifth { A }
         "fourth",
         "Fifth",
       ]);
+    });
+
+    it("keeps source order for declarations sharing a line, through a limited listing", () => {
+      // Rust puts no weight on line breaks, so several items can share a line.
+      // Ordering those by name would put a later declaration before an earlier
+      // one, and `listSymbols` cuts at its limit in payload order — so at the
+      // boundary the earlier declaration is the one that disappears. The key is
+      // the byte offset, which no two declarations share.
+      const src = "pub const ZULU: u8 = 1; pub struct Alpha; pub const Mike: u8 = 2;\n";
+      const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
+      expect(out.symbols.map((s) => s.name)).toEqual(["<module>", "ZULU", "Alpha", "Mike"]);
+      expect(out.symbols[0].name).toBe("<module>");
+
+      // And through the reader that does the cutting. A limit of 1 must show
+      // the first declaration of the line, not the alphabetically first.
+      const payload = {
+        file: "crates/x/src/lib.rs",
+        language: "rust",
+        contentHash: "",
+        symbols: out.symbols,
+        outgoingCalls: [],
+      };
+      const release = Object.assign(() => {}, { token: Symbol("reader") });
+      const cache = {
+        acquireReader: () => release,
+        getFilePayload: async () => payload,
+      } as unknown as Parameters<typeof listSymbols>[0];
+
+      return listSymbols(cache, { file: "crates/x/src/lib.rs", limit: 1 }).then((shown) => {
+        expect(shown.map((s) => s.name)).toEqual(["ZULU"]);
+      });
     });
 
     it("reads an associated type and const inside an impl, under a bare name", () => {

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -218,6 +218,111 @@ impl S {
       expect(names).toContain("foo");
       expect(names).toContain("bar");
       expect(out.symbols.some((s) => s.name === "<module>")).toBe(true);
+      // The fixture above already declared `struct S`, and nothing asserted it:
+      // only `function_item` was read, so every type a crate exposes was
+      // invisible to symbol lookup.
+      expect(names).toContain("S");
+    });
+
+    it("extracts the items that are not functions, each under its own kind", () => {
+      const src = `
+pub struct Config { pub a: u32 }
+pub union Either { a: u32, b: f32 }
+pub enum Mode { One, Two }
+pub trait Speaks { fn say(&self); }
+pub type Alias = Config;
+pub const LIMIT: u32 = 3;
+pub static NAME: &str = "x";
+pub fn build() -> Config { Config { a: 0 } }
+`;
+      const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
+      const byName = new Map(out.symbols.map((s) => [s.name, s.kind]));
+      // The kinds this file already gives these shapes: `struct` as C++, C# and
+      // Swift give it, `trait` as Scala and PHP give it.
+      expect(byName.get("Config")).toBe("struct");
+      expect(byName.get("Either")).toBe("struct");
+      expect(byName.get("Mode")).toBe("enum");
+      expect(byName.get("Speaks")).toBe("trait");
+      expect(byName.get("Alias")).toBe("type");
+      expect(byName.get("LIMIT")).toBe("variable");
+      expect(byName.get("NAME")).toBe("variable");
+      // The function was already read; the point is that it still is.
+      expect(byName.get("build")).toBe("function");
+    });
+
+    it("gives a Rust item the line it is declared on", () => {
+      // A symbol whose position is wrong is worse than one that is missing: the
+      // id is built from the line, so two items would collide or a lookup would
+      // send the reader to the wrong place.
+      const src = "\n\npub enum Mode { One }\n";
+      const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
+      const mode = out.symbols.find((s) => s.name === "Mode");
+      expect(mode?.line).toBe(3);
+      expect(mode?.endLine).toBe(3);
+    });
+
+    it("reads both declarations of one name under opposite cfgs", () => {
+      // The graph has no feature resolution, so both are read — the same rule
+      // the file graph already follows for `mod` under `#[cfg]`. On separate
+      // lines their ids differ, because `makeId` carries the line. Two items of
+      // one name on the *same* line would share an id; that is a property of
+      // `makeId`, not of this extractor, and the pull request says so.
+      const src = `
+#[cfg(unix)] pub struct Sys { pub a: u32 }
+#[cfg(windows)] pub struct Sys { pub b: u32 }
+`;
+      const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
+      const sys = out.symbols.filter((s) => s.name === "Sys");
+      expect(sys).toHaveLength(2);
+      expect(new Set(sys.map((s) => s.id)).size).toBe(2);
+      expect(sys.map((s) => s.line).sort()).toEqual([2, 3]);
+    });
+
+    it("returns the symbols in declaration order", () => {
+      // A reader is shown a prefix of this list, not all of it: `listSymbols`
+      // cuts at its limit in payload order. Collected in two passes the items
+      // would all sit behind the functions, and on ripgrep's
+      // `crates/core/flags/defs.rs` not one appeared under a limit of 200.
+      const src = `
+pub const FIRST: u32 = 1;
+pub fn second() {}
+pub struct Third;
+pub fn fourth() {}
+pub enum Fifth { A }
+`;
+      const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
+      expect(out.symbols.map((s) => s.name)).toEqual([
+        "<module>",
+        "FIRST",
+        "second",
+        "Third",
+        "fourth",
+        "Fifth",
+      ]);
+    });
+
+    it("reads an associated type and const inside an impl, under a bare name", () => {
+      // `safeFindAll` walks the whole tree, so an impl's contents are read.
+      // The name carries no owner, the way a method's name already does not —
+      // two impls of one trait therefore give two symbols of the same name.
+      // Documented rather than changed: qualifying a name is a change to how
+      // every language in this file names a member.
+      const src = `
+pub trait Conv { type Out; }
+pub struct A;
+pub struct B;
+impl Conv for A { type Out = u32; }
+impl Conv for B { type Out = u64; }
+impl A { pub const MAX: u32 = 9; }
+`;
+      const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
+      const outs = out.symbols.filter((s) => s.name === "Out");
+      expect(outs).toHaveLength(2);
+      expect(outs.every((s) => s.kind === "type")).toBe(true);
+      expect(out.symbols.some((s) => s.name === "MAX" && s.kind === "variable")).toBe(true);
+      // The trait's own declaration is an `associated_type`, not a `type_item`,
+      // so the declaration a reader looks for is the one that is missing.
+      expect(out.symbols.filter((s) => s.name === "Out").every((s) => s.line > 4)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

`extractFromRust` reads `function_item` and nothing else. Every other item a Rust file declares — `struct`, `union`, `enum`, `trait`, `type`, `const`, `static` — never becomes a symbol, so `codebase_symbol` and `codebase_symbols` cannot find a Rust type by name at all, and the symbols of a file that declares no functions are just the synthetic `<module>`.

On the same source, before and after — counting declared symbols, not the synthetic per-file `<module>`, which is the convention `persistSymbolGraph` uses for `meta.symbolCount` and therefore what `codebase_graph_status` reports:

| | `main` | this branch |
|---|---|---|
| symbols extracted | **1** | **8** |

```rust
pub struct Config { pub a: u32 }
pub union Either { a: u32, b: f32 }
pub enum Mode { One, Two }
pub trait Speaks { fn say(&self); }
pub type Alias = Config;
pub const LIMIT: u32 = 3;
pub static NAME: &str = "x";
pub fn build() -> Config { Config { a: 0 } }
```

`main` returns `build` alone. Measured through `extractSymbolsAndCalls` directly, so the number is the extractor's and not an index's.

That measurement is the reproducible one: it is a test in this PR, so it can be re-run without my machine.

For corroboration on real code, three trees — two of them public, so the numbers below can be re-taken without my machine:

| tree | files in graph | symbols `main` | symbols here | |
|---|---|---|---|---|
| tokio 1.40.0 | 505 | 4,812 | **5,981** | +1,169 |
| ripgrep 14.1.1 | 33 | 1,107 | **1,297** | +190 |
| a private 363-file app | 363 | 4,660 | **5,605** | +945 |

(Same convention: `<module>` excluded, so these are the counts `codebase_graph_status` shows. With it counted the totals are 505/33/363 higher.)

On the private one, `codebase_symbol HomeMechanism` — an enum — now answers `enum, crates/profiles/src/lib.rs:15–24` where it previously found nothing.

This is the Rust side of the gap #132 described for TypeScript ("non-function exports (const/type/interface)"), which #135 closed there. `extractFromGo` has the same shape and is untouched here: one language per change.

## Changes

`src/services/graph-symbols.ts`, `extractFromRust`: a table of the item kinds the grammar defines, each mapped to the symbol kind this file already gives that shape — `struct`/`union` → `struct`, `enum` → `enum`, `trait` → `trait`, `type` → `type`, `const`/`static` → `variable`. Plus one helper, `safeFindAllAny`, so the seven kinds are found in one traversal.

Four decisions are worth stating, because each has a wrong answer that looks right:

- **The kinds are `struct` and `trait`, not `class` and `interface`.** `SymbolKind` carries both, and they are not decorative. Run rather than read — the two are not the same thing here — a `struct` in and a `struct` out: `extractFromCFamily` gives it for C++ and `extractFromCSharp` for C#; `extractFromJvm` gives a Scala trait `trait`, and `extractFromPhp` a PHP one. Rust is the language those two names came from, so filing its structs as `class` would have been the odd one out. The viewer already colours both (`src/assets/viewer-app.js`), identically to `class` and `interface`, so nothing renders differently — only the label `codebase_symbol` prints. (`extractFromSwift` looks like a fifth precedent and is not: it maps `struct_declaration` to `struct`, but the packaged Swift grammar files a struct under `class_declaration`, so that branch never fires and Swift structs come out as `class`. That is a defect of its own and not this PR's to fix; I mention it only because it would otherwise look like a precedent I had miscounted.)
- **The name comes from the `name` field**, not from a search for the first `identifier` child. A `struct`'s first `identifier` is its first *field*, so searching would name `Config` after `a`. Checked against the grammar rather than assumed: the type-like items carry a `type_identifier` there, the value-like ones an `identifier`.
- **`impl_item` and `use_declaration` are not here.** An impl's methods are already `function_item` — `safeFindAll` walks the whole tree — and a `use` declares no item: what it names is declared elsewhere, and the file graph already carries that edge.
- **`isExported` is left unset**, exactly as it already is for `fn`. The resolver admits a symbol unless the flag is explicitly `false`, so writing `pub` into it would silently drop every private item from resolution. That is a change of behaviour, not an extraction fix, and it belongs in its own change if it is wanted.

And the extractor now returns its symbols **in declaration order**. This is not tidiness: `listSymbols` cuts at its limit in payload order, so items collected in a second pass all sat behind the functions, and on any file with more than the limit of them **not one of the new symbols would appear** — the change would have been invisible exactly where a listing is most needed. Measured, at the default limit of 200:

| file | symbols | new ones shown, unsorted | sorted |
|---|---|---|---|
| ripgrep `crates/core/flags/defs.rs` | 982 | **0** | 23 |
| private app `crates/actions/src/lib.rs` | 331 | **0** | 60 |
| private app `crates/sailor/src/flow_cmd.rs` | 287 | **0** | 42 |

The order is the byte offset each declaration starts at, so it is the source's own and it is total — Rust puts no weight on line breaks, and several declarations can share a line. Below the limit nothing changes but the reading order, which stopped jumping backwards. `<module>` is prepended rather than sorted.

## What it costs

`findAll` walks the whole tree per call, so asking for the seven kinds one at a time reads each file seven times. That is what a first draft of this change did, and it is worth its own line because a PR that reports the unresolved percentage to two decimals and says nothing about the time it added is measuring only what flatters it. Median of five runs of twenty extractions each, after a warm-up run:

| file | `main` | seven passes | one pass (this branch) |
|---|---|---|---|
| ripgrep `crates/core/flags/defs.rs` (983 symbols) | 36.9 ms | 57.4 ms (**+56%**) | **39.9 ms (+8%)** |
| private app `crates/sailor/src/flow_cmd.rs` (288 symbols) | 30.7 ms | 51.4 ms (**+67%**) | **34.1 ms (+11%)** |

The remaining 8–11% is the work itself: ~20% more symbols to build, and one sort. One pass and seven produce **byte-identical** resolution output on all three trees, and identical symbol lists — id, kind, line and position included. Unconditionally, since the sort key is the byte offset and no two declarations share one; an earlier revision of this branch broke the tie by name, which did make the two differ on declarations sharing a line.

`safeFindAllAny` fails differently from seven `safeFindAll` calls, on purpose: ast-grep throws on a kind the grammar does not define, so one missing kind loses the whole set here where separate calls would lose only that kind. Losing the set is the louder failure — the test names all seven kinds, so a grammar that dropped one turns a test red instead of quietly returning fewer symbols.

## What this does **not** change, measured

I would rather state these than have them found in review.

- **Unresolved call edges barely move**: 72.59% → 71.79% on tokio, 59.03% → 58.82% on ripgrep, 71.15% → 70.83% on the private tree. Rust call edges are produced only from `call_expression` and `macro_invocation`, and a type is not called. Extracting types gives resolution something to *match*, but nothing yet *refers* to them. Closing that gap means emitting reference edges for type positions, which is a separate and much larger change.
- **`codebase_impact` on a re-export-only crate root still answers 0.** I first read that as a Rust defect and it is not: three TypeScript barrel files (`index.ts`, 15–20 re-exports, no declarations of their own) answer 0 as well, on the language whose symbol support #135 has just overhauled. A file that declares no symbols has no dependents in a symbol-level model, in any language. Whether that is the right answer for a barrel is a design question, not a bug, and it is not what this change addresses.
- **The file-import graph is untouched** — the full `relativePath|sorted dependencies` signature of every node is byte-identical before and after, on all three trees.
- **Entry points move slightly, and only in one category.** `detectEntryPoints` marks a symbol `test` when its name matches `/^Test[A-Z_]/`, so Rust test-support structs now qualify: 487 → 497 on the private tree (`TestStore`, `TestDirectory`), 324 → 326 on tokio, 115 → 116 on ripgrep. Every other reason is unchanged. It is the same additive noise TypeScript classes already produce there; I mention it because "nothing downstream changed" would have been false.

And what it does not make *worse*, which is the question I would ask of a change that adds ~20% more symbols. Across **50,605 call edges** on the three trees, resolved and compared one edge at a time:

| tree | edges | changed | transitions |
|---|---|---|---|
| tokio 1.40.0 | 18,726 | 148 | 136 `unresolved → local`, 10 `unresolved → unique`, 1 pair `unresolved,unresolved → local,local`, 1 `unresolved → local` with 2 candidates |
| ripgrep 14.1.1 | 3,708 | 8 | 8 `unresolved → local` |
| private app | 28,171 | 91 | 90 `unresolved → local`, 1 `unresolved → unique` |

Every transition is `unresolved` becoming resolved. **No edge regresses**, and `multiple-candidates` is unchanged on all three (320 → 320, 72 → 72, 52 → 52). The reason is structural: the new symbols are `PascalCase` and `SCREAMING_CASE`, while the callee names Rust produces are `snake_case` functions and `PascalCase` tuple-struct constructions, so the collision surface is small by convention rather than by a guard in the code.

Two notes on how that was measured, because a comparison like this is easy to do in a way that cannot see a regression:

- Edges are keyed on `file#line#callee#caller#kind`, and **several edges can share that key** — `f(g(), g())` on one line gives two. Keeping one row per key silently merged 2,759 of tokio's and the private tree's edges, which would have hidden any regression inside a merged group. Each key therefore carries the sorted multiset of its edges' outcomes; one of tokio's changes is only visible that way.
- The comparison was checked against a change that **must** regress: an extractor that declares every `identifier` a symbol. It changes 2,644 of ripgrep's 3,047 keys, 69 of them `unique → multiple-candidates` — so an absent regression above is an absence, not a blind spot.

Both public trees are one `curl` away (`static.crates.io/crates/tokio/tokio-1.40.0.crate`, `.../ripgrep/ripgrep-14.1.1.crate`); the whole comparison is `buildCodeGraph` plus `resolveCallSites` on the extracted tree, once per side, so it can be re-taken without my machine.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test coverage improvement

## Testing

- [x] Unit tests pass (`npm run test:unit`) — **1,674 passed**
- [x] Full suite passes (`npx vitest run`) — **1,877 passed**, 83 files
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Lint clean (`npm run lint`)
- [x] New tests added for new/changed functionality

Six new tests and one strengthened, each mutation-checked rather than assumed to bite. The count is what each mutation turns red out of the 55 tests in the file:

| mutation | of the 54 Rust-file tests |
|---|---|
| `struct_item` mapped to `type` instead of `struct` | **1 red** |
| name taken by searching for `identifier` instead of the `name` field | **3 red** |
| line reported as `r.start.line` instead of `+ 1` | **4 red** |
| the declaration-order sort removed | **1 red** |
| the sort's tie broken by name instead of by offset | **1 red** |
| `safeFindAllAny` narrowed to the first kind it is given | **4 red** |
| the extraction loop removed entirely (i.e. `main`) | **6 red** |

The last row is the honest form of "these test the change and not the language": run the new test file against `main`'s extractor and all six go red.

The existing Rust test already declared `struct S;` in its fixture and asserted nothing about it; it now asserts it, which is why it is one of those six.

The line test exists because a symbol at the wrong line is worse than a missing one: `makeId` builds the id from file, name and line, so a wrong line either collides with another item or sends the reader to the wrong place.

## Known limits

Each of these was measured on the extractor, not reasoned about.

- **An item produced by a macro expansion is not extracted.** `macro_rules! factory { () => { pub struct Made; }; } factory!();` yields nothing: the extractor reads the file as written, as it did before.
- **A trait's associated type declaration is not extracted; an impl's definition of it is.** In `trait Speaks { type Voice; }` the declaration is an `associated_type` node, not a `type_item`, so `Speaks` is extracted and `Voice` is not; `impl Speaks for Loud { type Voice = String; }` does yield `Voice` as a `type`, without the implementing type in its name — which matches how the extractor already names a method.
- **A `const` declared inside a function becomes a symbol.** `safeFindAll` walks the whole tree, so `fn f() { const INNER: u32 = 2; }` yields `INNER` as a `variable`. This is the behaviour the extractor already has for a nested `fn`, and making the two disagree would be the odder choice; a reader looking up `INNER` gets its real position.
- **Two items of the same name under opposite `#[cfg]`s both become symbols**, one per declaration, since the graph has no feature resolution — the same rule the file graph already follows for `mod` under `#[cfg]`. On separate lines their ids differ, because `makeId` carries the line. **On the same line they share an id**: `mod a { pub struct S; } mod b { pub struct S; }` written on one line yields two symbols with one id, and the second is then unreachable through the name shard. That is a property of `makeId`, shared with every language here, and I have left it alone rather than change an id scheme from inside a Rust change. Measured rather than assumed rare: across the **763 `.rs` files** of the three trees and the 11,903 Rust symbols they yield, **no two share an id**.
- **Two `impl`s of one trait give two symbols of the same associated name**, since the name carries no owner — the way a method's name already does not. Counted on tokio, `Output` now appears 81 times where it appeared none; `getSymbolContext` iterates a name's refs without a cap, so `codebase_symbol Output` loads 81 payloads. That is not new ground on this path — `new` already stands at 191 on the same tree and `fmt` at 154 — but the limit deserves its number. Qualifying the name would change how every language in this file names a member, so it is reported rather than done here.
- **A trait's declared methods are not extracted, and neither are `extern` block functions.** `trait Tr { fn declared(&self); const K: u32; }` yields `Tr` and `K` but not `declared`, which is a `function_signature_item` rather than a `function_item`; `extern "C" { pub fn c_fn(); pub static C_VAR: u32; }` yields `C_VAR` and not `c_fn`. Both shapes predate this change, but a reader who can now *find* a trait will expect its methods, so it is worth saying that the gap moved rather than closed.
- **A type-qualified call is still not a call.** `extractCalleeInfoJs` stops at `::`, so `Type::method()` — the commonest call shape in Rust — has never produced a call edge, before this change or after. This is worth knowing when reading the unresolved percentage above: the new symbols sit above an edge set that does not see that form.
- **A name that now resolves to more than one candidate.** Two files declaring `pub struct Handle(pub i32)` under opposite `cfg`s, with `Handle(fd)` written in a third, moves from `unresolved` to `multiple-candidates` with both files listed — the file graph does not evaluate `cfg`. I did not observe it on any of the three trees — `multiple-candidates` is unchanged on all of them, and edge by edge the only transitions are the 247 improvements above — but it is constructible and worth stating.

## Related

Closes #140. Same class as #132 (TypeScript), closed by #135. `extractFromGo` has the identical functions-only shape and would take the same treatment; I have left it alone rather than fold two languages into one change.
