### PR TITLE
docs: update installation and host integration guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ By submitting a pull request, you agree to the [Contributor License Agreement (C
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 18.17 or newer
 - Docker (for integration and E2E tests)
 - Git
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -168,7 +168,7 @@ npm run release:dry
 This will automatically:
 1. Determine the version bump from your commits
 2. Update `CHANGELOG.md` with all `feat:`, `fix:`, etc. entries
-3. Bump the version in `package.json`
+3. Bump the version in `package.json`, plugin manifests, Gemini extension manifest, and VS Code extension package files
 4. Create a git commit and tag (`v1.1.0`)
 5. Push to GitHub and create a GitHub Release
 
@@ -178,7 +178,7 @@ This will automatically:
 
 ```
 src/
-├── index.ts                 # MCP server entry point — registers all 21 tools
+├── index.ts                 # MCP server entry point; registers all SocratiCode tools
 ├── config.ts                # Project ID generation (SHA-256), collection naming, linked projects, branch detection
 ├── constants.ts             # All constants: ports, container names, models, chunk sizes, extensions
 ├── types.ts                 # TypeScript interfaces and types
@@ -1503,13 +1503,14 @@ Edit `DEFAULT_IGNORE_PATTERNS` in `src/services/ignore.ts`.
 
 ## VS Code / Open VSX Extension
 
-The repo also ships a regular VS Code extension that auto-registers the
-SocratiCode MCP server in any MCP-aware host (Copilot agent mode, Cline,
-Continue, Roo Code) and adds native UI: sidebar, status bar, interactive
-graph webview, walkthrough, and palette commands. The same `.vsix` is
-published to both VS Code Marketplace and Open VSX, so it installs in
-Cursor, VSCodium, Gitpod, code-server, Theia, Antigravity, and Particle
-Workbench in addition to stock VS Code.
+The repo also ships a regular VS Code extension that registers the
+SocratiCode MCP server with the editor's native MCP registry through
+`vscode.lm.registerMcpServerDefinitionProvider`. It also adds native UI:
+sidebar, status bar, interactive graph webview, walkthrough, and palette
+commands. The same `.vsix` is published to both VS Code Marketplace and
+Open VSX. A VS Code-derived editor must implement the MCP provider API for
+native MCP registration to work. Independent clients such as Cline,
+Continue, and Roo Code require their own MCP configuration.
 
 Source: [`extension/`](./extension)
 
@@ -1592,12 +1593,11 @@ npm run publish:all
 
 ### Versioning
 
-The extension's version tracks the engine version. The
-`scripts/bump-plugin-versions.mjs` `release-it` hook bumps
-`extension/package.json` along with every plugin manifest, so an engine
-release `vX.Y.Z` automatically bumps the extension to `X.Y.Z`. Patch
-drift is allowed for extension-only hotfixes (e.g. release the engine
-at `1.7.2` but ship the extension at `1.7.3` for a UI bug fix).
+The shipped integrations track the engine version. The
+`scripts/bump-plugin-versions.mjs` `release-it` hook updates every plugin
+manifest, `gemini-extension.json`, `extension/package.json`, and both version
+fields in `extension/package-lock.json`. An engine release `vX.Y.Z` therefore
+publishes matching integration metadata.
 
 ### What the extension does NOT do
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://github.com/giancarloerra/socraticode/actions/workflows/ci.yml"><img src="https://github.com/giancarloerra/socraticode/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg" alt="License: AGPL-3.0"></a>
   <a href="https://www.npmjs.com/package/socraticode"><img src="https://img.shields.io/npm/v/socraticode.svg" alt="npm version"></a>
-  <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/node-%3E%3D18-brightgreen.svg" alt="Node.js >= 18"></a>
+  <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/node-%3E%3D18.17-brightgreen.svg" alt="Node.js >= 18.17"></a>
   <a href="https://github.com/giancarloerra/socraticode"><img src="https://img.shields.io/github/stars/giancarloerra/socraticode?style=social" alt="GitHub stars"></a>
   <a href="https://mcptoplist.com/server/io.github.giancarloerra%2Fsocraticode"><img src="https://mcptoplist.com/badge/io.github.giancarloerra%2Fsocraticode.svg" alt="MCP Toplist rank"></a>
   <a href="https://discord.gg/dHNMKVY2J2"><img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
@@ -18,7 +18,7 @@
   <a href="#claude-code-plugin-recommended-for-claude-code-users"><img src="https://img.shields.io/badge/Claude_Code-Install_Plugin-CC785C?style=flat-square&logoColor=white" alt="Install Claude Code Plugin"></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=giancarloerra.socraticode"><img src="https://vsmarketplacebadges.dev/version-short/giancarloerra.socraticode.svg?style=flat-square&label=VS%20Code%20Marketplace&logo=visualstudiocode&color=0098FF" alt="VS Code Marketplace"></a>
   <a href="https://open-vsx.org/extension/giancarloerra/socraticode"><img src="https://img.shields.io/open-vsx/v/giancarloerra/socraticode?style=flat-square&label=Open%20VSX&color=A52A2A" alt="Open VSX"></a>
-  <a href="https://insiders.vscode.dev/redirect/mcp/install?name=socraticode&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22socraticode%22%5D%7D"><img src="https://img.shields.io/badge/VS_Code-Install_MCP_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white" alt="Install in VS Code"></a>
+  <a href="https://vscode.dev/redirect/mcp/install?name=socraticode&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22socraticode%22%5D%7D"><img src="https://img.shields.io/badge/VS_Code-Install_MCP_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white" alt="Install in VS Code"></a>
   <a href="https://insiders.vscode.dev/redirect/mcp/install?name=socraticode&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22socraticode%22%5D%7D&quality=insiders"><img src="https://img.shields.io/badge/VS_Code_Insiders-Install_MCP_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white" alt="Install in VS Code Insiders"></a>
   <a href="cursor://anysphere.cursor-deeplink/mcp/install?name=socraticode&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInNvY3JhdGljb2RlIl19"><img src="https://img.shields.io/badge/Cursor-Install_MCP_Server-F14C28?style=flat-square&logo=cursor&logoColor=white" alt="Install in Cursor"></a>
 </p>
@@ -41,7 +41,7 @@
 
 > **☁️ SocratiCode Cloud (private beta)** — Hosted, shared team index built on the same engine as the open-source version, plus SSO, audit logs, branch-aware indexing, and VPC / air-gapped deployment options. The open-source core remains free forever. [Request early access →](https://socraticode.cloud)
 
-**One thing, done well: deep codebase intelligence — zero setup, no bloat, fully automatic.** SocratiCode gives AI assistants deep semantic understanding of your codebase — **hybrid search, cross-project search, polyglot code dependency graphs, symbol-level impact analysis and flow, interactive HTML graph explorer for visual navigation, and searchable context artifacts (database schemas, API specs, infra configs, architecture docs)**. Zero configuration — add it to **any MCP host**, or install the **Native Plugin** for Claude Code, Cursor, VS Code Copilot, Codex or Gemini CLI. It manages everything automatically.
+**One thing, done well: deep codebase intelligence — zero setup, no bloat, fully automatic.** SocratiCode gives AI assistants deep semantic understanding of your codebase — **hybrid search, cross-project search, polyglot code dependency graphs, symbol-level impact analysis and flow, interactive HTML graph explorer for visual navigation, and searchable context artifacts (database schemas, API specs, infra configs, architecture docs)**. Zero configuration — add it to an **MCP host that supports local stdio servers**, or use a supported plugin or extension. It manages everything automatically.
 
 **Production-ready**, battle-tested on **enterprise-level** large repositories (up to and over **~40 million lines of code**). **Batched**, automatic **resumable** indexing checkpoints progress — pauses, crashes, restarts, and interruptions don't lose work. The file watcher keeps the **index automatically updated** at every file change and across sessions. **Multi-branch, multi-repo** and **multi-agent ready** — multiple AI agents can work on the same codebase simultaneously, sharing a single index with automatic coordination and zero configuration.
 
@@ -56,7 +56,7 @@ The first Qdrant‑based MCP/Claude Plugin/Skill that pairs auto‑managed, zero
 ## Contents
 
 - [Quick Start](#quick-start)
-- [Plugins](#plugins)
+- [Plugins and host integrations](#plugins-and-host-integrations)
 - [Why SocratiCode](#why-socraticode)
 - [Features](#features)
 - [Prerequisites](#prerequisites)
@@ -79,71 +79,29 @@ The first Qdrant‑based MCP/Claude Plugin/Skill that pairs auto‑managed, zero
 
 ## Quick Start
 
-> **Only [Docker](https://www.docker.com/products/docker-desktop/) (running) required.**
+> **Requirements:** [Node.js 18.17 or newer](https://nodejs.org/) with `npx` on `PATH`, plus [Docker](https://www.docker.com/products/docker-desktop/) running for the default local Qdrant and Ollama stack.
 
-**One-click install** — Claude Code, VS Code and Cursor:
+**Quick install guidance for Claude Code, VS Code, and Cursor:**
 
 [![Install Claude Code Plugin](https://img.shields.io/badge/Claude_Code-Install_Plugin-CC785C?style=flat-square&logoColor=white)](#claude-code-plugin-recommended-for-claude-code-users)
-[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_MCP_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=socraticode&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22socraticode%22%5D%7D) [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_MCP_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=socraticode&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22socraticode%22%5D%7D&quality=insiders) [![Install in Cursor](https://img.shields.io/badge/Cursor-Install_MCP_Server-F14C28?style=flat-square&logo=cursor&logoColor=white)](cursor://anysphere.cursor-deeplink/mcp/install?name=socraticode&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInNvY3JhdGljb2RlIl19) 
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_MCP_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=socraticode&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22socraticode%22%5D%7D) [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_MCP_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=socraticode&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22socraticode%22%5D%7D&quality=insiders) [![Install in Cursor](https://img.shields.io/badge/Cursor-Install_MCP_Server-F14C28?style=flat-square&logo=cursor&logoColor=white)](cursor://anysphere.cursor-deeplink/mcp/install?name=socraticode&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsInNvY3JhdGljb2RlIl19)
 
-**All MCP hosts** — add the following to your `mcpServers` (Claude Desktop, Windsurf, Cline, Roo Code) or `servers` (VS Code project-local `.vscode/mcp.json`) config:
-
-```json
-"socraticode": {
-  "command": "npx",
-  "args": ["-y", "socraticode"]
-}
-```
-
-**Claude Code** — install the plugin (recommended, includes workflow skills for best results):
-
-From your shell:
-
-```bash
-claude plugin marketplace add giancarloerra/socraticode
-claude plugin install socraticode@socraticode
-```
-
-Or from within Claude Code:
-
-```
-/plugin marketplace add giancarloerra/socraticode
-/plugin install socraticode@socraticode
-```
-
-> **Auto-updates:** After installing, enable automatic updates by opening `/plugin` → Marketplaces → select `socraticode` → Enable auto-update.
-
-Or as MCP only (without skills):
-
-```bash
-claude mcp add socraticode -- npx -y socraticode
-```
-
-> **Updating:** `npx` caches the package after the first run. To get the latest version, clear the cache and restart your MCP host: `rm -rf ~/.npm/_npx && claude mcp restart socraticode`. Alternatively, use `npx -y socraticode@latest` in your config to always check for updates on startup (slightly slower).
-
-**OpenCode** — add to your `opencode.json` (or `opencode.jsonc`):
+**MCP hosts with a JSON `mcpServers` object** can use this complete configuration:
 
 ```json
 {
-  "mcp": {
+  "mcpServers": {
     "socraticode": {
-      "type": "local",
-      "command": ["npx", "-y", "socraticode"],
-      "enabled": true
+      "command": "npx",
+      "args": ["-y", "socraticode"]
     }
   }
 }
 ```
 
-**OpenAI Codex CLI** — add to `~/.codex/config.toml`:
+Configuration schemas are host-specific. Continue, VS Code, Zed, OpenCode, Gemini CLI, Cline, and Roo Code have dedicated examples in [Plugins and host integrations](#plugins-and-host-integrations).
 
-```toml
-[mcp_servers.socraticode]
-command = "npx"
-args = ["-y", "socraticode"]
-```
-
-Restart your host. On first use SocratiCode automatically pulls Docker images, starts its own Qdrant and Ollama containers, and downloads the embedding model — one-time setup, ~5 minutes depending on your connection. After that, it starts in seconds.
+Restart your host. With the default local configuration, first use pulls the required Docker images and starts managed Qdrant. `OLLAMA_MODE=auto` reuses a detected native Ollama instance or starts managed Ollama, then downloads the local embedding model if it is not already available. Cloud and external embedding providers do not download a local model. Initial setup usually takes about five minutes, depending on the connection; later starts take seconds.
 
 **First time on a project** — ask your AI: **"Index this codebase"**. Indexing runs in the background; ask **"What is the codebase index status?"** to monitor progress. Depending on codebase size and whether you're using GPU-accelerated Ollama or cloud embeddings, first-time indexing can take anywhere from a few seconds to a few minutes (it takes under 10 minutes to first-index +3 million lines of code on a Macbook Pro M4). Once complete it doesn't need to be run again, you can search, explore the dependency graph, and query context artifacts.
 
@@ -157,45 +115,327 @@ Restart your host. On first use SocratiCode automatically pulls Docker images, s
 
 > **Advanced**: cloud embeddings (OpenAI / Google), external Qdrant, remote Ollama, native Ollama, and dozens of tuning options are all available. See [Configuration](#configuration) below.
 
-## Plugins
+## Plugins and host integrations
 
-SocratiCode is available as a native plugin on multiple AI coding platforms. Plugins bundle the MCP server with workflow skills and agent instructions — one install gives you everything.
+SocratiCode can be installed as a native agent plugin, a VS Code editor extension, a Gemini CLI extension, or a directly configured local stdio MCP server. These are separate integration types and use different configuration and update paths.
 
-| Platform | Install method |
-|:---------|:---------------|
-| Claude Code | `claude plugin marketplace add giancarloerra/socraticode && claude plugin install socraticode@socraticode` — [full instructions](#claude-code-plugin-recommended-for-claude-code-users) |
-| **VS Code / Cursor / VSCodium / Gitpod / code-server / Theia / Antigravity / Particle Workbench** (extension) | Search **SocratiCode** in the Extensions panel (VS Code Marketplace or Open VSX). The extension auto-registers the MCP server in Copilot agent mode, Cline, Continue and Roo Code, and adds a sidebar, interactive graph webview, and onboarding walkthrough. _Source: [`extension/`](./extension)._ |
-| Cursor | `/add-plugin https://github.com/giancarloerra/socraticode` (plugin format with skills). Also listed in the Cursor Marketplace at [cursor.com/marketplace](https://cursor.com/marketplace). |
-| VS Code Copilot | Command Palette → `Chat: Install Plugin From Source` → `https://github.com/giancarloerra/socraticode` (plugin format with skills) |
-| Zed | Add as a custom MCP server in Zed settings — [config example](#zed) |
-| Gemini CLI | `gemini extensions install https://github.com/giancarloerra/socraticode` |
-| OpenAI Codex | No public plugin directory yet — use the [MCP config](#quick-start) or see **Codex local install** below |
+Every path below requires Node.js 18.17 or newer with `npx` on `PATH`. The default local stack also requires Docker to be running. Docker is optional when Qdrant is external and embeddings use either a detected native Ollama instance or a cloud or external provider.
 
-> **Extension vs plugin (what to install in VS Code / Cursor):**
->
-> - The **extension** (Marketplace / Open VSX listing) is a regular VS Code-style extension. It auto-registers the MCP server in Copilot agent mode, Cline, Continue, Roo Code, plus adds a sidebar, status-bar item, interactive graph webview, walkthrough and palette commands. Best for most users.
-> - The **plugins** (`/add-plugin` for Cursor, `Chat: Install Plugin From Source` for VS Code Copilot) bundle the MCP server **plus skills + agent instructions** that teach the AI to use SocratiCode tools effectively. Best when you want the agent to be opinionated about using SocratiCode.
-> - You can install both. The extension only registers the MCP server once, so they don't conflict.
-> - **VS Code Copilot note**: the chat plugins feature is in preview. Enable it with `chat.plugins.enabled: true` in your VS Code settings.
+| Host | Recommended integration | Scope |
+|:-----|:------------------------|:------|
+| Claude Code | Native plugin | User |
+| OpenAI Codex | Native plugin | User |
+| VS Code | Agent Plugin or editor extension | Current VS Code profile |
+| Cursor | Local Cursor plugin or direct MCP | User or project |
+| Gemini CLI | Gemini extension | User |
+| Continue | Direct MCP | Project or user config |
+| Cline | Direct MCP | Project or user config |
+| Roo Code | Direct MCP | Project or user config |
+| Zed | Direct MCP | User or project settings |
+| OpenCode | Direct MCP | Project or user config |
 
-> **Codex local plugin install**: Clone the repo and register it in your personal plugin marketplace:
-> ```bash
-> git clone https://github.com/giancarloerra/socraticode.git ~/.agents/plugins/socraticode
-> ```
-> Then add it to `~/.agents/plugins/marketplace.json`:
-> ```json
-> {
->   "plugins": [
->     {
->       "name": "socraticode",
->       "path": "~/.agents/plugins/socraticode"
->     }
->   ]
-> }
-> ```
-> Codex will discover the plugin from `.codex-plugin/plugin.json` on next launch.
+### Claude Code plugin (recommended for Claude Code users)
 
-> **All other MCP hosts** (Claude Desktop, Windsurf, Cline, Roo Code, OpenCode): Use the [MCP config](#quick-start) — works with any host that supports the MCP protocol.
+The native plugin bundles the MCP server, workflow skills, and agent instructions. Install it for the current user:
+
+```bash
+claude plugin marketplace add giancarloerra/socraticode
+claude plugin install --scope user socraticode@socraticode
+claude plugin list
+```
+
+Start a new Claude Code session after installation. Existing sessions do not load a newly installed plugin. To enable automatic updates, open `/plugin`, select **Marketplaces**, select `socraticode`, and enable auto-update. To update manually:
+
+```bash
+claude plugin marketplace update socraticode
+claude plugin update --scope user socraticode@socraticode
+```
+
+Run `/reload-plugins` or start a new session after updating. If SocratiCode was previously added as a standalone MCP server, remove that duplicate with `claude mcp remove socraticode`; the plugin already provides the server.
+
+For custom providers or external Qdrant, put inherited variables in Claude Code's user settings and restart the session:
+
+```json
+{
+  "env": {
+    "EMBEDDING_PROVIDER": "openai",
+    "OPENAI_API_KEY": "<your key>"
+  }
+}
+```
+
+Keep this user-scoped file private, or provide secrets through the process environment. Never commit secret values.
+
+See the [Claude Code plugin documentation](https://code.claude.com/docs/en/discover-plugins).
+
+#### Claude Code MCP-only installation
+
+For a user-scoped installation without the bundled skills:
+
+```bash
+claude mcp add --scope user socraticode -- npx -y socraticode
+claude mcp list
+```
+
+Start a new session, or run `/mcp` and select **Reconnect**. For an immediate package update, replace the configuration with an explicit latest-version command and reconnect:
+
+```bash
+claude mcp remove --scope user socraticode
+claude mcp add --scope user socraticode -- npx -y socraticode@latest
+```
+
+`claude mcp add` defaults to project-local scope when `--scope user` is omitted. See the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp).
+
+### OpenAI Codex plugin
+
+The Codex plugin bundles SocratiCode's MCP server, skills, and instructions. Add the Git marketplace and install the plugin for the current user:
+
+```bash
+codex plugin marketplace add giancarloerra/socraticode --ref main
+codex plugin add socraticode@socraticode
+codex plugin list --available --json
+```
+
+Start a new Codex task or CLI session after installation. Reopening an existing task does not load newly installed skills or MCP tools. Update and verify with:
+
+```bash
+codex plugin marketplace upgrade socraticode
+codex plugin add socraticode@socraticode
+codex plugin list --available --json
+```
+
+Codex has a public plugin directory, but SocratiCode is not currently published there. Plugins are supported in the ChatGPT desktop Codex environment and Codex CLI. The Codex IDE extension supports shared MCP configuration, not plugin discovery. See the [OpenAI plugin documentation](https://learn.chatgpt.com/docs/plugins).
+
+#### OpenAI Codex MCP-only installation
+
+`codex mcp add` writes the user configuration in `~/.codex/config.toml`:
+
+```bash
+codex mcp add socraticode -- npx -y socraticode
+codex mcp list
+```
+
+Start a new task or CLI session after installation. For an immediate package update:
+
+```bash
+codex mcp remove socraticode
+codex mcp add socraticode -- npx -y socraticode@latest
+codex mcp list
+```
+
+The equivalent TOML is:
+
+```toml
+[mcp_servers.socraticode]
+command = "npx"
+args = ["-y", "socraticode"]
+```
+
+Both inline `env = { ... }` and a nested `[mcp_servers.socraticode.env]` table are valid. The CLI `--env KEY=value` option is usually clearer. See the [OpenAI Codex MCP documentation](https://learn.chatgpt.com/docs/extend/mcp?surface=cli).
+
+### VS Code Agent Plugin
+
+This plugin bundles the MCP server, skills, and agent instructions for VS Code's native agent. It is separate from the SocratiCode editor extension.
+
+1. Add this complete setting to the current VS Code profile before installation:
+
+   ```json
+   {
+     "chat.plugins.enabled": true
+   }
+   ```
+
+2. Run **Chat: Install Plugin From Source** from the Command Palette and enter `https://github.com/giancarloerra/socraticode`.
+3. Start a new Chat session.
+4. Verify SocratiCode under **Agent Plugins - Installed**, then run **MCP: List Servers** and confirm that its server is running.
+
+Run **Extensions: Check for Extension Updates** to refresh installed agent plugins, then start a new Chat session. See [VS Code Agent Plugins](https://code.visualstudio.com/docs/agent-customization/agent-plugins).
+
+### VS Code editor extension
+
+The separately published editor extension adds the SocratiCode sidebar, status item, commands, walkthrough, and interactive graph webview. Install **SocratiCode** from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=giancarloerra.socraticode) in the current VS Code profile.
+
+On Microsoft VS Code 1.99+ and compatible editors that implement the VS Code MCP provider API, the extension registers SocratiCode with the editor's native MCP registry. It does not configure independent clients such as Cline, Continue, or Roo Code.
+
+Reload the window and start a new Chat session after installation. Run **MCP: List Servers** to confirm that `SocratiCode` is running, and open the SocratiCode sidebar to verify the editor UI. Update it through the Extensions view or **Extensions: Check for Extension Updates**.
+
+The [Open VSX package](https://open-vsx.org/extension/giancarloerra/socraticode) can be installed in VS Code-derived editors, but native MCP registration requires that editor to implement `vscode.lm.registerMcpServerDefinitionProvider`. See the [VS Code MCP extension API](https://code.visualstudio.com/api/extension-guides/ai/mcp).
+
+#### VS Code direct MCP installation
+
+Use the Stable or Insiders badge above, choose user or workspace scope in VS Code, then start a new Chat session. A project-scoped `.vscode/mcp.json` uses this complete object:
+
+```json
+{
+  "servers": {
+    "socraticode": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "socraticode"]
+    }
+  }
+}
+```
+
+Verify with **MCP: List Servers**. To update immediately, change the package argument to `socraticode@latest`, restart the server from that command, and start a new Chat session.
+
+### Cursor
+
+The repository includes a Cursor-format plugin with the MCP server, skills, and instructions. SocratiCode is not currently published in the Cursor Marketplace, so use Cursor's documented user-scoped local-plugin directory:
+
+```bash
+mkdir -p ~/.cursor/plugins/local
+git clone https://github.com/giancarloerra/socraticode.git ~/.cursor/plugins/local/socraticode
+```
+
+Restart Cursor or run **Developer: Reload Window**, then verify the plugin under **Customize**. Update it with:
+
+```bash
+git -C ~/.cursor/plugins/local/socraticode pull --ff-only
+```
+
+Reload Cursor after updating. See [Cursor plugins](https://prod.cursor.com/docs/plugins).
+
+For direct MCP configuration, use the Cursor badge above and select the intended user or project scope in Cursor. Start a new Agent chat, then verify `socraticode` under **Cursor Settings → Tools & MCP**. Reopen the installer with `socraticode@latest` as the package argument when an immediate update is required. See [Cursor MCP install links](https://prod.cursor.com/docs/mcp/install-links).
+
+The SocratiCode package on Open VSX is a VS Code-style editor extension, not a Cursor plugin. Installing that extension does not establish that Cursor implements VS Code's native MCP provider API. Use the local plugin or direct MCP path when MCP availability is required.
+
+### Gemini CLI extension
+
+Install the user-scoped Gemini extension with automatic updates, verify it, then restart any active Gemini CLI session:
+
+```bash
+gemini extensions install https://github.com/giancarloerra/socraticode --auto-update
+gemini extensions list
+```
+
+If it was installed without `--auto-update`, update it manually and restart Gemini:
+
+```bash
+gemini extensions update socraticode
+gemini extensions list
+```
+
+Gemini limits which inherited environment variables are passed to extension MCP servers. For advanced configuration, define a server with the same name in user scope (`~/.gemini/settings.json`) or workspace scope (`.gemini/settings.json`). That definition overrides the extension server and explicitly forwards only the variables named in `env`:
+
+```json
+{
+  "mcpServers": {
+    "socraticode": {
+      "command": "npx",
+      "args": ["-y", "socraticode"],
+      "env": {
+        "EMBEDDING_PROVIDER": "openai",
+        "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+        "QDRANT_MODE": "external",
+        "QDRANT_URL": "${QDRANT_URL}",
+        "QDRANT_API_KEY": "${QDRANT_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Keep secret values in the process environment rather than committing them. Restart Gemini and run `gemini mcp list` to verify the overridden server. See the [Gemini extension reference](https://geminicli.com/docs/extensions/reference/) and [Gemini MCP configuration](https://geminicli.com/docs/tools/mcp-server/).
+
+### Continue
+
+Continue uses a YAML `mcpServers` list. For project scope, create `.continue/mcpServers/socraticode.yaml`:
+
+```yaml
+name: SocratiCode MCP
+version: 1.0.0
+schema: v1
+mcpServers:
+  - name: SocratiCode
+    type: stdio
+    command: npx
+    args:
+      - "-y"
+      - socraticode
+```
+
+Continue refreshes saved configuration automatically. Open a new Continue Agent session and confirm the SocratiCode tools are listed. For user scope, add the same `mcpServers` list to `~/.continue/config.yaml`. To update immediately, change `socraticode` to `socraticode@latest` and save the file. Continue can also import complete JSON MCP files placed in `.continue/mcpServers/`. See [Continue MCP configuration](https://docs.continue.dev/customize/deep-dives/mcp) and the [Continue YAML reference](https://docs.continue.dev/reference).
+
+### Cline
+
+For project scope, save this complete object as `.cline/mcp.json`. For user scope, add the same server to `~/.cline/data/settings/cline_mcp_settings.json` through Cline's MCP settings interface:
+
+```json
+{
+  "mcpServers": {
+    "socraticode": {
+      "command": "npx",
+      "args": ["-y", "socraticode"],
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+Start a new Cline task and verify that `socraticode` and its tools appear in the MCP Servers view. To update immediately, change the package argument to `socraticode@latest` and reconnect the server. See the [Cline MCP documentation](https://docs.cline.bot/mcp/mcp-overview).
+
+### Roo Code
+
+For project scope, save this complete object as `.roo/mcp.json`. For user scope, open Roo Code's MCP Servers view and select **Edit Global MCP**:
+
+```json
+{
+  "mcpServers": {
+    "socraticode": {
+      "command": "npx",
+      "args": ["-y", "socraticode"],
+      "disabled": false
+    }
+  }
+}
+```
+
+Start a new Roo Code task and verify that `socraticode` is connected in the MCP Servers view. To update immediately, change the package argument to `socraticode@latest` and restart the server. Project configuration takes precedence over a global server with the same name. See [Using MCP in Roo Code](https://github.com/RooCodeInc/Roo-Code-Docs/blob/main/docs/features/mcp/using-mcp-in-roo.mdx).
+
+### Zed
+
+Open **Settings → AI → MCP Servers → Add Server → Add Local Server**. The UI writes user-scoped settings. Use this complete server definition, either there or in project-scoped `.zed/settings.json`:
+
+```json
+{
+  "context_servers": {
+    "socraticode": {
+      "command": "npx",
+      "args": ["-y", "socraticode"],
+      "env": {}
+    }
+  }
+}
+```
+
+Verify that the indicator beside SocratiCode is green and its tooltip says **Server is active**, then start a new Agent conversation. To update immediately, change the package argument to `socraticode@latest` and restart the server from the MCP Servers page.
+
+Zed uses `~/.config/zed/AGENTS.md` for personal instructions. For project instructions it uses the first matching supported file, which can be `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, or another supported compatibility file. Zed Rules were replaced by Skills and Instructions. See [Zed MCP servers](https://zed.dev/docs/ai/mcp) and [Zed Instructions](https://zed.dev/docs/ai/instructions).
+
+### OpenCode
+
+Use project-root `opencode.json` or `opencode.jsonc` for project scope. Use `~/.config/opencode/opencode.json` or `opencode.jsonc` for user scope:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "socraticode": {
+      "type": "local",
+      "command": ["npx", "-y", "socraticode"],
+      "enabled": true
+    }
+  }
+}
+```
+
+Restart OpenCode and verify the server with `opencode mcp list`. To update immediately, change `socraticode` to `socraticode@latest` and restart OpenCode. This is the current OpenCode 1.x schema. See [OpenCode MCP servers](https://opencode.ai/docs/mcp-servers/) and [OpenCode configuration](https://opencode.ai/docs/config/).
+
+### Other local stdio MCP hosts
+
+The complete JSON object in [Quick Start](#quick-start) applies only to hosts whose documentation specifies an `mcpServers` object. Add it at the user or project scope documented by that host, restart the MCP server or start a new session, and verify SocratiCode in the host's MCP server and tool list. To update immediately, change the final package argument to `socraticode@latest`. Hosts that support only remote HTTP MCP servers cannot launch SocratiCode directly.
 
 ## Why SocratiCode
 
@@ -266,7 +506,7 @@ On VS Code's 2.45M‑line codebase, SocratiCode answers architectural questions 
 | Dependency | Purpose | Install |
 |------------|---------|---------|
 | [Docker](https://www.docker.com/products/docker-desktop/) | Runs Qdrant (vector DB) and by default Ollama (embeddings) | [docker.com](https://www.docker.com/products/docker-desktop/) |
-| Node.js 18+ | Runs the MCP server | [nodejs.org](https://nodejs.org/) |
+| Node.js 18.17+ with `npx` on `PATH` | Runs the MCP server | [nodejs.org](https://nodejs.org/) |
 
 Docker must be **running** when you use the server in the default `managed` mode. 
 
@@ -354,7 +594,7 @@ For best results, add instructions like the following to your AI assistant's pro
 | Claude Code | `CLAUDE.md` at project root (auto-loaded). Plugin users get this via skills automatically. |
 | Cursor | `AGENTS.md` at project root, or `.cursor/rules/socraticode.mdc` for a dedicated rule file |
 | VS Code Copilot | `.github/copilot-instructions.md`, or a custom instructions file in your VS Code User prompts folder |
-| Zed | `AGENTS.md` at project root (Zed auto-reads it), or use the Rules Library to create a default rule |
+| Zed | `AGENTS.md` at project root, or `~/.config/zed/AGENTS.md` for personal instructions. Zed uses the first matching supported project instruction file. |
 | Windsurf | `.windsurfrules` at project root |
 | Claude Desktop / Cline / Roo Code | Add directly to your system prompt configuration |
 
@@ -450,119 +690,12 @@ before reading any files directly.
 > **Why semantic search first?** A single `codebase_search` call returns ranked, deduplicated snippets from across the entire codebase in milliseconds. This gives you a broad map at negligible token cost — far cheaper than opening files speculatively. Once you know which files matter, targeted reading is both faster and more accurate. That said, grep remains the right tool when you have an exact string or pattern — use whichever fits the query.
 
 > **Keep the connection alive during indexing.** Indexing runs in the background — the MCP server continues working even when not actively responding to tool calls. However, some MCP hosts might disconnect an idle MCP connection after a period of inactivity, which might cut off the background process. Instruct your AI to call `codebase_status` roughly every 60 seconds after starting `codebase_index` until it completes. This keeps the host connection active and provides real-time progress.
+
 ## Configuration
 
 ### Install
 
-#### Claude Code plugin (recommended for Claude Code users)
-
-The SocratiCode plugin bundles both the MCP server and workflow skills that teach Claude how to use the tools effectively. One install gives you everything:
-
-From your shell:
-
-```bash
-claude plugin marketplace add giancarloerra/socraticode
-claude plugin install socraticode@socraticode
-```
-
-Or from within Claude Code:
-
-```
-/plugin marketplace add giancarloerra/socraticode
-/plugin install socraticode@socraticode
-```
-
-The plugin includes:
-- **MCP server** — all 21 SocratiCode tools (search, graph, context artifacts, etc.)
-- **Exploration skill** — teaches Claude the search-before-reading workflow
-- **Management skill** — guides setup, indexing, watching, and troubleshooting
-- **Explorer agent** — delegatable subagent for deep codebase analysis
-
-> If you previously installed SocratiCode as a standalone MCP (`claude mcp add socraticode`), remove it after installing the plugin to avoid duplicates: `claude mcp remove socraticode`
-
-**Auto-updates:** Third-party plugins don't auto-update by default. To enable automatic updates, open `/plugin` → Marketplaces → select `socraticode` → Enable auto-update. To update manually:
-
-From your shell:
-
-```bash
-claude plugin marketplace update socraticode
-claude plugin update socraticode@socraticode
-```
-
-Or from within Claude Code:
-
-```
-/plugin marketplace update socraticode
-/plugin update socraticode@socraticode
-```
-
-**Configuring environment variables:** SocratiCode works with zero config for most users (local Ollama + managed Qdrant). If you need cloud embeddings, a remote Qdrant, or other customisation:
-
-1. **Claude Code settings** (recommended) — add to `~/.claude/settings.json`:
-   ```json
-   {
-     "env": {
-       "EMBEDDING_PROVIDER": "openai",
-       "OPENAI_API_KEY": "sk-..."
-     }
-   }
-   ```
-   This works in all environments — CLI, VS Code, and JetBrains.
-
-2. **Shell profile** — set vars in `~/.zshrc` or `~/.bashrc`:
-   ```bash
-   export EMBEDDING_PROVIDER=openai
-   export OPENAI_API_KEY=sk-...
-   ```
-   Works when Claude Code is launched from a terminal. Note: IDE-launched sessions (e.g. VS Code opened from Finder/Dock) may not inherit shell profile variables — use option 1 instead.
-
-Restart Claude Code after changing variables. See [Environment Variables](#environment-variables) for all options.
-
-#### npx (recommended for all other MCP hosts — no installation)
-
-Requires Node.js 18+ and Docker (running). Already covered in [Quick Start](#quick-start) above, add the following to your `mcpServers` (Claude Desktop, Windsurf, Cline, Roo Code) or `servers` (VS Code project-local `.vscode/mcp.json`) config:
-
-```json
-    "socraticode": {
-      "command": "npx",
-      "args": ["-y", "socraticode"]
-    }
-```
-
-#### Zed
-
-Add SocratiCode as a custom MCP server in Zed's settings (`Zed > Settings > Settings` or `cmd+,`). Under `context_servers`, add:
-
-```json
-{
-  "context_servers": {
-    "socraticode": {
-      "command": "npx",
-      "args": ["-y", "socraticode"],
-      "env": {}
-    }
-  }
-}
-```
-
-To pass environment variables (e.g. for cloud embeddings or branch-aware indexing), add them to the `env` object:
-
-```json
-{
-  "context_servers": {
-    "socraticode": {
-      "command": "npx",
-      "args": ["-y", "socraticode"],
-      "env": {
-        "EMBEDDING_PROVIDER": "openai",
-        "OPENAI_API_KEY": "sk-..."
-      }
-    }
-  }
-}
-```
-
-Zed auto-reads `AGENTS.md` from the project root for agent instructions. Copy the [Agent Instructions](#agent-instructions) block into your project's `AGENTS.md` to ensure the agent uses SocratiCode tools effectively. You can also add them as a default rule in Zed's Rules Library (`agent: open rules library`).
+Use the host-specific steps in [Plugins and host integrations](#plugins-and-host-integrations). They cover installation scope, activation, verification, updates, and each host's actual configuration schema.
 
 #### From source (for contributors)
 
@@ -573,17 +706,15 @@ npm install
 npm run build
 ```
 
-Then use `node /absolute/path/to/socraticode/dist/index.js` in place of `npx -y socraticode` in the config examples below.
+Register `node /absolute/path/to/socraticode/dist/index.js` in the user or project scope supported by your MCP host, then restart the server or start a new session. Verify SocratiCode in the host's MCP server list. To update, run `git pull --ff-only`, `npm install`, and `npm run build` in the clone, then restart the MCP server and verify it again.
 
 ### MCP host config variants
 
-> All `env` options below apply equally to the `npx` install. Just add the `"env"` block to the npx config shown above.
-
-Add to your MCP settings - `mcpServers` (Claude Desktop, Windsurf, Cline, Roo Code) or `servers` (VS Code project-local `.vscode/mcp.json`):
+The examples below use the conventional JSON `mcpServers` shape to show SocratiCode settings. Apply the same command and environment values through the host-specific schema documented in [Plugins and host integrations](#plugins-and-host-integrations). Continue, Gemini CLI, VS Code, Zed, and OpenCode use different configuration paths or wrappers.
 
 #### Default (zero config, from source)
 
-> Using **npx**? Your config is already in [Quick Start](#quick-start). Add any `"env"` block from the examples below as needed.
+> Using **npx**? Replace the `node` command and source path below with `"command": "npx"` and `"args": ["-y", "socraticode"]`.
 
 ```json
 {
@@ -1145,27 +1276,38 @@ Without artifacts, the agent only sees source code. With artifacts, it has the f
 
 ## Environment Variables
 
-SocratiCode reads configuration from environment variables. The way you pass them depends on your MCP host — the key name and file format differ across the three main config flavours. If env vars appear to be ignored, check the host's config format first — most "it's not picking up my settings" issues are a mismatched key.
+SocratiCode reads configuration from environment variables. The key name and file format depend on the MCP host. If variables appear to be ignored, check the host's documented schema and installation scope first.
 
 ### Passing env vars by host
 
 | Host | Config file | Env-var syntax |
 |------|-------------|---------|
-| Claude Code / Claude Desktop / Windsurf / Cline / Roo Code / Cursor / VS Code Copilot | MCP JSON (`mcpServers` or `servers`) | `"env": { "KEY": "value" }` |
-| **OpenCode** | `opencode.json` / `opencode.jsonc` ([schema](https://opencode.ai/config.json)) | **`"environment": { "KEY": "value" }`** — *not* `"env"`, which is silently ignored |
-| **OpenAI Codex CLI** | `~/.codex/config.toml` ([reference](https://developers.openai.com/codex/config-reference/)) | **Nested TOML table** — a `[mcp_servers.NAME.env]` block with `KEY = "value"` lines. Inline `env = { ... }` is *not* the Codex form. |
+| Claude Code native plugin | `~/.claude/settings.json` | Top-level `"env": { "KEY": "value" }` |
+| Claude Code MCP-only | User or project MCP configuration | `claude mcp add --env KEY=value ...` or an `env` object in the stored server definition |
+| Claude Desktop, Windsurf, Cursor, Cline, and Roo Code | Host MCP JSON | `"env": { "KEY": "value" }` inside the server definition |
+| VS Code direct MCP | `.vscode/mcp.json` or user MCP configuration | `"env": { "KEY": "value" }` inside the `servers` entry |
+| VS Code editor extension | VS Code settings | `"socraticode.env": { "KEY": "value" }` |
+| Continue | YAML config | `env:` map inside the `mcpServers` list item |
+| Zed | `context_servers` JSON | `"env": { "KEY": "value" }` |
+| Gemini CLI extension override | `~/.gemini/settings.json` or `.gemini/settings.json` | Explicit `"env"` entries; the extension does not inherit every process variable |
+| OpenCode | `opencode.json` / `opencode.jsonc` ([schema](https://opencode.ai/config.json)) | `"environment": { "KEY": "value" }`, not `"env"` |
+| OpenAI Codex CLI | `~/.codex/config.toml` | `codex mcp add --env KEY=value`, inline TOML `env = { ... }`, or `[mcp_servers.NAME.env]` |
 
 Worked examples with a few env vars set:
 
-**Standard MCP JSON** — Claude Code, Claude Desktop, Windsurf, Cline, Roo Code, Cursor, VS Code Copilot:
+**MCP JSON hosts** such as Claude Desktop, Windsurf, Cline, Roo Code, and Cursor:
 
 ```json
-"socraticode": {
-  "command": "npx",
-  "args": ["-y", "socraticode"],
-  "env": {
-    "QDRANT_MODE": "external",
-    "QDRANT_URL": "https://xyz.qdrant.io"
+{
+  "mcpServers": {
+    "socraticode": {
+      "command": "npx",
+      "args": ["-y", "socraticode"],
+      "env": {
+        "QDRANT_MODE": "external",
+        "QDRANT_URL": "https://xyz.qdrant.io"
+      }
+    }
   }
 }
 ```
@@ -1189,7 +1331,7 @@ Worked examples with a few env vars set:
 }
 ```
 
-**OpenAI Codex CLI** — env vars go in a separate `[mcp_servers.NAME.env]` table:
+**OpenAI Codex CLI** with the nested-table form:
 
 ```toml
 [mcp_servers.socraticode]
@@ -1200,6 +1342,8 @@ args = ["-y", "socraticode"]
 QDRANT_MODE = "external"
 QDRANT_URL = "https://xyz.qdrant.io"
 ```
+
+The equivalent CLI form is `codex mcp add socraticode --env QDRANT_MODE=external --env QDRANT_URL=https://xyz.qdrant.io -- npx -y socraticode`. Inline `env = { ... }` is also valid TOML.
 
 The rest of this section documents the variables themselves. Pass them using whichever syntax matches your host.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 > **☁️ SocratiCode Cloud (private beta)** — Hosted, shared team index built on the same engine as the open-source version, plus SSO, audit logs, branch-aware indexing, and VPC / air-gapped deployment options. The open-source core remains free forever. [Request early access →](https://socraticode.cloud)
 
-**One thing, done well: deep codebase intelligence — zero setup, no bloat, fully automatic.** SocratiCode gives AI assistants deep semantic understanding of your codebase — **hybrid search, cross-project search, polyglot code dependency graphs, symbol-level impact analysis and flow, interactive HTML graph explorer for visual navigation, and searchable context artifacts (database schemas, API specs, infra configs, architecture docs)**. Zero configuration — add it to an **MCP host that supports local stdio servers**, or use a supported plugin or extension. It manages everything automatically.
+**One thing, done well: deep codebase intelligence with zero setup, no bloat, and full automation.** SocratiCode gives AI assistants deep semantic understanding of your codebase: **hybrid search, cross-project search, polyglot code dependency graphs, symbol-level impact analysis and flow, interactive HTML graph explorer for visual navigation, and searchable context artifacts (database schemas, API specs, infra configs, architecture docs)**. Zero configuration: add it to an **MCP host that supports local stdio servers**, or use a supported plugin or extension. It manages everything automatically.
 
 **Production-ready**, battle-tested on **enterprise-level** large repositories (up to and over **~40 million lines of code**). **Batched**, automatic **resumable** indexing checkpoints progress — pauses, crashes, restarts, and interruptions don't lose work. The file watcher keeps the **index automatically updated** at every file change and across sessions. **Multi-branch, multi-repo** and **multi-agent ready** — multiple AI agents can work on the same codebase simultaneously, sharing a single index with automatic coordination and zero configuration.
 
@@ -103,16 +103,16 @@ Configuration schemas are host-specific. Continue, VS Code, Zed, OpenCode, Gemin
 
 Restart your host. With the default local configuration, first use pulls the required Docker images and starts managed Qdrant. `OLLAMA_MODE=auto` reuses a detected native Ollama instance or starts managed Ollama, then downloads the local embedding model if it is not already available. Cloud and external embedding providers do not download a local model. Initial setup usually takes about five minutes, depending on the connection; later starts take seconds.
 
-**First time on a project** — ask your AI: **"Index this codebase"**. Indexing runs in the background; ask **"What is the codebase index status?"** to monitor progress. Depending on codebase size and whether you're using GPU-accelerated Ollama or cloud embeddings, first-time indexing can take anywhere from a few seconds to a few minutes (it takes under 10 minutes to first-index +3 million lines of code on a Macbook Pro M4). Once complete it doesn't need to be run again, you can search, explore the dependency graph, and query context artifacts.
+**First time on a project:** ask your AI: **"Index this codebase"**. Indexing runs in the background; ask **"What is the codebase index status?"** to monitor progress. Depending on codebase size and whether you're using GPU-accelerated Ollama or cloud embeddings, first-time indexing can take anywhere from a few seconds to a few minutes (it takes under 10 minutes to first-index +3 million lines of code on a Macbook Pro M4). Once complete it doesn't need to be run again, you can search, explore the dependency graph, and query context artifacts.
 
-**Every time after that** — just use the tools (search, graph, etc.). On server startup SocratiCode automatically detects previously indexed projects, restarts the file watcher, and runs an incremental update to catch any changes made while the server was down. If indexing was interrupted, it resumes automatically from the last checkpoint. You can also explicitly start or restart the watcher with `codebase_watch { action: "start" }`.
+**Every time after that:** just use the tools (search, graph, etc.). On server startup SocratiCode automatically detects previously indexed projects, restarts the file watcher, and runs an incremental update to catch any changes made while the server was down. If indexing was interrupted, it resumes automatically from the last checkpoint. You can also explicitly start or restart the watcher with `codebase_watch { action: "start" }`.
 
 > **macOS / Windows on large codebases**: Docker containers can't use the GPU. For medium-to-large repos, [install native Ollama](https://ollama.com/download) (auto-detected, no config change needed) for Metal/CUDA acceleration, or use [OpenAI embeddings](#openai-embeddings) for speed without a local install. [Full details.](#embedding-performance-on-macos--windows)
-
-> **Recommended**: For best results, add the [Agent Instructions](#agent-instructions) to your AI assistant's system prompt or project instructions file (`CLAUDE.md`, `AGENTS.md`, etc.). The key principle — **search before reading** — helps your AI use SocratiCode's tools effectively and avoid unnecessary file reads.
-
-> **Claude Code users**: If you installed the SocratiCode plugin, the Agent Instructions are included automatically as skills — no need to add them to your `CLAUDE.md`. The plugin also bundles the MCP server, so you don't need a separate `claude mcp add`.
-
+>
+> **Recommended**: For best results, add the [Agent Instructions](#agent-instructions) to your AI assistant's system prompt or project instructions file (`CLAUDE.md`, `AGENTS.md`, etc.). The key principle, **search before reading**, helps your AI use SocratiCode's tools effectively and avoid unnecessary file reads.
+>
+> **Claude Code users**: If you installed the SocratiCode plugin, the Agent Instructions are included automatically as skills, so there is no need to add them to your `CLAUDE.md`. The plugin also bundles the MCP server, so you don't need a separate `claude mcp add`.
+>
 > **Advanced**: cloud embeddings (OpenAI / Google), external Qdrant, remote Ollama, native Ollama, and dozens of tuning options are all available. See [Configuration](#configuration) below.
 
 ## Plugins and host integrations

--- a/extension/README.md
+++ b/extension/README.md
@@ -87,9 +87,11 @@ their own MCP configuration.
    icon) and click *Index this workspace*. A local Ollama setup downloads
    its embedding model on first use if it is not already available; cloud
    and external providers do not. Subsequent updates are incremental.
-4. **Ask anything.** Use the editor's native agent: "where is auth handled?",
-   "what breaks if I change `processOrder`?", "trace the nightly cron
-   job", "what tables does this API touch?".
+4. **Ask anything.** In Microsoft VS Code, use native Agent Chat. In another
+   compatible editor, use that host's available agent or chat interface after
+   verifying the MCP provider. Ask: "where is auth handled?", "what breaks if
+   I change `processOrder`?", "trace the nightly cron job", or "what tables
+   does this API touch?".
 5. **Open the interactive graph.** Command Palette →
    `SocratiCode: Open interactive graph`.
 
@@ -147,10 +149,12 @@ independent client.
 ## Updating
 
 In Microsoft VS Code, use the Extensions view or run
-`Extensions: Check for Extension Updates`. In another editor, use that host's
-extension update flow. Reload the window, start a new native agent session, and
-verify both the installed version and SocratiCode server through the host's MCP
-server list. See the [host integration instructions](https://github.com/giancarloerra/socraticode#plugins-and-host-integrations).
+`Extensions: Check for Extension Updates`, reload the window, start a new native
+Agent Chat, and verify the final version and server with `MCP: List Servers`.
+In another editor, use that host's extension update flow, restart or reload it
+as documented, verify the registered MCP provider through its server list, and
+use its available agent or chat interface. See the
+[host integration instructions](https://github.com/giancarloerra/socraticode#plugins-and-host-integrations).
 
 ## SocratiCode Cloud (private beta)
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -26,9 +26,10 @@ Same understanding of your code, every assistant, every tool switch.</p>
 
 > **The big number.** On a 2.45M-line codebase, SocratiCode answers the same architectural question with **61% less context burned**, **84% fewer tool calls**, and **37x faster** than a grep-based AI agent. Same model, dramatically better answers. [Full benchmark on GitHub.](https://github.com/giancarloerra/socraticode#real-world-benchmark-vs-code-245m-lines-of-code-with-claude-opus-46)
 
-This extension auto-registers the SocratiCode MCP server in any
-MCP-compatible chat or agent in your editor, with no `mcp.json` editing
-required.
+On Microsoft VS Code 1.99+ and compatible editors that implement the VS Code
+MCP provider API, this extension registers SocratiCode with the editor's native
+MCP registry. Independent clients such as Cline, Continue, and Roo Code require
+their own MCP configuration.
 
 ## What it does
 
@@ -74,15 +75,20 @@ required.
 
 ## Quick start
 
-1. **Install the extension.** Search **SocratiCode** in your editor's
-   Extensions panel. The MCP server registers automatically.
-2. **Index the workspace.** Open the SocratiCode sidebar (Activity Bar
-   icon) and click *Index this workspace*. The first index downloads
-   the embedding model; subsequent updates are incremental.
-3. **Ask anything.** Use your AI assistant: "where is auth handled?",
+1. **Install the extension.** Search **SocratiCode** in the Extensions panel
+   and install it in the current editor profile from Visual Studio Marketplace
+   or Open VSX.
+2. **Activate and verify it.** Reload the editor window, start a new native
+   Agent Chat, and run `MCP: List Servers`. Confirm that `SocratiCode` is
+   listed and running.
+3. **Index the workspace.** Open the SocratiCode sidebar (Activity Bar
+   icon) and click *Index this workspace*. A local Ollama setup downloads
+   its embedding model on first use; cloud and external providers do not.
+   Subsequent updates are incremental.
+4. **Ask anything.** Use the editor's native agent: "where is auth handled?",
    "what breaks if I change `processOrder`?", "trace the nightly cron
    job", "what tables does this API touch?".
-4. **Open the interactive graph.** Command Palette →
+5. **Open the interactive graph.** Command Palette →
    `SocratiCode: Open interactive graph`.
 
 A walkthrough is shown on first install; re-open it any time via
@@ -90,11 +96,13 @@ A walkthrough is shown on first install; re-open it any time via
 
 ## Requirements
 
-- An editor on the VS Code 1.99+ API (any of the editors listed above).
-- Node.js 18+ on `PATH` (the engine launches via `npx`).
-- Docker Desktop running (for the default local engine), OR a
-  reachable external Qdrant if you'd rather not use Docker (configured
-  via `socraticode.env`, see Settings).
+- Microsoft VS Code 1.99+, or a compatible editor that implements
+  `vscode.lm.registerMcpServerDefinitionProvider`.
+- Node.js 18.17+ with `npx` on `PATH` (the engine launches via `npx`).
+- Docker Desktop running for the default managed Qdrant and Ollama stack.
+  Docker is optional when Qdrant is external and embeddings use either a
+  detected native Ollama instance or a cloud or external provider. Configure
+  these modes through `socraticode.env`; see Settings.
 
 ## Commands
 
@@ -118,31 +126,22 @@ All commands appear under `SocratiCode:` in the Command Palette.
 
 ## Compatibility
 
-**Editors.** This extension installs in any editor that supports the
-VS Code 1.99+ extension API:
+Microsoft VS Code Stable and Insiders implement the MCP provider API used by
+this extension. Open VSX makes the package available to VS Code-derived
+editors, but package installation alone does not prove that a host implements
+that API. If `MCP: List Servers` does not show SocratiCode, configure it through
+that host's own local stdio MCP settings.
 
-- Microsoft VS Code (Stable / Insiders)
-- Cursor
-- VSCodium
-- Gitpod
-- code-server
-- Eclipse Theia-based editors
-- Google Antigravity
-- Particle Workbench
+The extension registers only with the editor's native MCP host. It does not
+write configuration for Cursor Agent, Cline, Continue, Roo Code, or another
+independent client.
 
-**AI surfaces.** The MCP server registered by this extension is
-discovered automatically by any MCP-compatible chat or agent installed
-in your editor:
+## Updating
 
-- GitHub Copilot agent mode
-- Cursor's Agent / Composer
-- The Gemini chat surface in Antigravity
-- [Cline](https://github.com/cline/cline)
-- [Continue](https://www.continue.dev/)
-- [Roo Code](https://roo.tech/)
-- Any other MCP-aware client, including ones not listed here
-
-If your editor or AI surface speaks MCP, SocratiCode shows up.
+Use the Extensions view or run `Extensions: Check for Extension Updates`, then
+reload the window and start a new native Agent Chat. Verify the final version
+under the installed extension and confirm the server again with
+`MCP: List Servers`.
 
 ## SocratiCode Cloud (private beta)
 
@@ -178,11 +177,13 @@ project repo:
   https://docker.com/products/docker-desktop, or set `socraticode.env`
   with `QDRANT_MODE=external` plus `QDRANT_URL` to use an existing
   Qdrant instance.
-- **MCP tools don't appear in your assistant**: restart the chat after
-  install, or run `MCP: List Servers` from the command palette and
-  confirm `SocratiCode` is listed and started.
-- **First index is slow**: the engine downloads the embedding model
-  the first time. Subsequent runs are fast.
+- **MCP tools don't appear in the native agent**: reload the window, start a
+  new chat, then run `MCP: List Servers` from the command palette and confirm
+  `SocratiCode` is listed and started. Third-party clients require separate
+  MCP configuration.
+- **First local index is slow**: a local Ollama setup downloads the embedding
+  model the first time. Cloud and external providers do not. Subsequent runs
+  are fast.
 - **Anything else**: `SocratiCode: Show output / logs` from the
   command palette has the engine output.
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -83,8 +83,8 @@ their own MCP configuration.
    listed and running.
 3. **Index the workspace.** Open the SocratiCode sidebar (Activity Bar
    icon) and click *Index this workspace*. A local Ollama setup downloads
-   its embedding model on first use; cloud and external providers do not.
-   Subsequent updates are incremental.
+   its embedding model on first use if it is not already available; cloud
+   and external providers do not. Subsequent updates are incremental.
 4. **Ask anything.** Use the editor's native agent: "where is auth handled?",
    "what breaks if I change `processOrder`?", "trace the nightly cron
    job", "what tables does this API touch?".
@@ -98,6 +98,11 @@ A walkthrough is shown on first install; re-open it any time via
 
 - Microsoft VS Code 1.99+, or a compatible editor that implements
   `vscode.lm.registerMcpServerDefinitionProvider`.
+- To verify tools in Microsoft VS Code's native Agent Chat, enable AI features
+  and agents (`chat.agent.enabled`) and provide an available model through
+  GitHub Copilot or another supported configured provider. When using Copilot,
+  sign in with the account that has access and keep GitHub Copilot Chat current.
+  Organization policy can disable agents or restrict model access.
 - Node.js 18.17+ with `npx` on `PATH` (the engine launches via `npx`).
 - Docker Desktop running for the default managed Qdrant and Ollama stack.
   Docker is optional when Qdrant is external and embeddings use either a
@@ -182,8 +187,8 @@ project repo:
   `SocratiCode` is listed and started. Third-party clients require separate
   MCP configuration.
 - **First local index is slow**: a local Ollama setup downloads the embedding
-  model the first time. Cloud and external providers do not. Subsequent runs
-  are fast.
+  model if it is not already available. Cloud and external providers do not.
+  Subsequent runs are fast.
 - **Anything else**: `SocratiCode: Show output / logs` from the
   command palette has the engine output.
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -78,9 +78,11 @@ their own MCP configuration.
 1. **Install the extension.** Search **SocratiCode** in the Extensions panel
    and install it in the current editor profile from Visual Studio Marketplace
    or Open VSX.
-2. **Activate and verify it.** Reload the editor window, start a new native
-   Agent Chat, and run `MCP: List Servers`. Confirm that `SocratiCode` is
-   listed and running.
+2. **Activate and verify it.** In Microsoft VS Code, reload the window, start a
+   new native Agent Chat, and run `MCP: List Servers`. Confirm that
+   `SocratiCode` is listed and running. In another compatible editor, follow
+   that host's [integration instructions](https://github.com/giancarloerra/socraticode#plugins-and-host-integrations)
+   and verify through its own MCP server list.
 3. **Index the workspace.** Open the SocratiCode sidebar (Activity Bar
    icon) and click *Index this workspace*. A local Ollama setup downloads
    its embedding model on first use if it is not already available; cloud
@@ -104,7 +106,7 @@ A walkthrough is shown on first install; re-open it any time via
   sign in with the account that has access and keep GitHub Copilot Chat current.
   Organization policy can disable agents or restrict model access.
 - Node.js 18.17+ with `npx` on `PATH` (the engine launches via `npx`).
-- Docker Desktop running for the default managed Qdrant and Ollama stack.
+- Docker running for the default managed Qdrant and Ollama stack.
   Docker is optional when Qdrant is external and embeddings use either a
   detected native Ollama instance or a cloud or external provider. Configure
   these modes through `socraticode.env`; see Settings.
@@ -134,8 +136,9 @@ All commands appear under `SocratiCode:` in the Command Palette.
 Microsoft VS Code Stable and Insiders implement the MCP provider API used by
 this extension. Open VSX makes the package available to VS Code-derived
 editors, but package installation alone does not prove that a host implements
-that API. If `MCP: List Servers` does not show SocratiCode, configure it through
-that host's own local stdio MCP settings.
+that API. In Microsoft VS Code, verify registration with `MCP: List Servers`.
+In another editor, use its own MCP server list. If SocratiCode is unavailable,
+configure it through that host's local stdio MCP settings.
 
 The extension registers only with the editor's native MCP host. It does not
 write configuration for Cursor Agent, Cline, Continue, Roo Code, or another
@@ -143,10 +146,11 @@ independent client.
 
 ## Updating
 
-Use the Extensions view or run `Extensions: Check for Extension Updates`, then
-reload the window and start a new native Agent Chat. Verify the final version
-under the installed extension and confirm the server again with
-`MCP: List Servers`.
+In Microsoft VS Code, use the Extensions view or run
+`Extensions: Check for Extension Updates`. In another editor, use that host's
+extension update flow. Reload the window, start a new native agent session, and
+verify both the installed version and SocratiCode server through the host's MCP
+server list. See the [host integration instructions](https://github.com/giancarloerra/socraticode#plugins-and-host-integrations).
 
 ## SocratiCode Cloud (private beta)
 
@@ -178,14 +182,15 @@ project repo:
 
 ## Troubleshooting
 
-- **"Cannot find Docker"**: install Docker Desktop from
-  https://docker.com/products/docker-desktop, or set `socraticode.env`
-  with `QDRANT_MODE=external` plus `QDRANT_URL` to use an existing
-  Qdrant instance.
-- **MCP tools don't appear in the native agent**: reload the window, start a
-  new chat, then run `MCP: List Servers` from the command palette and confirm
-  `SocratiCode` is listed and started. Third-party clients require separate
-  MCP configuration.
+- **"Cannot find Docker"**: install and start
+  [Docker](https://docker.com/products/docker-desktop/). Docker-free operation
+  requires external Qdrant plus either a detected native Ollama instance or a
+  cloud or external embedding provider; configure those modes through
+  `socraticode.env`.
+- **MCP tools don't appear in the native agent**: reload the window and start a
+  new chat. In Microsoft VS Code, run `MCP: List Servers` and confirm that
+  `SocratiCode` is listed and started. In another editor, use its MCP server
+  list or follow the [host integration instructions](https://github.com/giancarloerra/socraticode#plugins-and-host-integrations).
 - **First local index is slow**: a local Ollama setup downloads the embedding
   model if it is not already available. Cloud and external providers do not.
   Subsequent runs are fast.

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "socraticode",
-  "version": "1.7.2",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "socraticode",
-      "version": "1.7.2",
+      "version": "1.12.0",
       "license": "AGPL-3.0-only",
       "devDependencies": {
         "@biomejs/biome": "^2.0.0",
@@ -19,7 +19,7 @@
         "typescript": "^5.6.0"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": ">=18.17.0",
         "vscode": "^1.99.0"
       }
     },

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "socraticode",
   "displayName": "SocratiCode",
-  "description": "Codebase context engine for AI assistants. Hybrid search, dependency and call graphs, symbol-level impact analysis (blast radius), interactive graph explorer, and searchable architecture artefacts. Works with Copilot agent mode, Cline, Continue, Roo Code, and any MCP-compatible host.",
+  "description": "Codebase context engine for VS Code's native MCP host. Hybrid search, dependency and call graphs, symbol-level impact analysis, interactive graph explorer, and searchable architecture artefacts.",
   "version": "1.12.0",
   "publisher": "giancarloerra",
   "license": "AGPL-3.0-only",
@@ -12,7 +12,7 @@
   },
   "engines": {
     "vscode": "^1.99.0",
-    "node": ">=18.0.0"
+    "node": ">=18.17.0"
   },
   "categories": [
     "AI",
@@ -81,7 +81,7 @@
     "viewsWelcome": [
       {
         "view": "socraticode.projects",
-        "contents": "SocratiCode indexes your codebase so AI assistants can search, trace dependencies and run impact analysis on it.\n\n[Index this workspace](command:socraticode.indexCurrentWorkspace)\n\nAsk your AI assistant (Copilot agent mode, Cline, Continue, Roo Code) to call any SocratiCode tool. The MCP server registers automatically on activation.\n\n[Open the getting-started walkthrough](command:socraticode.openWalkthrough)\n\n[Read the docs](https://github.com/giancarloerra/socraticode#readme)"
+        "contents": "SocratiCode indexes your codebase so AI assistants can search, trace dependencies and run impact analysis on it.\n\n[Index this workspace](command:socraticode.indexCurrentWorkspace)\n\nAsk VS Code's native agent to call a SocratiCode tool. The MCP server registers with VS Code's native MCP registry on activation. Third-party clients require their own MCP configuration.\n\n[Open the getting-started walkthrough](command:socraticode.openWalkthrough)\n\n[Read the docs](https://github.com/giancarloerra/socraticode#readme)"
       }
     ],
     "commands": [

--- a/extension/package.json
+++ b/extension/package.json
@@ -81,7 +81,7 @@
     "viewsWelcome": [
       {
         "view": "socraticode.projects",
-        "contents": "SocratiCode indexes your codebase so AI assistants can search, trace dependencies and run impact analysis on it.\n\n[Index this workspace](command:socraticode.indexCurrentWorkspace)\n\nAsk VS Code's native agent to call a SocratiCode tool. The MCP server registers with VS Code's native MCP registry on activation. Third-party clients require their own MCP configuration.\n\n[Open the getting-started walkthrough](command:socraticode.openWalkthrough)\n\n[Read the docs](https://github.com/giancarloerra/socraticode#readme)"
+        "contents": "SocratiCode indexes your codebase so AI assistants can search, trace dependencies and run impact analysis on it.\n\n[Index this workspace](command:socraticode.indexCurrentWorkspace)\n\nAsk your editor's native agent to call a SocratiCode tool. The MCP server registers with the editor's native MCP registry on activation. Independent clients require their own MCP configuration; see the host-specific integration guidance.\n\n[Open the getting-started walkthrough](command:socraticode.openWalkthrough)\n\n[Read the docs](https://github.com/giancarloerra/socraticode#readme)"
       }
     ],
     "commands": [

--- a/extension/src/mcpProvider.ts
+++ b/extension/src/mcpProvider.ts
@@ -6,13 +6,13 @@ import { log } from "./output.js";
 import { getSettings } from "./settings.js";
 
 /**
- * Registers the SocratiCode MCP server with VS Code's MCP host (Copilot
- * agent mode, Cline, Continue, Roo Code, ...) via the
+ * Registers the SocratiCode MCP server with VS Code's native MCP host via the
  * `vscode.lm.registerMcpServerDefinitionProvider` API (VS Code 1.99+).
  *
  * This is the single most important thing the extension does. Once this
- * provider is registered, every MCP-aware chat / agent in the editor sees
- * SocratiCode's tools without the user editing any `.vscode/mcp.json`.
+ * provider is registered, VS Code's native agent sees SocratiCode's tools
+ * without the user editing any `.vscode/mcp.json`. Independent clients use
+ * their own MCP configuration.
  *
  * The provider returns a single stdio definition that launches the engine
  * via `npx -y socraticode` (overridable via `socraticode.command` /

--- a/extension/walkthroughs/first-search.md
+++ b/extension/walkthroughs/first-search.md
@@ -4,12 +4,16 @@ Now your codebase is indexed, two things to try.
 
 ## Ask your AI assistant
 
-In VS Code's native agent mode, ask any of:
+In Microsoft VS Code's native Agent Chat, ask any of:
 
 - "Where is authentication handled in this project?"
 - "What breaks if I change the function `processOrder`?"
 - "Trace the execution flow of the cron job that runs nightly."
 - "Show me every place that talks to the `users` table."
+
+In another compatible editor, first verify the registered MCP provider using
+that host's [integration instructions](https://github.com/giancarloerra/socraticode#plugins-and-host-integrations),
+then use the editor's available agent or chat interface.
 
 The assistant will call SocratiCode's MCP tools (`codebase_search`,
 `codebase_impact`, `codebase_flow`, `codebase_symbol`, etc.) automatically.

--- a/extension/walkthroughs/first-search.md
+++ b/extension/walkthroughs/first-search.md
@@ -4,7 +4,7 @@ Now your codebase is indexed, two things to try.
 
 ## Ask your AI assistant
 
-In Copilot agent mode, Cline, Continue or Roo Code, ask any of:
+In VS Code's native agent mode, ask any of:
 
 - "Where is authentication handled in this project?"
 - "What breaks if I change the function `processOrder`?"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "socraticode",
-  "version": "1.4.1",
+  "version": "1.12.0",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "socraticode": {

--- a/scripts/bump-plugin-versions.mjs
+++ b/scripts/bump-plugin-versions.mjs
@@ -4,8 +4,9 @@
 //
 // release-it `after:bump` hook. Synchronises the version field across
 // every plugin / extension manifest in the repo so a single engine
-// release also bumps the Claude / Cursor / Codex plugins and the
-// VS Code / Open VSX extension. Skips manifests that don't exist.
+// release also bumps the Claude / Cursor / Codex plugins, the Gemini
+// extension, and the VS Code / Open VSX extension. Skips manifests that
+// don't exist.
 //
 // Usage: node scripts/bump-plugin-versions.mjs <version>
 
@@ -16,7 +17,9 @@ const MANIFESTS = [
   ".claude-plugin/plugin.json",
   ".cursor-plugin/plugin.json",
   ".codex-plugin/plugin.json",
+  "gemini-extension.json",
   "extension/package.json",
+  "extension/package-lock.json",
 ];
 
 const version = process.argv[2];
@@ -31,8 +34,20 @@ for (const rel of MANIFESTS) {
   if (!existsSync(path)) continue;
   try {
     const json = JSON.parse(readFileSync(path, "utf8"));
-    if (json.version === version) continue;
-    json.version = version;
+    let changed = false;
+    if (json.version !== version) {
+      json.version = version;
+      changed = true;
+    }
+    if (
+      rel.endsWith("package-lock.json") &&
+      json.packages?.[""] &&
+      json.packages[""].version !== version
+    ) {
+      json.packages[""].version = version;
+      changed = true;
+    }
+    if (!changed) continue;
     writeFileSync(path, `${JSON.stringify(json, null, 2)}\n`);
     console.log(`bumped ${rel} -> ${version}`);
     touched += 1;

--- a/tests/unit/plugin-version-sync.test.ts
+++ b/tests/unit/plugin-version-sync.test.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const projectRoot = fileURLToPath(new URL("../../", import.meta.url));
+const manifestPaths = [
+  ".claude-plugin/plugin.json",
+  ".cursor-plugin/plugin.json",
+  ".codex-plugin/plugin.json",
+  "gemini-extension.json",
+  "extension/package.json",
+  "extension/package-lock.json",
+];
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+}
+
+describe("plugin and extension version synchronisation", () => {
+  it("keeps every shipped manifest aligned with the package version", () => {
+    const packageVersion = readJson(join(projectRoot, "package.json")).version;
+
+    for (const relativePath of manifestPaths) {
+      const manifest = readJson(join(projectRoot, relativePath));
+      expect(manifest.version, relativePath).toBe(packageVersion);
+
+      if (relativePath.endsWith("package-lock.json")) {
+        const packages = manifest.packages as Record<string, Record<string, unknown>>;
+        expect(packages[""].version, `${relativePath} root package`).toBe(packageVersion);
+      }
+    }
+  });
+
+  it("bumps Gemini and the extension lockfile with the other manifests", () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "socraticode-version-sync-"));
+    temporaryDirectories.push(fixtureRoot);
+
+    for (const relativePath of manifestPaths) {
+      const path = join(fixtureRoot, relativePath);
+      mkdirSync(dirname(path), { recursive: true });
+      const manifest = relativePath.endsWith("package-lock.json")
+        ? { version: "0.0.0", packages: { "": { version: "0.0.0" } } }
+        : { version: "0.0.0" };
+      writeFileSync(path, `${JSON.stringify(manifest)}\n`);
+    }
+
+    execFileSync(
+      process.execPath,
+      [join(projectRoot, "scripts/bump-plugin-versions.mjs"), "9.9.9"],
+      { cwd: fixtureRoot },
+    );
+
+    for (const relativePath of manifestPaths) {
+      const manifest = readJson(join(fixtureRoot, relativePath));
+      expect(manifest.version, relativePath).toBe("9.9.9");
+      if (relativePath.endsWith("package-lock.json")) {
+        const packages = manifest.packages as Record<string, Record<string, unknown>>;
+        expect(packages[""].version).toBe("9.9.9");
+      }
+    }
+  });
+
+  it("updates an npm v1 lockfile without a packages map", () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "socraticode-version-sync-v1-"));
+    temporaryDirectories.push(fixtureRoot);
+    const lockfilePath = join(fixtureRoot, "extension/package-lock.json");
+    mkdirSync(dirname(lockfilePath), { recursive: true });
+    writeFileSync(
+      lockfilePath,
+      `${JSON.stringify({ name: "socraticode", version: "0.0.0", lockfileVersion: 1 })}\n`,
+    );
+
+    execFileSync(
+      process.execPath,
+      [join(projectRoot, "scripts/bump-plugin-versions.mjs"), "9.9.9"],
+      { cwd: fixtureRoot },
+    );
+
+    expect(readJson(lockfilePath).version).toBe("9.9.9");
+  });
+});


### PR DESCRIPTION
## Summary

- document current install, scope, activation, verification, and update paths for supported hosts
- distinguish native plugins, the VS Code editor extension, Gemini extensions, and direct MCP configuration
- synchronize Gemini and VS Code extension metadata and keep it aligned during releases
- add regression coverage for integration manifest version synchronization

Closes #144

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- VS Code extension lint, typecheck, tests, and package
- `gemini extensions validate .`
- isolated Claude plugin and MCP connection smoke tests
- isolated Codex plugin and MCP configuration smoke tests
- isolated VS Code 1.136 VSIX activation and native MCP provider registration
- isolated Gemini extension connection smoke test
- current official documentation link checks
- local CodeRabbit review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation requirements to Node.js 18.17 or newer.
  * Expanded setup guidance for supported MCP clients, including Claude Code, Codex, VS Code, Cursor, Gemini CLI, and others.
  * Clarified native VS Code MCP integration, independent client configuration, provider options, Docker/Ollama behavior, updating, and troubleshooting.
  * Updated walkthroughs, Zed guidance, extension compatibility information, and release-versioning documentation.

* **Chores**
  * Updated the Gemini extension version and synchronized shipped plugin and extension metadata.

* **Tests**
  * Added coverage for plugin and extension version synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->