### PR TITLE
fix(symbols): take the Swift declaration kind from its keyword (#142)

### DIFF
--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -2271,7 +2271,27 @@ function extractFromSwift(
   const symbols: SymbolNode[] = [moduleSym];
   const scopes: ScopeFrame[] = [];
 
-  for (const k of ["class_declaration", "struct_declaration", "protocol_declaration", "enum_declaration"]) {
+  // The node kind does not say which form this is. The packaged Swift grammar
+  // files a `class`, a `struct`, an `enum`, an `actor` and an `extension` all
+  // under `class_declaration`, and defines no `struct_declaration` or
+  // `enum_declaration` at all — asking for those threw, `safeFindAll` returned
+  // empty, and the `struct` and `enum` branches below were unreachable, so every
+  // Swift struct and enum was extracted as a `class`.
+  //
+  // What distinguishes them is the declaration keyword, and it is not reliably
+  // the first child: `public struct P` puts a `modifiers` node first, and
+  // `indirect enum E` an `indirect`. So the keyword is searched for among the
+  // direct children rather than read off the head — `children()` does not
+  // descend, so a nested `struct` inside a body cannot be mistaken for it.
+  //
+  // Only `struct` and `enum` are named. `class`, `actor` and `extension` keep
+  // the `class` they already had; naming them is a separate question about what
+  // those forms should be called, not this fix.
+  const SWIFT_FORM_KINDS = new Map<string, SymbolNode["kind"]>([
+    ["struct", "struct"],
+    ["enum", "enum"],
+  ]);
+  for (const k of ["class_declaration", "protocol_declaration"]) {
     for (const cls of safeFindAll(root, k)) {
       const nameNode = safeFind(cls, "type_identifier")
         ?? safeFind(cls, "identifier");
@@ -2280,12 +2300,14 @@ function extractFromSwift(
       const r = cls.range();
       const startLine = r.start.line + 1;
       const endLine = r.end.line + 1;
+      // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+      const keyword = cls.children().find((c: any) => SWIFT_FORM_KINDS.has(c.kind()));
       const sym: SymbolNode = {
         id: makeId(file, name, startLine),
         name, qualifiedName: name,
-        kind: k.includes("struct") ? "struct"
-          : k.includes("protocol") ? "interface"
-          : k.includes("enum") ? "enum" : "class",
+        kind: k === "protocol_declaration"
+          ? "interface"
+          : (keyword && SWIFT_FORM_KINDS.get(keyword.kind())) ?? "class",
         file, line: startLine, endLine, language,
       };
       symbols.push(sym);

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -573,6 +573,62 @@ class Foo {
       expect(names).toContain("greet");
       expect(names).toContain("Foo");
       expect(names).toContain("bar");
+      // The fixture above already declared a class and asserted only its name.
+      expect(out.symbols.find((s) => s.name === "Foo")?.kind).toBe("class");
+    });
+
+    it("takes the kind from the declaration keyword, not from the node kind", () => {
+      // The grammar files class, struct, enum, actor and extension all under
+      // `class_declaration`, so the node kind cannot tell them apart.
+      const src = `
+class C { var a: Int = 0 }
+struct S { var a: Int }
+enum E { case one }
+protocol P { func f() }
+actor A { var a: Int = 0 }
+`;
+      const out = extractSymbolsAndCalls(src, "swift" as unknown as Lang, ".swift", "App.swift");
+      const byName = new Map(out.symbols.map((s) => [s.name, s.kind]));
+      expect(byName.get("C")).toBe("class");
+      expect(byName.get("S")).toBe("struct");
+      expect(byName.get("E")).toBe("enum");
+      expect(byName.get("P")).toBe("interface");
+      // An actor keeps the `class` it already had: naming that form is a
+      // separate question from reading the keyword.
+      expect(byName.get("A")).toBe("class");
+    });
+
+    it("finds the keyword when a modifier precedes it", () => {
+      // `public struct P` puts a `modifiers` node first and `indirect enum E`
+      // an `indirect`, so the keyword is not reliably the first child — and
+      // reading the head instead would misfile the commonest declaration in
+      // real Swift.
+      const src = `
+public struct PS { var a: Int }
+final class FC { var a: Int = 0 }
+indirect enum IE { case one(IE) }
+`;
+      const out = extractSymbolsAndCalls(src, "swift" as unknown as Lang, ".swift", "App.swift");
+      const byName = new Map(out.symbols.map((s) => [s.name, s.kind]));
+      expect(byName.get("PS")).toBe("struct");
+      expect(byName.get("FC")).toBe("class");
+      expect(byName.get("IE")).toBe("enum");
+    });
+
+    it("does not take a nested declaration's keyword for the outer one", () => {
+      // The keyword is searched among direct children only, so a `struct`
+      // inside an extension's body cannot rename the extension.
+      const src = `
+extension C {
+    struct Inner { var a: Int }
+    func g() {}
+}
+`;
+      const out = extractSymbolsAndCalls(src, "swift" as unknown as Lang, ".swift", "App.swift");
+      const byName = new Map(out.symbols.map((s) => [s.name, s.kind]));
+      expect(byName.get("C")).toBe("class");
+      expect(byName.get("Inner")).toBe("struct");
+      expect(byName.get("g")).toBe("function");
     });
   });
 


### PR DESCRIPTION
## Summary

`extractFromSwift` asked for `struct_declaration` and `enum_declaration`, which the packaged grammar does not define, and picked the symbol kind from the node kind's spelling. ast-grep throws on an undefined kind and `safeFindAll` returns `[]`, so those two iterations matched nothing, the `struct` and `enum` branches of the conditional were unreachable, and **every Swift struct and enum was extracted as a `class`**.

Only the label was wrong — the symbols themselves were extracted by the `class_declaration` pass, with the right names and lines.

| source | `main` | this branch |
|---|---|---|
| `class C {}` | `class` | `class` |
| `struct S {}` | **`class`** | **`struct`** |
| `enum E { case one }` | **`class`** | **`enum`** |
| `protocol P {}` | `interface` | `interface` |
| `actor A {}` | `class` | `class` |
| `extension C {}` | `class` | `class` |

## Changes

The grammar files `class`, `struct`, `enum`, `actor` and `extension` all under `class_declaration`, so the node kind cannot tell them apart. The two kinds it cannot produce are removed, and the kind comes from the declaration keyword.

**The keyword is searched for among the direct children, not read off the head.** It is not reliably first:

```
struct S { var a: Int }          children: struct, type_identifier, class_body
public struct PS { var a: Int }  children: modifiers, struct, type_identifier
indirect enum IE { case one }    children: indirect, enum, type_identifier
final class FC {}                children: modifiers, class, type_identifier
```

`children()[0]` would pass a test written with a bare `struct P` and misfile `public struct P`, which is the commoner declaration in real Swift. `children()` does not descend, so a `struct` nested in an extension's body cannot rename the extension.

**Only `struct` and `enum` are named.** `class`, `actor` and `extension` keep the `class` they already had. What those forms should be called is a separate question from reading the keyword, and #142 asks for the label to be fixed, not widened.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test coverage improvement

## Testing

- [x] Unit tests pass (`npm run test:unit`)
- [x] Full suite passes (`npx vitest run`) — **1,906 passed**, 86 files
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Lint clean (`npm run lint`)
- [x] New tests added for new/changed functionality

Three tests — the five forms under one node kind, a modifier and an `indirect` before the keyword, and a nested declaration that must not rename its container — and the pre-existing Swift test now asserts the kind it always declared. Each mutation-checked, of the 58 tests in the file:

| mutation | result |
|---|---|
| the previous implementation (i.e. `main`) | **3 red** |
| the keyword read as `children()[0]` | **1 red** |
| the search descending instead of staying on direct children | **3 red** |
| `enum` dropped from the table | **2 red** |

## Known limits

- **An `extension` is still extracted under the name of the type it extends, with the kind `class`.** `extension C { ... }` yields `C:class`, so an extension and the class it extends produce two symbols of one name when both are in the graph. That is pre-existing and unchanged here; naming extensions is the separate question mentioned above.
- **`actor` is `class`.** `SymbolKind` has no member for it, and adding one is a change to the shared union rather than to this extractor.
- **The other extractors are untouched.** I checked the four that #141's discussion cited as precedent by running them, not by reading them: C++ and C# do yield `struct`, Scala and PHP do yield `trait`. Swift was the one place where the intent in the source did not reach the output.

## Related

Closes #142. Found while checking, for #141, which extractors already emit `struct` — reading the source, Swift looked like a precedent; running it, it was not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Swift code symbols are now classified correctly as classes, structs, enums, interfaces, or actors.
  - Declarations with modifiers such as `public`, `final`, or `indirect` are recognized accurately.
  - Nested declarations no longer cause the surrounding declaration to receive the wrong symbol type.

- **Tests**
  - Added coverage for Swift declaration classification, modifiers, and nested declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->