### PR TITLE
fix(symbols): read Rust qualified calls, and resolve them by their qualifier

### DIFF
--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -253,6 +253,7 @@ async function doRebuildGraph(
           built.outgoingCallsByFile,
           built.rustBindingsByFile,
           built.rustCrateRootByFile,
+          built.rustInlineScopedCalls,
         );
 
         progress.phase = "persisting symbols";
@@ -816,6 +817,12 @@ export async function buildCodeGraph(
   rustBindingsByFile: Map<string, RustUseBinding[]>;
   /** Rust file → its crate's directory prefix. Resolution input only. */
   rustCrateRootByFile: Map<string, string>;
+  /**
+   * The call edges whose qualifier is rooted in an inline `mod` — a scope with
+   * no file to name. Resolution leaves them unresolved. Held by identity, so
+   * nothing about it reaches an edge or the store.
+   */
+  rustInlineScopedCalls: Set<SymbolEdge>;
 }> {
   ensureDynamicLanguages();
 
@@ -839,6 +846,7 @@ export async function buildCodeGraph(
   const symbolsByFile = new Map<string, SymbolNode[]>();
   const outgoingCallsByFile = new Map<string, SymbolEdge[]>();
   const rustBindingsByFile = new Map<string, RustUseBinding[]>();
+  const rustInlineScopedCalls = new Set<SymbolEdge>();
 
   // Per-reason counts, holding only the reasons that actually fired — the build log
   // emits `skipReasons` straight from this map, so it never carries a zero.
@@ -1080,7 +1088,14 @@ export async function buildCodeGraph(
     try {
       const extracted = extractSymbolsAndCalls(source, extractionLang, ext, relPath);
       symbolsByFile.set(relPath, extracted.symbols);
-      outgoingCallsByFile.set(relPath, rawCallsToUnresolvedEdges(extracted.rawCalls));
+      const edges = rawCallsToUnresolvedEdges(extracted.rawCalls);
+      outgoingCallsByFile.set(relPath, edges);
+      // One edge per raw call, in order, so the call at `i` is the edge at `i`.
+      // The flag stays out of the edge itself: it is resolution's business and
+      // the store must not grow a field for it.
+      for (let i = 0; i < extracted.rawCalls.length; i++) {
+        if (extracted.rawCalls[i].qualifierRootedInInlineMod) rustInlineScopedCalls.add(edges[i]);
+      }
       if (extracted.bindings && extracted.bindings.length > 0) {
         rustBindingsByFile.set(relPath, extracted.bindings);
       }
@@ -1179,5 +1194,6 @@ export async function buildCodeGraph(
     outgoingCallsByFile,
     rustBindingsByFile,
     rustCrateRootByFile,
+    rustInlineScopedCalls,
   };
 }

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -18,7 +18,12 @@ import { loadPathAliases } from "./graph-aliases.js";
 import { extractImports } from "./graph-imports.js";
 import { buildCsNamespaceMap, buildDartPackageMap, buildElixirModuleMap, buildGoModuleInfo, buildJvmSuffixMap, buildPhpFqcnMap, buildPhpPsr4Map, buildPythonManifests, buildRustCrateMap, pythonRootsForFile, resolveImport } from "./graph-resolution.js";
 import { computeUnresolvedPct, resolveCallSites } from "./graph-symbol-resolution.js";
-import { extractSymbolsAndCalls, rawCallsToUnresolvedEdges } from "./graph-symbols.js";
+import {
+  extractSymbolsAndCalls,
+  type RustUseBinding,
+  rawCallsToUnresolvedEdges,
+} from "./graph-symbols.js";
+
 import { createIgnoreFilter, shouldIgnore } from "./ignore.js";
 import { logger } from "./logger.js";
 import { deleteGraphData, describeQdrantError, getGraphMetadata, loadGraphData, saveGraphData } from "./qdrant.js";
@@ -242,7 +247,13 @@ async function doRebuildGraph(
     if (!opts.skipSymbolGraph) {
       try {
         progress.phase = "resolving symbols";
-        resolveCallSites(graph, built.symbolsByFile, built.outgoingCallsByFile);
+        resolveCallSites(
+          graph,
+          built.symbolsByFile,
+          built.outgoingCallsByFile,
+          built.rustBindingsByFile,
+          built.rustCrateRootByFile,
+        );
 
         progress.phase = "persisting symbols";
         await persistSymbolGraph(projectId, resolvedPath, built.symbolsByFile, built.outgoingCallsByFile);
@@ -801,6 +812,10 @@ export async function buildCodeGraph(
 ): Promise<CodeGraph & {
   symbolsByFile: Map<string, SymbolNode[]>;
   outgoingCallsByFile: Map<string, SymbolEdge[]>;
+  /** Rust `use` bindings per file — resolution input only, never persisted. */
+  rustBindingsByFile: Map<string, RustUseBinding[]>;
+  /** Rust file → its crate's directory prefix. Resolution input only. */
+  rustCrateRootByFile: Map<string, string>;
 }> {
   ensureDynamicLanguages();
 
@@ -823,6 +838,7 @@ export async function buildCodeGraph(
   const edges: CodeGraphEdge[] = [];
   const symbolsByFile = new Map<string, SymbolNode[]>();
   const outgoingCallsByFile = new Map<string, SymbolEdge[]>();
+  const rustBindingsByFile = new Map<string, RustUseBinding[]>();
 
   // Per-reason counts, holding only the reasons that actually fired — the build log
   // emits `skipReasons` straight from this map, so it never carries a zero.
@@ -935,6 +951,28 @@ export async function buildCodeGraph(
   const hasRust = files.some((f) => path.extname(f).toLowerCase() === ".rs");
   const rustCrates = hasRust ? buildRustCrateMap(fileSet, resolvedPath) : undefined;
 
+  // Which crate each Rust file belongs to, as a path prefix. `crate::` is
+  // relative to a crate's own root module, so resolution needs the boundary —
+  // and the manifests are what draw it. Deriving it from the path instead
+  // means guessing at a layout: a marker like `src/` misses a crate that has
+  // no `src/` directory (ripgrep) and misreads one whose sources start at the
+  // project root (tokio), and the guess fails silently in both.
+  //
+  // The owning crate is the one whose directory contains the file and is
+  // deepest, with the workspace root at `"."` ranking as no depth at all —
+  // the same rule the import resolver settled on. A crate at the root confines
+  // nothing, which is correct: there is only one crate to be in.
+  const rustCrateRootByFile = new Map<string, string>();
+  if (rustCrates && rustCrates.length > 0) {
+    const depthOf = (crate: { dir: string }): number => (crate.dir === "." ? 0 : crate.dir.length);
+    const ranked = [...rustCrates].sort((a, b) => depthOf(b) - depthOf(a));
+    for (const relPath of files) {
+      if (!relPath.endsWith(".rs")) continue;
+      const owner = ranked.find((c) => c.dir === "." || relPath.startsWith(`${c.dir}/`));
+      if (owner) rustCrateRootByFile.set(relPath, owner.dir === "." ? "" : `${owner.dir}/`);
+    }
+  }
+
   for (const relPath of files) {
     let ext = path.extname(relPath).toLowerCase();
     let lang = getAstGrepLang(ext);
@@ -1043,6 +1081,9 @@ export async function buildCodeGraph(
       const extracted = extractSymbolsAndCalls(source, extractionLang, ext, relPath);
       symbolsByFile.set(relPath, extracted.symbols);
       outgoingCallsByFile.set(relPath, rawCallsToUnresolvedEdges(extracted.rawCalls));
+      if (extracted.bindings && extracted.bindings.length > 0) {
+        rustBindingsByFile.set(relPath, extracted.bindings);
+      }
     } catch (err) {
       logger.debug("Symbol extraction failed (continuing)", {
         file: relPath,
@@ -1136,5 +1177,7 @@ export async function buildCodeGraph(
     edges,
     symbolsByFile,
     outgoingCallsByFile,
+    rustBindingsByFile,
+    rustCrateRootByFile,
   };
 }

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -254,6 +254,7 @@ async function doRebuildGraph(
           built.rustBindingsByFile,
           built.rustCrateRootByFile,
           built.rustInlineScopedCalls,
+          built.rustInlineDeclaredSymbols,
         );
 
         progress.phase = "persisting symbols";
@@ -823,6 +824,12 @@ export async function buildCodeGraph(
    * nothing about it reaches an edge or the store.
    */
   rustInlineScopedCalls: Set<SymbolEdge>;
+  /**
+   * The ids of the Rust symbols declared inside an inline `mod`. A path
+   * anchored at a file's own module cannot reach them, so resolution drops
+   * them from that path's candidates. Resolution input only, never persisted.
+   */
+  rustInlineDeclaredSymbols: Set<string>;
 }> {
   ensureDynamicLanguages();
 
@@ -847,6 +854,7 @@ export async function buildCodeGraph(
   const outgoingCallsByFile = new Map<string, SymbolEdge[]>();
   const rustBindingsByFile = new Map<string, RustUseBinding[]>();
   const rustInlineScopedCalls = new Set<SymbolEdge>();
+  const rustInlineDeclaredSymbols = new Set<string>();
 
   // Per-reason counts, holding only the reasons that actually fired — the build log
   // emits `skipReasons` straight from this map, so it never carries a zero.
@@ -1096,6 +1104,11 @@ export async function buildCodeGraph(
       for (let i = 0; i < extracted.rawCalls.length; i++) {
         if (extracted.rawCalls[i].qualifierRootedInInlineMod) rustInlineScopedCalls.add(edges[i]);
       }
+      // Same reason, one level down: which declarations sit inside an inline
+      // `mod` is visible in the extractor and nowhere after it.
+      if (extracted.inlineModSymbolIds) {
+        for (const id of extracted.inlineModSymbolIds) rustInlineDeclaredSymbols.add(id);
+      }
       if (extracted.bindings && extracted.bindings.length > 0) {
         rustBindingsByFile.set(relPath, extracted.bindings);
       }
@@ -1195,5 +1208,6 @@ export async function buildCodeGraph(
     rustBindingsByFile,
     rustCrateRootByFile,
     rustInlineScopedCalls,
+    rustInlineDeclaredSymbols,
   };
 }

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -829,7 +829,7 @@ export async function buildCodeGraph(
    * anchored at a file's own module cannot reach them, so resolution drops
    * them from that path's candidates. Resolution input only, never persisted.
    */
-  rustInlineDeclaredSymbols: Set<string>;
+  rustInlineDeclaredSymbols: Map<string, string>;
 }> {
   ensureDynamicLanguages();
 
@@ -854,7 +854,7 @@ export async function buildCodeGraph(
   const outgoingCallsByFile = new Map<string, SymbolEdge[]>();
   const rustBindingsByFile = new Map<string, RustUseBinding[]>();
   const rustInlineScopedCalls = new Set<SymbolEdge>();
-  const rustInlineDeclaredSymbols = new Set<string>();
+  const rustInlineDeclaredSymbols = new Map<string, string>();
 
   // Per-reason counts, holding only the reasons that actually fired — the build log
   // emits `skipReasons` straight from this map, so it never carries a zero.
@@ -1107,7 +1107,9 @@ export async function buildCodeGraph(
       // Same reason, one level down: which declarations sit inside an inline
       // `mod` is visible in the extractor and nowhere after it.
       if (extracted.inlineModSymbolIds) {
-        for (const id of extracted.inlineModSymbolIds) rustInlineDeclaredSymbols.add(id);
+        for (const [id, owner] of extracted.inlineModSymbolIds) {
+          rustInlineDeclaredSymbols.set(id, owner);
+        }
       }
       if (extracted.bindings && extracted.bindings.length > 0) {
         rustBindingsByFile.set(relPath, extracted.bindings);

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -261,6 +261,7 @@ async function doRebuildGraph(
           built.rustCrateRootByFile,
           built.rustInlineScopedCalls,
           built.rustInlineDeclaredSymbols,
+          built.rustCrateRootsByFile,
         );
 
         progress.phase = "persisting symbols";
@@ -932,6 +933,8 @@ export async function buildCodeGraph(
   rustBindingsByFile: Map<string, RustUseBinding[]>;
   /** Rust file → its crate's directory prefix. Resolution input only. */
   rustCrateRootByFile: Map<string, string>;
+  /** Rust file → every target root its parsed Cargo manifest declares. */
+  rustCrateRootsByFile: Map<string, string[]>;
   /**
    * The call edges whose qualifier is rooted in an inline `mod` — a scope with
    * no file to name. Resolution leaves them unresolved. Held by identity, so
@@ -1113,13 +1116,21 @@ export async function buildCodeGraph(
   // the same rule the import resolver settled on. A crate at the root confines
   // nothing, which is correct: there is only one crate to be in.
   const rustCrateRootByFile = new Map<string, string>();
+  const rustCrateRootsByFile = new Map<string, string[]>();
   if (rustCrates && rustCrates.length > 0) {
     const depthOf = (crate: { dir: string }): number => (crate.dir === "." ? 0 : crate.dir.length);
     const ranked = [...rustCrates].sort((a, b) => depthOf(b) - depthOf(a));
     for (const relPath of files) {
       if (!relPath.endsWith(".rs")) continue;
       const owner = ranked.find((c) => c.dir === "." || relPath.startsWith(`${c.dir}/`));
-      if (owner) rustCrateRootByFile.set(relPath, owner.dir === "." ? "" : `${owner.dir}/`);
+      if (owner) {
+        rustCrateRootByFile.set(relPath, owner.dir === "." ? "" : `${owner.dir}/`);
+        // Only a parsed manifest is complete enough to make absence a verdict.
+        // An unreadable manifest contributes convention roots for import
+        // recovery, but those roots must not hide a custom target it could not
+        // declare to us.
+        if (!owner.manifestUnread) rustCrateRootsByFile.set(relPath, [...owner.roots]);
+      }
     }
   }
 
@@ -1380,6 +1391,7 @@ export async function buildCodeGraph(
     outgoingCallsByFile,
     rustBindingsByFile,
     rustCrateRootByFile,
+    rustCrateRootsByFile,
     rustInlineScopedCalls,
     rustInlineDeclaredSymbols,
   };

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -446,7 +446,19 @@ export function resolveCallSites(
       const binding = bindings.find((b) => b.local === segments[0]);
       if (binding) {
         const bound = binding.path.split("::").map((s) => s.trim()).filter(Boolean);
-        if (bound[0] === "crate") inOwnCrate = true;
+        // The same path, so the same scope: `use crate as root;` makes
+        // `root::helper()` mean `crate::helper()`, and reading it in the
+        // caller's own scope would answer nothing where the plain spelling
+        // answers the crate root.
+        let boundRoot: string | null = null;
+        if (bound[0] === "crate") {
+          inOwnCrate = true;
+          boundRoot = crateRootFileOf(callerFile);
+          if (boundRoot) {
+            homes = [boundRoot];
+            scopeDeps = [...new Set([boundRoot, ...(depsByFile.get(boundRoot) ?? []), ...deps])];
+          }
+        }
         if (bound[0] === "super") {
           // `use super::config;` binds the parent's `config`, so the bound path
           // is read where `super::config` is read. Stripping the hop and
@@ -464,7 +476,8 @@ export function resolveCallSites(
         } else {
           const head = bound[0] === "crate" || bound[0] === "self" ? bound.slice(1) : bound;
           rest = [...head, ...segments.slice(1)];
-          if (rest.length === 0) return null;
+          // `use crate as root;` binds the crate root itself.
+          if (rest.length === 0) return boundRoot ? [boundRoot] : null;
         }
       }
     }

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -219,6 +219,12 @@ export function resolveCallSites(
    * it: nothing is dropped then, which is what this did before.
    */
   rustInlineDeclaredSymbols?: ReadonlyMap<string, string>,
+  /**
+   * Rust file → every target root declared by its parsed Cargo manifest.
+   * This is in-memory build metadata only. Kept optional and last so existing
+   * callers retain the pre-manifest fallback behaviour.
+   */
+  rustCrateRootsByFile?: ReadonlyMap<string, readonly string[]>,
 ): void {
   // Build a fast lookup: file → Map<symbolName, SymbolNode[]>
   const symbolIndexByFile = new Map<string, Map<string, SymbolNode[]>>();
@@ -445,6 +451,21 @@ export function resolveCallSites(
   function crateRootFilesOf(callerFile: string): string[] | null {
     const prefix = rustCrateRootByFile?.get(callerFile);
     if (prefix === undefined) return null;
+
+    // The manifest parser already knows every target root, including custom
+    // `[lib] path`, `[[bin]] path`, tests, examples, benches and build scripts.
+    // Prefer that authoritative list when it is available. A root is its own
+    // crate; a module belongs to the roots that reach it. When several targets
+    // exist and none reaches the file, choosing any one would manufacture a
+    // cross-target edge, so the honest answer is unresolved.
+    const declaredRoots = rustCrateRootsByFile?.get(callerFile);
+    if (declaredRoots) {
+      if (declaredRoots.includes(callerFile)) return [callerFile];
+      if (declaredRoots.length === 0) return [];
+      const reaching = declaredRoots.filter((root) => reachedFrom(root).has(callerFile));
+      if (reaching.length > 0) return reaching;
+      return declaredRoots.length === 1 ? [...declaredRoots] : [];
+    }
 
     for (const dir of CARGO_TARGET_DIRS) {
       const targetDir = `${prefix}${dir}/`;
@@ -748,8 +769,14 @@ export function resolveCallSites(
         } else {
           const head = bound[0] === "crate" || bound[0] === "self" ? bound.slice(1) : bound;
           rest = [...head, ...segments.slice(1)];
-          // `use crate as root;` binds the crate root itself.
-          if (rest.length === 0) return boundRoots ? asPath(boundRoots) : null;
+          // `use crate as root;` binds the crate root itself; `use self as
+          // this_module;` binds the caller's own module. Neither anchor has a
+          // path segment left after the alias is expanded.
+          if (rest.length === 0) {
+            if (boundRoots) return asPath(boundRoots);
+            if (bound[0] === "self") return asPath(homes);
+            return null;
+          }
         }
       }
     }
@@ -851,26 +878,103 @@ export function resolveCallSites(
     return null;
   }
 
+  /** Cached module paths used to validate crate- and super-rooted re-exports. */
+  const rustModulePathsByFile = new Map<string, string[][]>();
+
+  /** Module paths of `file`, relative to each target root that reaches it. */
+  function rustModulePathsOf(file: string): string[][] {
+    const cached = rustModulePathsByFile.get(file);
+    if (cached) return cached;
+
+    const paths: string[][] = [];
+    const roots = crateRootFilesOf(file) ?? [];
+    for (const root of roots) {
+      if (root === file) {
+        paths.push([]);
+        continue;
+      }
+      const base = childModuleDirOf(root, true);
+      if (base && !file.startsWith(`${base}/`)) continue;
+      const relative = base ? file.slice(base.length + 1) : file;
+      if (!relative.endsWith(".rs")) continue;
+      const segments = relative.slice(0, -3).split("/").filter(Boolean);
+      if (segments.at(-1) === "mod") segments.pop();
+      if (segments.length > 0) paths.push(segments);
+    }
+    rustModulePathsByFile.set(file, paths);
+    return paths;
+  }
+
+  const samePath = (left: string[], right: string[]): boolean =>
+    left.length === right.length && left.every((segment, index) => segment === right[index]);
+
+  /** Whether one top-level binding reads from the inline owner of a symbol. */
+  function bindingReadsInlineOwner(
+    file: string,
+    binding: RustUseBinding,
+    owner: string,
+    name: string,
+  ): boolean {
+    if (binding.local !== "*" && binding.local !== name) return false;
+
+    const target = binding.path.split("::").map((segment) => segment.trim()).filter(Boolean);
+    if (binding.local !== "*") {
+      // An alias of a differently named symbol does not make an unrelated
+      // same-named declaration in this file the re-export's target.
+      if (target.at(-1) !== name) return false;
+      target.pop();
+    }
+
+    const ownerPath = owner.split("::").filter(Boolean);
+    if (ownerPath.length === 0) return false;
+
+    // Without a readable manifest, keep the established best-effort behavior:
+    // explicit uses stay accepted, while a glob must at least name the full
+    // inline owner rather than merely sharing its outermost segment.
+    if (!rustCrateRootsByFile?.has(file)) {
+      if (binding.local !== "*") return true;
+      const unanchored = target[0] === "self" || target[0] === "crate"
+        ? target.slice(1)
+        : target;
+      return unanchored.length >= ownerPath.length &&
+        samePath(unanchored.slice(-ownerPath.length), ownerPath);
+    }
+
+    if (target[0] === "self") return samePath(target.slice(1), ownerPath);
+    if (target[0] !== "crate" && target[0] !== "super") {
+      return samePath(target, ownerPath);
+    }
+
+    const filePaths = rustModulePathsOf(file);
+    const expected = filePaths.map((filePath) => [...filePath, ...ownerPath]);
+    if (target[0] === "crate") {
+      const absolute = target.slice(1);
+      return expected.some((candidate) => samePath(absolute, candidate));
+    }
+
+    let supers = 0;
+    while (target[supers] === "super") supers += 1;
+    const rest = target.slice(supers);
+    return filePaths.some((filePath, index) => {
+      if (supers > filePath.length) return false;
+      const absolute = [...filePath.slice(0, filePath.length - supers), ...rest];
+      return samePath(absolute, expected[index]);
+    });
+  }
+
   /**
    * Whether the top level of the file declaring `id` brings `name` up to
    * itself with a `use`.
    *
    * From a file's own module Rust reaches what the file declares at its top
-   * level *and what the top level imports* — a name a `use` carries there is
-   * as reachable as one written there. `counters.rs` in tokio declares
+   * level and what the top level imports. `counters.rs` in tokio declares
    * `inc_num_inc_notify_local()` inside `mod imp` and then writes
-   * `pub(super) use imp::*;`, so `super::counters::inc_num_inc_notify_local()`
-   * compiles; `ucred.rs` does the same with seven explicit
-   * `pub(crate) use self::impl_<os>::get_peer_cred;`. Refusing those on the
-   * grounds that the symbol sits inside an inline `mod` withdrew 35 answers
-   * that were right.
+   * `pub(super) use imp::*;`; `ucred.rs` does the same with explicit uses.
    *
    * A glob is recorded under `*` and carries the module it reads from, which
-   * is what bounds it: `pub use imp::*;` exports what `imp` exports and
-   * nothing from a sibling `mod altro { … }` in the same file — rustc answers
-   * E0425 for `crate::glob::nascosto()` when `nascosto` is in `altro`. So the
-   * glob's own path has to name the inline `mod` the symbol sits in, and the
-   * outermost one is the one the file's top level can name.
+   * is what bounds it. `pub use imp::*;` exports what `imp` exports, not a
+   * sibling module or a private `imp::hidden` nested beneath it. The complete
+   * inline owner path therefore has to match the binding's source module.
    */
   function reExportedToTopLevel(id: string, name: string): boolean {
     const file = fileOfSymbolId.get(id);
@@ -878,14 +982,8 @@ export function resolveCallSites(
     const declared = rustBindingsByFile?.get(file);
     if (!declared) return false;
     const owner = rustInlineDeclaredSymbols?.get(id);
-    return declared.some((b) => {
-      if (b.local === name) return true;
-      if (b.local !== "*") return false;
-      // `use imp::*;` reads from `imp`; `use self::imp::*;` and
-      // `use crate::a::imp::*;` from the last segment of their path.
-      const from = b.path.split("::").pop();
-      return owner !== undefined && from === owner;
-    });
+    return owner !== undefined &&
+      declared.some((binding) => bindingReadsInlineOwner(file, binding, owner, name));
   }
 
   for (const [callerFile, edges] of outgoingCallsByFile.entries()) {

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -38,6 +38,14 @@ function normalizePath(p: string): string {
 const KNOWN_CODE_EXT =
   /\.(?:[jt]sx?|m[jt]s|c[jt]s|py|rb|php|go|rs|java|kt|scala|cs|swift|dart|c|cpp|h|hpp|ex|exs|vue|svelte|lua|sh)$/i;
 
+/**
+ * The kinds a Rust path can be qualified by, as this extractor labels them: a
+ * `struct` (which also covers `union`), an `enum`, a `trait`, and a `type`
+ * (which also covers an associated type). Rust keeps types and values in
+ * separate namespaces, and only the first can stand before a `::`.
+ */
+const RUST_TYPE_NAMESPACE = new Set(["struct", "enum", "trait", "type"]);
+
 function stripKnownExt(p: string): string {
   const lastSlash = p.lastIndexOf("/");
   const dir = lastSlash >= 0 ? p.slice(0, lastSlash + 1) : "";
@@ -158,10 +166,16 @@ export function resolveCallSites(
   // `Foo` declared?" into a scope of files, without taking the file apart from
   // the id string.
   const fileOfSymbolId = new Map<string, string>();
+  // symbol id → what it declares. A Rust type qualifier is answered by the
+  // file that declares that *type*, and a name lives in one namespace or the
+  // other: `const Config` cannot qualify `Config::run()`, so the file that
+  // declares it is not an answer.
+  const kindOfSymbolId = new Map<string, SymbolNode["kind"]>();
   for (const [file, syms] of symbolsByFile.entries()) {
     const idx = new Map<string, SymbolNode[]>();
     for (const s of syms) {
       fileOfSymbolId.set(s.id, file);
+      kindOfSymbolId.set(s.id, s.kind);
       if (s.name === "<module>") continue;
       const existing = idx.get(s.name);
       if (existing) existing.push(s);
@@ -448,9 +462,14 @@ export function resolveCallSites(
       searchIn = [...homes, ...reachable];
     }
 
+    // Only what Rust can put before a `::`. A name is in the type namespace or
+    // in the value one, never both, so a `const Config` or a `fn Config` in
+    // reach says nothing about `Config::run()` — counting it would put its file
+    // in scope and answer with whatever `run` that file happens to declare.
     const declaring = new Set<string>();
     for (const file of searchIn) {
       for (const id of findSymbolsInTarget(file, typeName)) {
+        if (!RUST_TYPE_NAMESPACE.has(kindOfSymbolId.get(id) ?? "")) continue;
         const declaredIn = fileOfSymbolId.get(id);
         if (declaredIn) declaring.add(declaredIn);
       }

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -350,7 +350,10 @@ export function resolveCallSites(
    * guarantee: the answer is a module the path really reaches, or the edge
    * stays unresolved with its qualifier.
    *
-   * Every hop moves strictly deeper into the tree, so the walk cannot cycle.
+   * The walk is bounded by the number of segments, not by depth: a hop out of
+   * a crate root stays in the same directory (`src/lib.rs` declares
+   * `src/a.rs`), so "each hop goes deeper" is not what stops it. The loop runs
+   * once per segment and ends.
    */
   function walkModulePath(homes: string[], segments: string[]): string[] {
     if (segments.length === 0) return [];
@@ -826,6 +829,32 @@ export function resolveCallSites(
     return null;
   }
 
+  /**
+   * Whether the top level of the file declaring `id` brings `name` up to
+   * itself with a `use`.
+   *
+   * From a file's own module Rust reaches what the file declares at its top
+   * level *and what the top level imports* — a name a `use` carries there is
+   * as reachable as one written there. `counters.rs` in tokio declares
+   * `inc_num_inc_notify_local()` inside `mod imp` and then writes
+   * `pub(super) use imp::*;`, so `super::counters::inc_num_inc_notify_local()`
+   * compiles; `ucred.rs` does the same with seven explicit
+   * `pub(crate) use self::impl_<os>::get_peer_cred;`. Refusing those on the
+   * grounds that the symbol sits inside an inline `mod` withdrew 35 answers
+   * that were right.
+   *
+   * A glob is recorded under `*` because its names cannot be enumerated here.
+   * It is read as "this might be reachable", which keeps the refusal to the
+   * case that is provably out of reach.
+   */
+  function reExportedToTopLevel(id: string, name: string): boolean {
+    const file = fileOfSymbolId.get(id);
+    if (!file) return false;
+    const declared = rustBindingsByFile?.get(file);
+    if (!declared) return false;
+    return declared.some((b) => b.local === name || b.local === "*");
+  }
+
   for (const [callerFile, edges] of outgoingCallsByFile.entries()) {
     const localIdx = symbolIndexByFile.get(callerFile);
     const deps = depsByFile.get(callerFile) ?? [];
@@ -874,7 +903,9 @@ export function resolveCallSites(
         // qualifier and goes unresolved, because the module the path names
         // declares nothing of that name.
         if (scope?.viaModulePath && rustInlineDeclaredSymbols) {
-          uniq = uniq.filter((id) => !rustInlineDeclaredSymbols.has(id));
+          uniq = uniq.filter(
+            (id) => !rustInlineDeclaredSymbols.has(id) || reExportedToTopLevel(id, edge.calleeName),
+          );
         }
         edge.calleeCandidates = uniq;
         if (uniq.length === 0) edge.confidence = "unresolved";

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -101,6 +101,33 @@ function matchModulePath(deps: string[], segments: string[]): string[] {
   return hits;
 }
 
+/**
+ * The directory a module's own children are filed in.
+ *
+ * Rust files a submodule beside its parent, not beside the parent's file:
+ * `src/lib.rs` and `src/a/mod.rs` both take their children from the directory
+ * they stand for (`src/` and `src/a/`), while `src/a.rs` takes its children
+ * from `src/a/` — the directory named after it, which does not hold the file
+ * itself.
+ *
+ * A crate root takes them from its own directory whatever it is called, which
+ * the stem alone does not say: cargo 1.90.0 on `src/bin/x.rs` writing
+ * `mod helper;` answers `file not found for module helper … create file
+ * "src/bin/helper.rs"`, not `src/bin/x/helper.rs`, and a `tests/t.rs` with
+ * `mod support;` compiles against `tests/support.rs`. So `isCrateRoot` is
+ * asked, and not guessed from the name.
+ */
+function childModuleDirOf(file: string, isCrateRoot: boolean): string {
+  const noExt = stripKnownExt(file);
+  const lastSlash = file.lastIndexOf("/");
+  // A file at the project root has no directory, and `""` is the answer:
+  // `file.slice(0, -1)` is the name with its last letter cut off.
+  const dir = lastSlash >= 0 ? file.slice(0, lastSlash) : "";
+  const stem = noExt.slice(noExt.lastIndexOf("/") + 1);
+  if (isCrateRoot || stem === "mod" || stem === "lib" || stem === "main") return dir;
+  return dir ? `${dir}/${stem}` : stem;
+}
+
 /** Resolve an import's module specifier to a dependency file path */
 function resolveDepFile(callerFile: string, sourceModule: string, deps: string[]): string | null {
   if (!sourceModule) return null;
@@ -261,6 +288,82 @@ export function resolveCallSites(
       : ["lib.rs", "main.rs"];
     const dependents = new Set(dependentsByFile.get(file) ?? []);
     return candidates.filter((c) => dependents.has(c));
+  }
+
+  /**
+   * Whether Cargo compiles this file as a crate of its own: a binary under
+   * `src/bin/`, an integration test, an example, a benchmark, or the library
+   * root itself. It decides where the file's own submodules are filed, and it
+   * is the same question {@link crateRootFilesOf} answers for `crate::` — a
+   * file whose `crate::` starts at itself *is* a root — so it is asked there
+   * rather than restated as a second pattern that could drift from it.
+   */
+  function isOwnCrateRoot(file: string): boolean {
+    const roots = crateRootFilesOf(file);
+    return roots?.length === 1 && roots[0] === file;
+  }
+
+  /**
+   * The files one module declares under the name `segment` — one hop of a
+   * module path.
+   *
+   * Two things have to hold, and each rules out a different wrong answer.
+   *
+   * The file has to sit where Rust files a child of *this* module:
+   * `<childDir>/<segment>.rs` or `<childDir>/<segment>/mod.rs`. A file graph's
+   * dependencies mix `mod x;` with `use`, so `a/mod.rs` that writes
+   * `use crate::other::b;` depends on `other/b.rs` — and a hop that asked only
+   * "is it a dependency called `b`?" would read `crate::a::b` as
+   * `crate::other::b`.
+   *
+   * And the parent has to actually depend on it, which is the graph's record
+   * that the declaration was written. Two files can sit at the two spellings of
+   * one module, which rustc rejects (E0761) and a graph merely reports; taking
+   * both is honest about it, and the caller turns two answers into
+   * `multiple-candidates` rather than picking one.
+   */
+  function childModulesOf(parent: string, segment: string): string[] {
+    // A segment that is not a plain identifier is not a module name, and
+    // pasting it into a path is how `..` would climb out of the crate.
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(segment)) return [];
+    const dir = childModuleDirOf(parent, isOwnCrateRoot(parent));
+    const candidates = dir
+      ? [`${dir}/${segment}.rs`, `${dir}/${segment}/mod.rs`]
+      : [`${segment}.rs`, `${segment}/mod.rs`];
+    const deps = new Set(depsByFile.get(parent) ?? []);
+    return candidates.filter((c) => deps.has(c));
+  }
+
+  /**
+   * The files a module path names, walked one segment at a time from `homes`.
+   *
+   * `crate::a::b` is two hops, not one suffix: the crate root declares `a` and
+   * `a` declares `b`, and no single file has to depend on `a/b.rs` for the path
+   * to be real. Matching the whole qualifier against the caller's own
+   * dependencies instead both missed those — the graph reaches `a/mod.rs` and
+   * stops — and answered too widely, because a suffix is not a path:
+   * `crate::task` in tokio's `runtime/tests/task.rs` came back as
+   * `runtime/task/mod.rs`, a file that path does not name, only because the
+   * caller imports it and `task` is the tail of its directory.
+   *
+   * A hop that finds nothing ends the walk with nothing. That is the whole
+   * guarantee: the answer is a module the path really reaches, or the edge
+   * stays unresolved with its qualifier.
+   *
+   * Every hop moves strictly deeper into the tree, so the walk cannot cycle.
+   */
+  function walkModulePath(homes: string[], segments: string[]): string[] {
+    if (segments.length === 0) return [];
+    let frontier = homes;
+    for (const segment of segments) {
+      const next = new Set<string>();
+      for (const file of frontier) {
+        for (const child of childModulesOf(file, segment)) next.add(child);
+      }
+      if (next.size === 0) return [];
+      frontier = [...next];
+    }
+    return frontier;
   }
 
   /** The root modules of one crate directory, in the order Cargo looks. */
@@ -620,9 +723,45 @@ export function resolveCallSites(
     const reachable = inOwnCrate && mine !== undefined
       ? scopeDeps.filter((d) => rustCrateRootByFile?.get(d) === mine)
       : scopeDeps;
+    const confine = (files: string[]): string[] =>
+      inOwnCrate && mine !== undefined
+        ? files.filter((f) => rustCrateRootByFile?.get(f) === mine)
+        : files;
 
-    // A module path: the dependency whose own path ends with these segments.
-    const byPath = matchModulePath(reachable, rest);
+    /**
+     * The files a module path names: walked from the scope the path starts in,
+     * and only where the walk comes back empty, matched by suffix as before.
+     *
+     * The walk speaks first because it is the one that can be wrong in the
+     * direction that matters. Ordering it first is what turns tokio's
+     * `crate::task::yield_now()` from `runtime/task/mod.rs` — a file that path
+     * does not name, reached because the caller imports it and `task` is the
+     * tail of its directory — into the honest `unresolved`.
+     *
+     * The suffix is kept underneath rather than deleted because the walk needs
+     * the module tree to be visible in the file graph, and four things hide it:
+     * a `mod` written inside a macro, an inline `mod x { … }` block that has no
+     * file of its own, a `use` re-binding in an ancestor module (Rust resolves
+     * `super::queue` through one), and a crate root named by `[[bin]] path =`
+     * rather than by its location.
+     *
+     * Measured over ripgrep 14.1.1, tokio 1.40.0 and Sailor: 46 edges that
+     * resolve today are ones the walk alone does not reach — 28 in tokio, 18 in
+     * ripgrep, none in Sailor. The fallback recovers 40 of them, and all 40
+     * were read against the Rust source and were right. Refusing them buys no
+     * truth: the walk has nothing to say there, so the choice is the old answer
+     * or none. The 6 it does not recover are the ones where the walk does reach
+     * a module and the name is simply not found in it, and 5 of those 6 are the
+     * `crate::task` answer above.
+     */
+    const modulePathFiles = (segments: string[]): string[] => {
+      const walked = confine(walkModulePath(homes, segments));
+      if (walked.length > 0) return walked;
+      return matchModulePath(reachable, segments);
+    };
+
+    // A module path, walked segment by segment from the scope it starts in.
+    const byPath = modulePathFiles(rest);
     if (byPath.length > 0) return byPath;
 
     // A type qualifier: the files, within reach, that declare that name. The
@@ -638,7 +777,7 @@ export function resolveCallSites(
     const modulePrefix = rest.slice(0, -1);
     let searchIn: string[];
     if (modulePrefix.length > 0) {
-      searchIn = matchModulePath(reachable, modulePrefix);
+      searchIn = modulePathFiles(modulePrefix);
       if (searchIn.length === 0) return null;
     } else {
       searchIn = [...homes, ...reachable];

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -210,20 +210,35 @@ export function resolveCallSites(
   }
 
   /**
-   * The scope a `super`-rooted path is read in: the parent modules themselves,
-   * and what they import. `null` when the parent is not reachable, which leaves
-   * the edge unresolved rather than falling back to the caller's own scope —
-   * the caller's scope is a different namespace, and answering out of it is how
-   * `use super::config;` would land on the caller's own `config` submodule.
+   * The scope a `super`-rooted path is read in, one hop per leading `super`:
+   * the modules reached by climbing, and what they import. `null` when a hop
+   * has no reachable parent, which leaves the edge unresolved rather than
+   * falling back to the caller's own scope — the caller's scope is a different
+   * namespace, and answering out of it is how `use super::config;` would land
+   * on the caller's own `config` submodule.
    */
-  function parentScopeOf(file: string): { homes: string[]; deps: string[] } | null {
-    const parents = parentModulesOf(file);
-    if (parents.length === 0) return null;
-    const deps = new Set<string>();
-    for (const parent of parents) {
-      for (const dep of depsByFile.get(parent) ?? []) deps.add(dep);
+  function climbSuper(
+    callerFile: string,
+    path: string[],
+  ): { homes: string[]; deps: string[]; rest: string[] } | null {
+    let homes = [callerFile];
+    let deps: string[] = [];
+    let rest = path;
+    while (rest[0] === "super") {
+      const parents = new Set<string>();
+      for (const home of homes) {
+        for (const parent of parentModulesOf(home)) parents.add(parent);
+      }
+      if (parents.size === 0) return null;
+      homes = [...parents];
+      const reached = new Set<string>();
+      for (const home of homes) {
+        for (const dep of depsByFile.get(home) ?? []) reached.add(dep);
+      }
+      deps = [...reached];
+      rest = rest.slice(1);
     }
-    return { homes: parents, deps: [...deps] };
+    return { homes, deps, rest };
   }
 
   // Re-export traversal is on the hot path for every unresolved edge. Build
@@ -345,11 +360,11 @@ export function resolveCallSites(
       if (segments.length === 1) return [callerFile];
       rest = segments.slice(1);
     } else if (segments[0] === "super") {
-      const parent = parentScopeOf(callerFile);
-      if (!parent) return null;
-      homes = parent.homes;
-      scopeDeps = parent.deps;
-      rest = segments.slice(1);
+      const climbed = climbSuper(callerFile, segments);
+      if (!climbed) return null;
+      homes = climbed.homes;
+      scopeDeps = climbed.deps;
+      rest = climbed.rest;
       if (rest.length === 0) return homes;
     } else if (segments[0] === "crate") {
       rest = segments.slice(1);
@@ -370,16 +385,19 @@ export function resolveCallSites(
           // matching `config` against the caller's own dependencies reaches the
           // caller's own child module of that name instead — a wrong answer
           // reported as `unique`.
-          const parent = parentScopeOf(callerFile);
-          if (!parent) return null;
-          homes = parent.homes;
-          scopeDeps = parent.deps;
+          const climbed = climbSuper(callerFile, bound);
+          if (!climbed) return null;
+          homes = climbed.homes;
+          scopeDeps = climbed.deps;
+          rest = [...climbed.rest, ...segments.slice(1)];
+          // `use super as up;` binds the parent itself, so `up::f()` is a call
+          // into the parent — the same answer `super::f()` gets.
+          if (rest.length === 0) return homes;
+        } else {
+          const head = bound[0] === "crate" || bound[0] === "self" ? bound.slice(1) : bound;
+          rest = [...head, ...segments.slice(1)];
+          if (rest.length === 0) return null;
         }
-        const head = bound[0] === "crate" || bound[0] === "self" || bound[0] === "super"
-          ? bound.slice(1)
-          : bound;
-        rest = [...head, ...segments.slice(1)];
-        if (rest.length === 0) return bound[0] === "super" ? homes : null;
       }
     }
     if (rest.length === 0) return null;

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -173,6 +173,17 @@ export function resolveCallSites(
    * one of those is not something Rust can reach from the other.
    */
   rustInlineScopedCalls?: Set<SymbolEdge>,
+  /**
+   * The ids of the Rust symbols declared inside an inline `mod`. A `self`
+   * qualifier names the file's own module, and from there Rust reaches what
+   * the file declares at its top level and nothing an inline `mod` encloses —
+   * so these are dropped from a `self` path's candidates, and the call is
+   * refused when dropping them leaves none.
+   *
+   * Absent for every other language, and absent when a caller does not have
+   * it: nothing is dropped then, which is what this did before.
+   */
+  rustInlineDeclaredSymbols?: Set<string>,
 ): void {
   // Build a fast lookup: file → Map<symbolName, SymbolNode[]>
   const symbolIndexByFile = new Map<string, Map<string, SymbolNode[]>>();
@@ -672,7 +683,29 @@ export function resolveCallSites(
         if (scope) {
           for (const file of scope) candidates.push(...findSymbolsInTarget(file, edge.calleeName));
         }
-        const uniq = Array.from(new Set(candidates));
+        let uniq = Array.from(new Set(candidates));
+        // `self` is the file's own module, and by the time a qualifier reads
+        // `self` that is provably what it names: the extractor rewrites
+        // `super::helper()` to it only after every inline `mod` the call sits
+        // in has been climbed out of, and refuses a `self::` written inside
+        // one rather than rewriting it.
+        //
+        // From that module Rust reaches the file's top-level declarations, and
+        // not a `helper` an inline `mod` encloses — checked against rustc,
+        // which answers E0425 for `super::helper()` when the only `helper` in
+        // the file is declared inside a sibling inline `mod`. The scope is the
+        // file, so those ids come back with the rest; dropping them is what
+        // keeps `unique` and `local` from naming a symbol that is not callable
+        // from where the call is written, and whoever walks the candidates
+        // from following it.
+        //
+        // The refusal already in place for a path rooted in an inline `mod`
+        // then extends to this one: when nothing survives, the edge keeps its
+        // qualifier and goes unresolved, because the file's top level is the
+        // only scope the path names and it declares nothing of that name.
+        if (edge.calleeQualifier === "self" && rustInlineDeclaredSymbols) {
+          uniq = uniq.filter((id) => !rustInlineDeclaredSymbols.has(id));
+        }
         edge.calleeCandidates = uniq;
         if (uniq.length === 0) edge.confidence = "unresolved";
         // `self::helper()` lands in the caller's own file, which is what

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -216,13 +216,16 @@ export function resolveCallSites(
    * falling back to the caller's own scope — the caller's scope is a different
    * namespace, and answering out of it is how `use super::config;` would land
    * on the caller's own `config` submodule.
+   *
+   * A path with no leading `super` climbs nothing and comes back as the
+   * caller's own scope, so calling this on any path is safe.
    */
   function climbSuper(
     callerFile: string,
     path: string[],
   ): { homes: string[]; deps: string[]; rest: string[] } | null {
     let homes = [callerFile];
-    let deps: string[] = [];
+    let deps = depsByFile.get(callerFile) ?? [];
     let rest = path;
     while (rest[0] === "super") {
       const parents = new Set<string>();
@@ -328,9 +331,11 @@ export function resolveCallSites(
    * leaves the edge unresolved, because widening a qualified call to a
    * repository-wide name match is how `Vec::new()` would land on all 191 `new`.
    *
-   * The search never leaves the caller's own scope — its file, its resolved
-   * dependencies, and the re-export chains those reach — so a qualifier can
-   * only ever narrow.
+   * The search stays inside one module's scope — a file, its resolved
+   * dependencies, and the re-export chains those reach. That module is the
+   * caller's own, except under `super::`, where it is the parent the path
+   * names: a different scope, not a wider one, and the only way to answer a
+   * path that points out of the caller's.
    */
   function rustQualifierScope(
     callerFile: string,

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -599,12 +599,27 @@ export function resolveCallSites(
    * names: a different scope, not a wider one, and the only way to answer a
    * path that points out of the caller's.
    */
+  /**
+   * A qualifier's scope, and how the qualifier reached it.
+   *
+   * `viaModulePath` is true when the files were reached by naming modules —
+   * `crate::a`, `super::a`, `self`, a bare `a::b`, or the module prefix of a
+   * type qualifier. That is the case where an inline `mod` inside the answer
+   * is *not* reachable: `crate::a::f()` names `a`'s own module, and an `f`
+   * declared inside `mod holder { }` in `a.rs` needs `crate::a::holder::f()`,
+   * which is a different path. rustc says so with E0425.
+   *
+   * It is false when the qualifier is a bare type — `T::method()`, `Self::` —
+   * because the type may be declared inside the very inline `mod` the call is
+   * written in, and there Rust does reach it.
+   */
   function rustQualifierScope(
     callerFile: string,
     qualifier: string,
     deps: string[],
     bindings: RustUseBinding[],
-  ): string[] | null {
+  ): { files: string[]; viaModulePath: boolean } | null {
+    const asPath = (files: string[]) => ({ files, viaModulePath: true });
     const segments = qualifier.split("::").map((s) => s.trim()).filter(Boolean);
     if (segments.length === 0) return null;
 
@@ -624,7 +639,12 @@ export function resolveCallSites(
     let homes = [callerFile];
     let scopeDeps = deps;
     if (segments[0] === "self" || segments[0] === "Self") {
-      if (segments.length === 1) return [callerFile];
+      // `self` is the file's own module; `Self` is the implementing type, and
+      // a type can be declared inside the inline `mod` the call sits in. Only
+      // the first is a module path.
+      if (segments.length === 1) {
+        return { files: [callerFile], viaModulePath: segments[0] === "self" };
+      }
       rest = segments.slice(1);
     } else if (segments[0] === "super") {
       const climbed = climbSuper(callerFile, segments);
@@ -632,7 +652,7 @@ export function resolveCallSites(
       homes = climbed.homes;
       scopeDeps = climbed.deps;
       rest = climbed.rest;
-      if (rest.length === 0) return homes;
+      if (rest.length === 0) return asPath(homes);
     } else if (segments[0] === "crate") {
       rest = segments.slice(1);
       // Confined to the caller's own crate, which is what `crate::` means.
@@ -660,7 +680,7 @@ export function resolveCallSites(
         ];
       }
       // `crate::helper()` names the root module itself.
-      if (rest.length === 0) return roots;
+      if (rest.length === 0) return roots ? asPath(roots) : null;
     } else {
       // An imported binding rewrites the head into the path it names, so
       // `use crate::a::Type as Alias` makes `Alias::method()` reach exactly
@@ -703,12 +723,12 @@ export function resolveCallSites(
           rest = [...climbed.rest, ...segments.slice(1)];
           // `use super as up;` binds the parent itself, so `up::f()` is a call
           // into the parent — the same answer `super::f()` gets.
-          if (rest.length === 0) return homes;
+          if (rest.length === 0) return asPath(homes);
         } else {
           const head = bound[0] === "crate" || bound[0] === "self" ? bound.slice(1) : bound;
           rest = [...head, ...segments.slice(1)];
           // `use crate as root;` binds the crate root itself.
-          if (rest.length === 0) return boundRoots;
+          if (rest.length === 0) return boundRoots ? asPath(boundRoots) : null;
         }
       }
     }
@@ -762,7 +782,7 @@ export function resolveCallSites(
 
     // A module path, walked segment by segment from the scope it starts in.
     const byPath = modulePathFiles(rest);
-    if (byPath.length > 0) return byPath;
+    if (byPath.length > 0) return asPath(byPath);
 
     // A type qualifier: the files, within reach, that declare that name. The
     // last segment is the type — `crate::a::Type::method()` qualifies `method`
@@ -795,7 +815,13 @@ export function resolveCallSites(
         if (declaredIn) declaring.add(declaredIn);
       }
     }
-    if (declaring.size > 0) return [...declaring];
+    // A type named through a module prefix was reached by walking modules, so
+    // an inline `mod` in the answer is out of reach exactly as it is for a
+    // plain module path. A bare `T::method()` was not: `T` can be declared in
+    // the very inline `mod` the call sits in, and there Rust reaches it.
+    if (declaring.size > 0) {
+      return { files: [...declaring], viaModulePath: modulePrefix.length > 0 };
+    }
 
     return null;
   }
@@ -820,29 +846,34 @@ export function resolveCallSites(
           ? null
           : rustQualifierScope(callerFile, edge.calleeQualifier, deps, bindings);
         if (scope) {
-          for (const file of scope) candidates.push(...findSymbolsInTarget(file, edge.calleeName));
+          for (const file of scope.files) {
+            candidates.push(...findSymbolsInTarget(file, edge.calleeName));
+          }
         }
         let uniq = Array.from(new Set(candidates));
-        // `self` is the file's own module, and by the time a qualifier reads
-        // `self` that is provably what it names: the extractor rewrites
-        // `super::helper()` to it only after every inline `mod` the call sits
-        // in has been climbed out of, and refuses a `self::` written inside
-        // one rather than rewriting it.
+        // A path that names modules answers with a module, and from a module
+        // Rust reaches what the file declares at its top level — never what an
+        // inline `mod` inside it encloses. `crate::a::f()` names `a`'s own
+        // module; an `f` written in `mod holder { }` in `a.rs` is
+        // `crate::a::holder::f()`, a different path, and rustc answers E0425
+        // for the first. The scope this resolution has is the file, so those
+        // ids come back with the rest; dropping them is what keeps `unique`
+        // from naming a symbol that is not callable from where the call is
+        // written, and whoever walks the candidates from following it.
         //
-        // From that module Rust reaches the file's top-level declarations, and
-        // not a `helper` an inline `mod` encloses — checked against rustc,
-        // which answers E0425 for `super::helper()` when the only `helper` in
-        // the file is declared inside a sibling inline `mod`. The scope is the
-        // file, so those ids come back with the rest; dropping them is what
-        // keeps `unique` and `local` from naming a symbol that is not callable
-        // from where the call is written, and whoever walks the candidates
-        // from following it.
+        // It follows the *path*, not the spelling: `self`, `super::a`,
+        // `crate::a`, a bare `a::b` and the module prefix of a type qualifier
+        // all reach a module the same way. A bare `T::method()` does not — `T`
+        // can be declared in the very inline `mod` the call sits in, and there
+        // Rust does reach it — so `viaModulePath` says which it was, rather
+        // than the qualifier's first segment. Asking for the spelling `self`
+        // left every other way of reaching the same module answering `unique`.
         //
         // The refusal already in place for a path rooted in an inline `mod`
         // then extends to this one: when nothing survives, the edge keeps its
-        // qualifier and goes unresolved, because the file's top level is the
-        // only scope the path names and it declares nothing of that name.
-        if (edge.calleeQualifier === "self" && rustInlineDeclaredSymbols) {
+        // qualifier and goes unresolved, because the module the path names
+        // declares nothing of that name.
+        if (scope?.viaModulePath && rustInlineDeclaredSymbols) {
           uniq = uniq.filter((id) => !rustInlineDeclaredSymbols.has(id));
         }
         edge.calleeCandidates = uniq;

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -218,17 +218,42 @@ export function resolveCallSites(
   function parentModulesOf(file: string): string[] {
     const noExt = stripKnownExt(file);
     const stem = noExt.slice(noExt.lastIndexOf("/") + 1);
-    let dir = file.slice(0, file.lastIndexOf("/"));
+    const lastSlash = file.lastIndexOf("/");
+    // A file at the project root has no directory, and `""` is the answer, not
+    // `file.slice(0, -1)` — which is the name with its last letter cut off and
+    // matches nothing.
+    let dir = lastSlash >= 0 ? file.slice(0, lastSlash) : "";
     // A module root stands for its own directory, so its parent is the
     // directory above.
     if (stem === "mod" || stem === "lib" || stem === "main") {
       if (!dir.includes("/")) return [];
       dir = dir.slice(0, dir.lastIndexOf("/"));
     }
-    if (!dir) return [];
-    const candidates = [`${dir}/mod.rs`, `${dir}.rs`, `${dir}/lib.rs`, `${dir}/main.rs`];
+    // At the root the parent can only be the crate root itself, and `.rs` is
+    // not a file name.
+    const candidates = dir
+      ? [`${dir}/mod.rs`, `${dir}.rs`, `${dir}/lib.rs`, `${dir}/main.rs`]
+      : ["lib.rs", "main.rs"];
     const dependents = new Set(dependentsByFile.get(file) ?? []);
     return candidates.filter((c) => dependents.has(c));
+  }
+
+  /**
+   * The file a `crate::` path starts from: the crate's own root module.
+   *
+   * The manifests give the crate's directory; the root module is `lib.rs` or
+   * `main.rs` in it, with or without a `src/`, and it is a file this project
+   * extracted or it is nothing. `null` leaves `crate::` reading the caller's
+   * own scope, which is what it did before the crate map existed.
+   */
+  function crateRootFileOf(callerFile: string): string | null {
+    const prefix = rustCrateRootByFile?.get(callerFile);
+    if (prefix === undefined) return null;
+    for (const name of ["src/lib.rs", "src/main.rs", "lib.rs", "main.rs"]) {
+      const candidate = `${prefix}${name}`;
+      if (symbolsByFile.has(candidate)) return candidate;
+    }
+    return null;
   }
 
   /**
@@ -395,9 +420,25 @@ export function resolveCallSites(
       if (rest.length === 0) return homes;
     } else if (segments[0] === "crate") {
       rest = segments.slice(1);
-      if (rest.length === 0) return null;
       // Confined to the caller's own crate, which is what `crate::` means.
       inOwnCrate = true;
+      // And read from the crate root, which is where the path starts. A nested
+      // module does not import the root — the root imports it — so
+      // `crate::helper()` would otherwise miss a `helper` declared there, and
+      // `crate::a::b()` would need the caller to have imported `a` itself,
+      // which Rust does not ask of it.
+      // The root is added to the caller's own scope, not put in its place: a
+      // module path is matched one hop and by suffix, so `crate::sync::watch`
+      // is found through the caller's `watch.rs` and never through the root,
+      // which only declares `sync`. Both sides are inside the same crate, and
+      // the confinement below still applies to both.
+      const root = crateRootFileOf(callerFile);
+      if (root) {
+        homes = [root];
+        scopeDeps = [...new Set([root, ...(depsByFile.get(root) ?? []), ...deps])];
+      }
+      // `crate::helper()` names the root module itself.
+      if (rest.length === 0) return root ? [root] : null;
     } else {
       // An imported binding rewrites the head into the path it names, so
       // `use crate::a::Type as Alias` makes `Alias::method()` reach exactly

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -209,6 +209,23 @@ export function resolveCallSites(
     return candidates.filter((c) => dependents.has(c));
   }
 
+  /**
+   * The scope a `super`-rooted path is read in: the parent modules themselves,
+   * and what they import. `null` when the parent is not reachable, which leaves
+   * the edge unresolved rather than falling back to the caller's own scope —
+   * the caller's scope is a different namespace, and answering out of it is how
+   * `use super::config;` would land on the caller's own `config` submodule.
+   */
+  function parentScopeOf(file: string): { homes: string[]; deps: string[] } | null {
+    const parents = parentModulesOf(file);
+    if (parents.length === 0) return null;
+    const deps = new Set<string>();
+    for (const parent of parents) {
+      for (const dep of depsByFile.get(parent) ?? []) deps.add(dep);
+    }
+    return { homes: parents, deps: [...deps] };
+  }
+
   // Re-export traversal is on the hot path for every unresolved edge. Build
   // this once rather than rescanning every edge in a barrel on every lookup.
   const reexportsByFile = new Map<string, SymbolEdge[]>();
@@ -315,24 +332,25 @@ export function resolveCallSites(
 
     // `self::` and `Self::` name the caller itself. `super::` names its parent,
     // which the remaining segments are then matched against.
+    //
+    // `homes` and `scopeDeps` are the scope the rest of the path is read in:
+    // ordinarily the caller's own file and its dependencies, but under `super::`
+    // the parent module's, because `super::sibling::f()` names a module the
+    // caller may never import.
     let rest = segments;
     let inOwnCrate = false;
+    let homes = [callerFile];
+    let scopeDeps = deps;
     if (segments[0] === "self" || segments[0] === "Self") {
       if (segments.length === 1) return [callerFile];
       rest = segments.slice(1);
     } else if (segments[0] === "super") {
-      // The parent module itself, and then the rest of the path read inside the
-      // parent's own scope rather than the caller's — `super::sibling::f()`
-      // names a module the caller may never import.
-      const parents = parentModulesOf(callerFile);
-      if (parents.length === 0) return null;
-      const tail = segments.slice(1);
-      if (tail.length === 0) return parents;
-      const reached = new Set<string>();
-      for (const parent of parents) {
-        for (const hit of matchModulePath(depsByFile.get(parent) ?? [], tail)) reached.add(hit);
-      }
-      return reached.size > 0 ? [...reached] : null;
+      const parent = parentScopeOf(callerFile);
+      if (!parent) return null;
+      homes = parent.homes;
+      scopeDeps = parent.deps;
+      rest = segments.slice(1);
+      if (rest.length === 0) return homes;
     } else if (segments[0] === "crate") {
       rest = segments.slice(1);
       if (rest.length === 0) return null;
@@ -346,10 +364,22 @@ export function resolveCallSites(
       if (binding) {
         const bound = binding.path.split("::").map((s) => s.trim()).filter(Boolean);
         if (bound[0] === "crate") inOwnCrate = true;
+        if (bound[0] === "super") {
+          // `use super::config;` binds the parent's `config`, so the bound path
+          // is read where `super::config` is read. Stripping the hop and
+          // matching `config` against the caller's own dependencies reaches the
+          // caller's own child module of that name instead — a wrong answer
+          // reported as `unique`.
+          const parent = parentScopeOf(callerFile);
+          if (!parent) return null;
+          homes = parent.homes;
+          scopeDeps = parent.deps;
+        }
         const head = bound[0] === "crate" || bound[0] === "self" || bound[0] === "super"
           ? bound.slice(1)
           : bound;
         rest = [...head, ...segments.slice(1)];
+        if (rest.length === 0) return bound[0] === "super" ? homes : null;
       }
     }
     if (rest.length === 0) return null;
@@ -361,8 +391,8 @@ export function resolveCallSites(
     // answer costs nothing and gets nesting right.
     const mine = rustCrateRootByFile?.get(callerFile);
     const reachable = inOwnCrate && mine !== undefined
-      ? deps.filter((d) => rustCrateRootByFile?.get(d) === mine)
-      : deps;
+      ? scopeDeps.filter((d) => rustCrateRootByFile?.get(d) === mine)
+      : scopeDeps;
 
     // A module path: the dependency whose own path ends with these segments.
     const byPath = matchModulePath(reachable, rest);
@@ -384,7 +414,7 @@ export function resolveCallSites(
       searchIn = matchModulePath(reachable, modulePrefix);
       if (searchIn.length === 0) return null;
     } else {
-      searchIn = [callerFile, ...reachable];
+      searchIn = [...homes, ...reachable];
     }
 
     const declaring = new Set<string>();

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -116,6 +116,14 @@ function matchModulePath(deps: string[], segments: string[]): string[] {
  * "src/bin/helper.rs"`, not `src/bin/x/helper.rs`, and a `tests/t.rs` with
  * `mod support;` compiles against `tests/support.rs`. So `isCrateRoot` is
  * asked, and not guessed from the name.
+ *
+ * The three stems are still read by name, and that is Rust's module rule
+ * rather than a second guess at rootness: `src/a/mod.rs` is no crate root and
+ * files its children in `src/a/` all the same. It is wrong in exactly one
+ * shape — a `main.rs` that is an ordinary module, declared by a `mod main;`
+ * somewhere, whose children Rust would file under `main/`. Not reproduced
+ * against cargo, and named here rather than left implied by a comment that
+ * claims the question has only one answer in this file.
  */
 function childModuleDirOf(file: string, isCrateRoot: boolean): string {
   const noExt = stripKnownExt(file);

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -218,7 +218,7 @@ export function resolveCallSites(
    * Absent for every other language, and absent when a caller does not have
    * it: nothing is dropped then, which is what this did before.
    */
-  rustInlineDeclaredSymbols?: Set<string>,
+  rustInlineDeclaredSymbols?: ReadonlyMap<string, string>,
 ): void {
   // Build a fast lookup: file → Map<symbolName, SymbolNode[]>
   const symbolIndexByFile = new Map<string, Map<string, SymbolNode[]>>();
@@ -363,15 +363,25 @@ export function resolveCallSites(
    * `src/a.rs`), so "each hop goes deeper" is not what stops it. The loop runs
    * once per segment and ends.
    */
-  function walkModulePath(homes: string[], segments: string[]): string[] {
-    if (segments.length === 0) return [];
+  function walkModulePath(homes: string[], segments: string[]): string[] | null {
+    if (segments.length === 0) return null;
     let frontier = homes;
+    let entered = false;
     for (const segment of segments) {
       const next = new Set<string>();
       for (const file of frontier) {
         for (const child of childModulesOf(file, segment)) next.add(child);
       }
-      if (next.size === 0) return [];
+      // Two empty answers, and they are not the same. `null` — the first hop
+      // found nothing — means the module tree is invisible here, and the
+      // suffix match is the only thing left to try. `[]` — a hop failed after
+      // an earlier one succeeded — means the walk read a real module and the
+      // name is not in it, which rustc answers with E0433. Falling back there
+      // picks any reachable file whose path ends the same way: measured on a
+      // fixture, `crate::a::foglia::f()` with no `foglia` under `a` came back
+      // as the imported `altro/a/foglia.rs`, reported `unique`.
+      if (next.size === 0) return entered ? [] : null;
+      entered = true;
       frontier = [...next];
     }
     return frontier;
@@ -786,9 +796,13 @@ export function resolveCallSites(
      * `crate::task` answer above.
      */
     const modulePathFiles = (segments: string[]): string[] => {
-      const walked = confine(walkModulePath(homes, segments));
-      if (walked.length > 0) return walked;
-      return matchModulePath(reachable, segments);
+      const walked = walkModulePath(homes, segments);
+      // The walk never entered a module, so it has nothing to say and the
+      // suffix match answers as it did.
+      if (walked === null) return matchModulePath(reachable, segments);
+      // It did enter one. Its answer stands, confined to the caller's crate,
+      // and an empty one is a verdict rather than a shrug.
+      return confine(walked);
     };
 
     // A module path, walked segment by segment from the scope it starts in.
@@ -851,16 +865,27 @@ export function resolveCallSites(
    * grounds that the symbol sits inside an inline `mod` withdrew 35 answers
    * that were right.
    *
-   * A glob is recorded under `*` because its names cannot be enumerated here.
-   * It is read as "this might be reachable", which keeps the refusal to the
-   * case that is provably out of reach.
+   * A glob is recorded under `*` and carries the module it reads from, which
+   * is what bounds it: `pub use imp::*;` exports what `imp` exports and
+   * nothing from a sibling `mod altro { … }` in the same file — rustc answers
+   * E0425 for `crate::glob::nascosto()` when `nascosto` is in `altro`. So the
+   * glob's own path has to name the inline `mod` the symbol sits in, and the
+   * outermost one is the one the file's top level can name.
    */
   function reExportedToTopLevel(id: string, name: string): boolean {
     const file = fileOfSymbolId.get(id);
     if (!file) return false;
     const declared = rustBindingsByFile?.get(file);
     if (!declared) return false;
-    return declared.some((b) => b.local === name || b.local === "*");
+    const owner = rustInlineDeclaredSymbols?.get(id);
+    return declared.some((b) => {
+      if (b.local === name) return true;
+      if (b.local !== "*") return false;
+      // `use imp::*;` reads from `imp`; `use self::imp::*;` and
+      // `use crate::a::imp::*;` from the last segment of their path.
+      const from = b.path.split("::").pop();
+      return owner !== undefined && from === owner;
+    });
   }
 
   for (const [callerFile, edges] of outgoingCallsByFile.entries()) {

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -18,6 +18,7 @@
  */
 
 import type { CodeGraph, SymbolEdge, SymbolNode } from "../types.js";
+import type { RustUseBinding } from "./graph-symbols.js";
 
 /** Normalize relative path components like `foo/../bar` -> `bar` */
 function normalizePath(p: string): string {
@@ -43,6 +44,39 @@ function stripKnownExt(p: string): string {
   const fileName = lastSlash >= 0 ? p.slice(lastSlash + 1) : p;
   const stripped = fileName.replace(KNOWN_CODE_EXT, "");
   return dir + stripped;
+}
+
+/**
+ * The dependencies whose own path ends with these module segments.
+ *
+ * A Rust module is a file, a directory's `mod.rs`, or a crate's `lib.rs` /
+ * `main.rs`, so `a::b` can be `…/a/b.rs`, `…/a/b/mod.rs` or, when `b` is a
+ * crate, `…/b/src/lib.rs`. All three are matched; anything else is not a module
+ * path and the caller falls through to reading the qualifier as a type.
+ *
+ * Matched against the caller's resolved dependencies only. A path that names a
+ * real module the caller never imports returns nothing, which is the answer
+ * that keeps the qualifier narrowing.
+ */
+function matchModulePath(deps: string[], segments: string[]): string[] {
+  if (segments.length === 0) return [];
+  const wanted = segments.join("/");
+  const hits: string[] = [];
+  for (const dep of deps) {
+    const noExt = stripKnownExt(dep);
+    const tails = [noExt];
+    const last = noExt.slice(noExt.lastIndexOf("/") + 1);
+    if (last === "mod" || last === "lib" || last === "main") {
+      tails.push(noExt.slice(0, noExt.lastIndexOf("/")));
+    }
+    for (const tail of tails) {
+      if (tail === wanted || tail.endsWith(`/${wanted}`)) {
+        hits.push(dep);
+        break;
+      }
+    }
+  }
+  return hits;
 }
 
 /** Resolve an import's module specifier to a dependency file path */
@@ -97,12 +131,29 @@ export function resolveCallSites(
   fileGraph: CodeGraph,
   symbolsByFile: Map<string, SymbolNode[]>,
   outgoingCallsByFile: Map<string, SymbolEdge[]>,
+  /**
+   * Rust `use` bindings per file. Absent for every other language, and absent
+   * when a caller does not have them — resolution then behaves exactly as it
+   * did, which is what keeps a graph built before this readable.
+   */
+  rustBindingsByFile?: Map<string, RustUseBinding[]>,
+  /**
+   * Rust file → the directory prefix of the crate it belongs to, from the
+   * manifests. Absent for every other language, and absent when a caller does
+   * not have it — `crate::` then confines nothing, which is what it did before.
+   */
+  rustCrateRootByFile?: Map<string, string>,
 ): void {
   // Build a fast lookup: file → Map<symbolName, SymbolNode[]>
   const symbolIndexByFile = new Map<string, Map<string, SymbolNode[]>>();
+  // symbol id → the file that declares it. Needed to turn "where is the type
+  // `Foo` declared?" into a scope of files, without taking the file apart from
+  // the id string.
+  const fileOfSymbolId = new Map<string, string>();
   for (const [file, syms] of symbolsByFile.entries()) {
     const idx = new Map<string, SymbolNode[]>();
     for (const s of syms) {
+      fileOfSymbolId.set(s.id, file);
       if (s.name === "<module>") continue;
       const existing = idx.get(s.name);
       if (existing) existing.push(s);
@@ -119,8 +170,43 @@ export function resolveCallSites(
 
   // Build file → dependency files (1-hop from the file-import graph)
   const depsByFile = new Map<string, string[]>();
+  // And the reverse, which is the only way to reach what `super::` names: a
+  // module's parent is the file that declares `mod x;`, so it is a dependent
+  // of the module, never a dependency of it.
+  const dependentsByFile = new Map<string, string[]>();
   for (const node of fileGraph.nodes) {
     depsByFile.set(node.relativePath, node.dependencies.slice());
+    dependentsByFile.set(node.relativePath, node.dependents.slice());
+  }
+
+  /**
+   * The file `super::` names from `file`, if this project has it.
+   *
+   * Computed from the caller's own path and then checked against the
+   * dependents, in that order. Filtering the dependents by name instead — "any
+   * dependent called `lib`" — accepts the crate root as the parent of every
+   * file in the crate, because the crate root imports them all: `super::x()`
+   * in `a/b/leaf.rs` would then reach `src/lib.rs`, which Rust does not allow
+   * and the graph would state as `unique`.
+   *
+   * `a/b/leaf.rs` has parent `a/b/mod.rs`, or `a/b.rs` when the module is
+   * written beside its directory. `a/b/mod.rs` is itself the module `a::b`, so
+   * its parent is one level further up.
+   */
+  function parentModulesOf(file: string): string[] {
+    const noExt = stripKnownExt(file);
+    const stem = noExt.slice(noExt.lastIndexOf("/") + 1);
+    let dir = file.slice(0, file.lastIndexOf("/"));
+    // A module root stands for its own directory, so its parent is the
+    // directory above.
+    if (stem === "mod" || stem === "lib" || stem === "main") {
+      if (!dir.includes("/")) return [];
+      dir = dir.slice(0, dir.lastIndexOf("/"));
+    }
+    if (!dir) return [];
+    const candidates = [`${dir}/mod.rs`, `${dir}.rs`, `${dir}/lib.rs`, `${dir}/main.rs`];
+    const dependents = new Set(dependentsByFile.get(file) ?? []);
+    return candidates.filter((c) => dependents.has(c));
   }
 
   // Re-export traversal is on the hot path for every unresolved edge. Build
@@ -204,12 +290,147 @@ export function resolveCallSites(
     return candidates;
   }
 
+  /**
+   * The files a Rust qualifier names, or `null` when it names none that this
+   * project can reach. `null` is not "resolve it some other way": the caller
+   * leaves the edge unresolved, because widening a qualified call to a
+   * repository-wide name match is how `Vec::new()` would land on all 191 `new`.
+   *
+   * The search never leaves the caller's own scope — its file, its resolved
+   * dependencies, and the re-export chains those reach — so a qualifier can
+   * only ever narrow.
+   */
+  function rustQualifierScope(
+    callerFile: string,
+    qualifier: string,
+    deps: string[],
+    bindings: RustUseBinding[],
+  ): string[] | null {
+    const segments = qualifier.split("::").map((s) => s.trim()).filter(Boolean);
+    if (segments.length === 0) return null;
+
+    // `<T as Tr>::go()` and anything else the grammar hands back with syntax in
+    // it: not a path this can follow.
+    if (qualifier.includes("<") || qualifier.includes(">")) return null;
+
+    // `self::` and `Self::` name the caller itself. `super::` names its parent,
+    // which the remaining segments are then matched against.
+    let rest = segments;
+    let inOwnCrate = false;
+    if (segments[0] === "self" || segments[0] === "Self") {
+      if (segments.length === 1) return [callerFile];
+      rest = segments.slice(1);
+    } else if (segments[0] === "super") {
+      // The parent module itself, and then the rest of the path read inside the
+      // parent's own scope rather than the caller's — `super::sibling::f()`
+      // names a module the caller may never import.
+      const parents = parentModulesOf(callerFile);
+      if (parents.length === 0) return null;
+      const tail = segments.slice(1);
+      if (tail.length === 0) return parents;
+      const reached = new Set<string>();
+      for (const parent of parents) {
+        for (const hit of matchModulePath(depsByFile.get(parent) ?? [], tail)) reached.add(hit);
+      }
+      return reached.size > 0 ? [...reached] : null;
+    } else if (segments[0] === "crate") {
+      rest = segments.slice(1);
+      if (rest.length === 0) return null;
+      // Confined to the caller's own crate, which is what `crate::` means.
+      inOwnCrate = true;
+    } else {
+      // An imported binding rewrites the head into the path it names, so
+      // `use crate::a::Type as Alias` makes `Alias::method()` reach exactly
+      // what `crate::a::Type::method()` reaches and nothing else.
+      const binding = bindings.find((b) => b.local === segments[0]);
+      if (binding) {
+        const bound = binding.path.split("::").map((s) => s.trim()).filter(Boolean);
+        if (bound[0] === "crate") inOwnCrate = true;
+        const head = bound[0] === "crate" || bound[0] === "self" || bound[0] === "super"
+          ? bound.slice(1)
+          : bound;
+        rest = [...head, ...segments.slice(1)];
+      }
+    }
+    if (rest.length === 0) return null;
+
+    // Same crate, by identity rather than by prefix. A prefix is a superset:
+    // `""` for a package at the project root also covers a crate in `sub/`,
+    // and `crates/alpha/` covers one nested at `crates/alpha/inner/beta`. The
+    // map already says which crate each file belongs to, so comparing that
+    // answer costs nothing and gets nesting right.
+    const mine = rustCrateRootByFile?.get(callerFile);
+    const reachable = inOwnCrate && mine !== undefined
+      ? deps.filter((d) => rustCrateRootByFile?.get(d) === mine)
+      : deps;
+
+    // A module path: the dependency whose own path ends with these segments.
+    const byPath = matchModulePath(reachable, rest);
+    if (byPath.length > 0) return byPath;
+
+    // A type qualifier: the files, within reach, that declare that name. The
+    // last segment is the type — `crate::a::Type::method()` qualifies `method`
+    // with `crate::a::Type`.
+    //
+    // Anything before it is a module path and it is not decoration: it says
+    // *which* `Type`. Looked up without it, an alias for `crate::a::Type` would
+    // reach `b.rs`'s `Type` as well, which is the opposite of what an alias is
+    // for. When that prefix names no reachable module the answer is nothing,
+    // not everything — a qualifier narrows or it fails.
+    const typeName = rest[rest.length - 1];
+    const modulePrefix = rest.slice(0, -1);
+    let searchIn: string[];
+    if (modulePrefix.length > 0) {
+      searchIn = matchModulePath(reachable, modulePrefix);
+      if (searchIn.length === 0) return null;
+    } else {
+      searchIn = [callerFile, ...reachable];
+    }
+
+    const declaring = new Set<string>();
+    for (const file of searchIn) {
+      for (const id of findSymbolsInTarget(file, typeName)) {
+        const declaredIn = fileOfSymbolId.get(id);
+        if (declaredIn) declaring.add(declaredIn);
+      }
+    }
+    if (declaring.size > 0) return [...declaring];
+
+    return null;
+  }
+
   for (const [callerFile, edges] of outgoingCallsByFile.entries()) {
     const localIdx = symbolIndexByFile.get(callerFile);
     const deps = depsByFile.get(callerFile) ?? [];
+    const bindings = rustBindingsByFile?.get(callerFile) ?? [];
 
     for (const edge of edges) {
       const candidates: string[] = [];
+
+      // A qualified call is resolved by its qualifier or not at all.
+      //
+      // Gated on the caller being Rust, not merely on the field being present.
+      // Everything below reads `::`, `crate`, `self` and `super` as Rust means
+      // them, and `rawCallsToUnresolvedEdges` carries `calleeQualifier` for
+      // every language — so the day another extractor fills it, this would
+      // apply Rust's semantics to it silently.
+      if (edge.calleeQualifier && callerFile.endsWith(".rs")) {
+        const scope = rustQualifierScope(callerFile, edge.calleeQualifier, deps, bindings);
+        if (scope) {
+          for (const file of scope) candidates.push(...findSymbolsInTarget(file, edge.calleeName));
+        }
+        const uniq = Array.from(new Set(candidates));
+        edge.calleeCandidates = uniq;
+        if (uniq.length === 0) edge.confidence = "unresolved";
+        // `self::helper()` lands in the caller's own file, which is what
+        // `local` has always meant here — the qualifier changes how it was
+        // found, not where it was found.
+        else if (uniq.every((id) => fileOfSymbolId.get(id) === callerFile)) {
+          edge.confidence = "local";
+        } else if (uniq.length === 1) edge.confidence = "unique";
+        else edge.confidence = "multiple-candidates";
+        continue;
+      }
 
       // 1. Local (unless edge explicitly specifies an external source module)
       if (!edge.sourceModule) {

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -238,22 +238,63 @@ export function resolveCallSites(
     return candidates.filter((c) => dependents.has(c));
   }
 
-  /**
-   * The file a `crate::` path starts from: the crate's own root module.
-   *
-   * The manifests give the crate's directory; the root module is `lib.rs` or
-   * `main.rs` in it, with or without a `src/`, and it is a file this project
-   * extracted or it is nothing. `null` leaves `crate::` reading the caller's
-   * own scope, which is what it did before the crate map existed.
-   */
-  function crateRootFileOf(callerFile: string): string | null {
-    const prefix = rustCrateRootByFile?.get(callerFile);
-    if (prefix === undefined) return null;
-    for (const name of ["src/lib.rs", "src/main.rs", "lib.rs", "main.rs"]) {
-      const candidate = `${prefix}${name}`;
-      if (symbolsByFile.has(candidate)) return candidate;
+  /** The root modules of one crate directory, in the order Cargo looks. */
+  const rootFilesByCratePrefix = new Map<string, string[]>();
+  /** What a root module reaches, followed once per root that needs asking. */
+  const reachedFromRoot = new Map<string, Set<string>>();
+
+  function reachedFrom(root: string): Set<string> {
+    const known = reachedFromRoot.get(root);
+    if (known) return known;
+    const seen = new Set<string>([root]);
+    const queue = [root];
+    while (queue.length > 0) {
+      const file = queue.pop() as string;
+      for (const dep of depsByFile.get(file) ?? []) {
+        if (!seen.has(dep)) {
+          seen.add(dep);
+          queue.push(dep);
+        }
+      }
     }
-    return null;
+    reachedFromRoot.set(root, seen);
+    return seen;
+  }
+
+  /**
+   * The files a `crate::` path starts from: the crate's own root modules.
+   *
+   * The manifests give the crate's directory, and the root module is `lib.rs`
+   * or `main.rs` in it, with or without a `src/`. One directory can hold two
+   * of them, and then it holds two crates: `crate::` written in `main.rs`
+   * means the binary, and answering with the library is a different file, not
+   * a wider one. So a root module is its own `crate::`, a file under
+   * `src/bin/` is a root module of its own, and where a crate has more than
+   * one root the answer is the roots that actually reach the caller — all of
+   * them when the graph cannot tell, which is an honest ambiguity rather than
+   * a guess.
+   *
+   * Empty leaves `crate::` reading the caller's own scope, which is what it
+   * did before the crate map existed.
+   */
+  function crateRootFilesOf(callerFile: string): string[] {
+    const prefix = rustCrateRootByFile?.get(callerFile);
+    if (prefix === undefined) return [];
+    let roots = rootFilesByCratePrefix.get(prefix);
+    if (!roots) {
+      roots = ["src/lib.rs", "src/main.rs", "lib.rs", "main.rs"]
+        .map((name) => `${prefix}${name}`)
+        .filter((file) => symbolsByFile.has(file));
+      rootFilesByCratePrefix.set(prefix, roots);
+    }
+    // Cargo gives every `src/bin/x.rs` a crate of its own, and a root module
+    // is trivially its own root.
+    if (callerFile.startsWith(`${prefix}src/bin/`) || roots.includes(callerFile)) {
+      return [callerFile];
+    }
+    if (roots.length <= 1) return roots;
+    const reaching = roots.filter((root) => reachedFrom(root).has(callerFile));
+    return reaching.length > 0 ? reaching : roots;
   }
 
   /**
@@ -432,13 +473,15 @@ export function resolveCallSites(
       // is found through the caller's `watch.rs` and never through the root,
       // which only declares `sync`. Both sides are inside the same crate, and
       // the confinement below still applies to both.
-      const root = crateRootFileOf(callerFile);
-      if (root) {
-        homes = [root];
-        scopeDeps = [...new Set([root, ...(depsByFile.get(root) ?? []), ...deps])];
+      const roots = crateRootFilesOf(callerFile);
+      if (roots.length > 0) {
+        homes = roots;
+        scopeDeps = [
+          ...new Set([...roots, ...roots.flatMap((r) => depsByFile.get(r) ?? []), ...deps]),
+        ];
       }
       // `crate::helper()` names the root module itself.
-      if (rest.length === 0) return root ? [root] : null;
+      if (rest.length === 0) return roots.length > 0 ? roots : null;
     } else {
       // An imported binding rewrites the head into the path it names, so
       // `use crate::a::Type as Alias` makes `Alias::method()` reach exactly
@@ -450,13 +493,19 @@ export function resolveCallSites(
         // `root::helper()` mean `crate::helper()`, and reading it in the
         // caller's own scope would answer nothing where the plain spelling
         // answers the crate root.
-        let boundRoot: string | null = null;
+        let boundRoots: string[] = [];
         if (bound[0] === "crate") {
           inOwnCrate = true;
-          boundRoot = crateRootFileOf(callerFile);
-          if (boundRoot) {
-            homes = [boundRoot];
-            scopeDeps = [...new Set([boundRoot, ...(depsByFile.get(boundRoot) ?? []), ...deps])];
+          boundRoots = crateRootFilesOf(callerFile);
+          if (boundRoots.length > 0) {
+            homes = boundRoots;
+            scopeDeps = [
+              ...new Set([
+                ...boundRoots,
+                ...boundRoots.flatMap((r) => depsByFile.get(r) ?? []),
+                ...deps,
+              ]),
+            ];
           }
         }
         if (bound[0] === "super") {
@@ -477,7 +526,7 @@ export function resolveCallSites(
           const head = bound[0] === "crate" || bound[0] === "self" ? bound.slice(1) : bound;
           rest = [...head, ...segments.slice(1)];
           // `use crate as root;` binds the crate root itself.
-          if (rest.length === 0) return boundRoot ? [boundRoot] : null;
+          if (rest.length === 0) return boundRoots.length > 0 ? boundRoots : null;
         }
       }
     }

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -143,6 +143,14 @@ export function resolveCallSites(
    * not have it — `crate::` then confines nothing, which is what it did before.
    */
   rustCrateRootByFile?: Map<string, string>,
+  /**
+   * The edges whose qualifier is rooted in an inline `mod`, by identity. That
+   * scope has no file to name and no spelling this can follow, so the call is
+   * left unresolved with its qualifier rather than answered out of the file:
+   * the file holds the sibling inline modules too, and a `helper` declared in
+   * one of those is not something Rust can reach from the other.
+   */
+  rustInlineScopedCalls?: Set<SymbolEdge>,
 ): void {
   // Build a fast lookup: file → Map<symbolName, SymbolNode[]>
   const symbolIndexByFile = new Map<string, Map<string, SymbolNode[]>>();
@@ -468,7 +476,9 @@ export function resolveCallSites(
       // every language — so the day another extractor fills it, this would
       // apply Rust's semantics to it silently.
       if (edge.calleeQualifier && callerFile.endsWith(".rs")) {
-        const scope = rustQualifierScope(callerFile, edge.calleeQualifier, deps, bindings);
+        const scope = rustInlineScopedCalls?.has(edge)
+          ? null
+          : rustQualifierScope(callerFile, edge.calleeQualifier, deps, bindings);
         if (scope) {
           for (const file of scope) candidates.push(...findSymbolsInTarget(file, edge.calleeName));
         }

--- a/src/services/graph-symbol-resolution.ts
+++ b/src/services/graph-symbol-resolution.ts
@@ -39,6 +39,20 @@ const KNOWN_CODE_EXT =
   /\.(?:[jt]sx?|m[jt]s|c[jt]s|py|rb|php|go|rs|java|kt|scala|cs|swift|dart|c|cpp|h|hpp|ex|exs|vue|svelte|lua|sh)$/i;
 
 /**
+ * The directories, relative to a crate's own, where Cargo autodiscovers
+ * targets. Each target is a crate of its own, so `crate::` written inside one
+ * starts at that target's root and never reaches the library.
+ *
+ * Two conventional shapes live in each: a `.rs` file directly inside
+ * (`tests/foo.rs`) is a target, and so is `<name>/main.rs` one level down
+ * (`tests/foo/main.rs`), whose neighbours are that target's modules. Nothing
+ * else is: checked against `cargo metadata` on cargo 1.98, which lists
+ * `tests/dirtest/main.rs` as a target and never lists `tests/common/mod.rs`
+ * or `src/bin/tool/sub/main.rs`.
+ */
+const CARGO_TARGET_DIRS = ["src/bin", "tests", "benches", "examples"];
+
+/**
  * The kinds a Rust path can be qualified by, as this extractor labels them: a
  * `struct` (which also covers `union`), an `enum`, a `trait`, and a `type`
  * (which also covers an associated type). Rust keeps types and values in
@@ -262,24 +276,62 @@ export function resolveCallSites(
   }
 
   /**
-   * The files a `crate::` path starts from: the crate's own root modules.
+   * The files a `crate::` path starts from: the root of the *target* the
+   * caller is compiled into.
    *
-   * The manifests give the crate's directory, and the root module is `lib.rs`
-   * or `main.rs` in it, with or without a `src/`. One directory can hold two
-   * of them, and then it holds two crates: `crate::` written in `main.rs`
-   * means the binary, and answering with the library is a different file, not
-   * a wider one. So a root module is its own `crate::`, a file under
-   * `src/bin/` is a root module of its own, and where a crate has more than
-   * one root the answer is the roots that actually reach the caller — all of
-   * them when the graph cannot tell, which is an honest ambiguity rather than
-   * a guess.
+   * The manifests give the crate's directory, and the library's root module is
+   * `lib.rs` or `main.rs` in it, with or without a `src/`. One directory can
+   * hold two of them, and then it holds two crates: `crate::` written in
+   * `main.rs` means the binary, and answering with the library is a different
+   * file, not a wider one. So a root module is its own `crate::`, and where a
+   * crate has more than one root the answer is the roots that actually reach
+   * the caller.
    *
-   * Empty leaves `crate::` reading the caller's own scope, which is what it
-   * did before the crate map existed.
+   * A package is more than its library, though. Cargo compiles each binary,
+   * integration test, benchmark and example as a separate crate, and none of
+   * them is reachable from the library — a library never imports its own
+   * tests. Left to the fallback below those files got *every* root, which
+   * collapses to `unique` on the library as soon as the library alone declares
+   * the name, and that is the wrong file: checked with rustc, `crate::helper()`
+   * in `tests/foo.rs` is the test's own `helper` and does not compile against
+   * the library's. {@link CARGO_TARGET_DIRS} is where those roots are found by
+   * shape.
+   *
+   * Three answers, and they are not the same:
+   *   - `null` — nothing is known about this file's crate, so `crate::` keeps
+   *     reading the caller's own scope, which is what it did before the crate
+   *     map existed.
+   *   - `[]` — the layout proves the caller is not part of any root that can
+   *     be named here. The edge is left unresolved: a target declared only by
+   *     `[[bin]] path = "…"` is invisible from here, and answering with
+   *     another root names a different crate.
+   *   - a non-empty list — the roots the path starts at.
    */
-  function crateRootFilesOf(callerFile: string): string[] {
+  function crateRootFilesOf(callerFile: string): string[] | null {
     const prefix = rustCrateRootByFile?.get(callerFile);
-    if (prefix === undefined) return [];
+    if (prefix === undefined) return null;
+
+    for (const dir of CARGO_TARGET_DIRS) {
+      const targetDir = `${prefix}${dir}/`;
+      if (!callerFile.startsWith(targetDir)) continue;
+      const rest = callerFile.slice(targetDir.length);
+      const slash = rest.indexOf("/");
+      // `tests/foo.rs`, `src/bin/x.rs`: the file is the whole target, so it is
+      // its own root.
+      if (slash === -1) return [callerFile];
+      // `tests/foo/main.rs` roots the target `foo`, and every other file in
+      // that directory is one of its modules — however deep, because Cargo
+      // autodiscovers the first level only.
+      const mainFile = `${targetDir}${rest.slice(0, slash)}/main.rs`;
+      if (rustCrateRootByFile?.has(mainFile)) return [mainFile];
+      // Without that `main.rs` the directory is no target at all —
+      // `tests/common/mod.rs` is the shared-helper idiom, a module of whichever
+      // tests write `mod common;` — or it is one only because a
+      // `[[bin]] path = "…"` says so, which is not read here. Neither is
+      // provable, and the library is a different crate.
+      return [];
+    }
+
     let roots = rootFilesByCratePrefix.get(prefix);
     if (!roots) {
       roots = ["src/lib.rs", "src/main.rs", "lib.rs", "main.rs"]
@@ -287,14 +339,22 @@ export function resolveCallSites(
         .filter((file) => symbolsByFile.has(file));
       rootFilesByCratePrefix.set(prefix, roots);
     }
-    // Cargo gives every `src/bin/x.rs` a crate of its own, and a root module
-    // is trivially its own root.
-    if (callerFile.startsWith(`${prefix}src/bin/`) || roots.includes(callerFile)) {
-      return [callerFile];
-    }
-    if (roots.length <= 1) return roots;
+    // A root module is trivially its own root.
+    if (roots.includes(callerFile)) return [callerFile];
+    // No root module in sight is the same absence of information as no crate
+    // map, so it keeps the same answer rather than turning into a verdict.
+    if (roots.length === 0) return null;
+    if (roots.length === 1) return roots;
     const reaching = roots.filter((root) => reachedFrom(root).has(callerFile));
-    return reaching.length > 0 ? reaching : roots;
+    if (reaching.length > 0) return reaching;
+    // Nothing reaches the caller. For an ordinary module that is honest
+    // ambiguity and every root stays an answer: a `mod` declared inside a
+    // macro is invisible to the file graph, yet the file really does belong to
+    // one of these roots. A file named `main.rs` is not an ordinary module —
+    // `mod x;` reads `x.rs` or `x/mod.rs`, never `x/main.rs` — so an unreached
+    // one is a `[[bin]] path = "…"` target instead, and the library is not it.
+    if (callerFile.endsWith("/main.rs")) return [];
+    return roots;
   }
 
   /**
@@ -474,14 +534,19 @@ export function resolveCallSites(
       // which only declares `sync`. Both sides are inside the same crate, and
       // the confinement below still applies to both.
       const roots = crateRootFilesOf(callerFile);
-      if (roots.length > 0) {
+      // An empty list is a verdict, not a shrug: the caller sits in a target
+      // whose root cannot be named here, so the edge is left unresolved.
+      // Reading `crate::a::b()` in the caller's own scope instead would answer
+      // out of the caller's own module tree, which is a different namespace.
+      if (roots?.length === 0) return null;
+      if (roots) {
         homes = roots;
         scopeDeps = [
           ...new Set([...roots, ...roots.flatMap((r) => depsByFile.get(r) ?? []), ...deps]),
         ];
       }
       // `crate::helper()` names the root module itself.
-      if (rest.length === 0) return roots.length > 0 ? roots : null;
+      if (rest.length === 0) return roots;
     } else {
       // An imported binding rewrites the head into the path it names, so
       // `use crate::a::Type as Alias` makes `Alias::method()` reach exactly
@@ -493,11 +558,14 @@ export function resolveCallSites(
         // `root::helper()` mean `crate::helper()`, and reading it in the
         // caller's own scope would answer nothing where the plain spelling
         // answers the crate root.
-        let boundRoots: string[] = [];
+        let boundRoots: string[] | null = null;
         if (bound[0] === "crate") {
           inOwnCrate = true;
           boundRoots = crateRootFilesOf(callerFile);
-          if (boundRoots.length > 0) {
+          // `use crate as root;` is the same path under another name, so an
+          // unnameable root leaves it unresolved the same way.
+          if (boundRoots?.length === 0) return null;
+          if (boundRoots) {
             homes = boundRoots;
             scopeDeps = [
               ...new Set([
@@ -526,7 +594,7 @@ export function resolveCallSites(
           const head = bound[0] === "crate" || bound[0] === "self" ? bound.slice(1) : bound;
           rest = [...head, ...segments.slice(1)];
           // `use crate as root;` binds the crate root itself.
-          if (rest.length === 0) return boundRoots.length > 0 ? boundRoots : null;
+          if (rest.length === 0) return boundRoots;
         }
       }
     }

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -14,6 +14,25 @@ import { analyzeElixirTemplate, isElixirTemplateExtension } from "./elixir-templ
 import { logger } from "./logger.js";
 
 /** Result of extracting symbols + raw call sites from a file. */
+/**
+ * One name a Rust `use` puts in a file's own scope, and the path it names.
+ *
+ * The file-import graph cannot supply this: `rustUseLeafPath` strips the alias
+ * before the path is ever recorded, and `ImportInfo` has no field for a local
+ * binding. Without it, `use crate::a::Type as Alias;` followed by
+ * `Alias::method()` leaves the qualifier `Alias` naming nothing.
+ *
+ * Kept out of the persisted graph on purpose. It is an input to resolution,
+ * which runs once per full build and in the same process as extraction, so
+ * nothing needs to store it and no payload changes shape.
+ */
+export interface RustUseBinding {
+  /** The name written in this file — the alias when there is one. */
+  local: string;
+  /** The path it names, alias excluded: `crate::a::Type`, `std::fs`. */
+  path: string;
+}
+
 export interface ExtractedSymbols {
   symbols: SymbolNode[];
   /** Outgoing call sites — `calleeCandidates` and `confidence` are filled later by resolution. */
@@ -24,8 +43,15 @@ export interface ExtractedSymbols {
     sourceModule?: string;
     importedName?: string;
     localAlias?: string;
+    /**
+     * The path qualifying the callee, terminal name excluded: `Vec` in
+     * `Vec::new()`, `std::fs` in `std::fs::copy()`. Absent on a bare call.
+     */
+    calleeQualifier?: string;
     callSite: { file: string; line: number };
   }>;
+  /** Rust `use` bindings declared by this file. Absent for every other language. */
+  bindings?: RustUseBinding[];
 }
 
 /** Build a stable SymbolNode.id. */
@@ -1733,6 +1759,129 @@ function extractFromGo(
 
 // ── Rust ─────────────────────────────────────────────────────────────────
 
+/**
+ * Every name a file's `use` declarations put in its own scope, paired with the
+ * path each names. Walked over the tree rather than over the text, because the
+ * alias is what is wanted and the text-level helpers in `graph-imports.ts`
+ * delete it: `rustUseLeafPath` strips ` as X` before returning the path.
+ *
+ * A nested list carries its prefix down (`use a::{b, c as d}` binds `b` to
+ * `a::b` and `d` to `a::c`), and `self` in a list binds the prefix's own last
+ * segment (`use a::{self}` binds `a`). A wildcard binds no name and is skipped:
+ * what it brings into scope cannot be known from this file alone, and guessing
+ * would widen resolution rather than narrow it.
+ */
+/**
+ * A path with its turbofish removed: `Vec::<Option<u8>>` → `Vec`. Scanned for
+ * the matching `>` rather than matched with `::<[^>]*>`, which stops at the
+ * first `>` and leaves a stray one behind on a nested generic.
+ */
+function stripTurbofish(path: string): string {
+  let out = "";
+  for (let i = 0; i < path.length; i++) {
+    if (path[i] === ":" && path.slice(i, i + 3) === "::<") {
+      let depth = 0;
+      let j = i + 2;
+      for (; j < path.length; j++) {
+        if (path[j] === "<") depth++;
+        else if (path[j] === ">" && --depth === 0) break;
+      }
+      i = j;
+      continue;
+    }
+    out += path[i];
+  }
+  return out;
+}
+
+/**
+ * The callee of a Rust call, split into the terminal name and the path that
+ * qualifies it. Read off the `function` field rather than scanned out of the
+ * node's text, which is what `extractCalleeNameJs` did and why every qualified
+ * call was dropped: its chain pattern `[\w$.]+` stops dead at the `:` of `::`.
+ *
+ * A chain needs no special case here. ast-grep reports one `call_expression`
+ * per link, and each link's own `function` field names only that link, so
+ * `Path::new(p).components().all(f)` yields `all`, `components` and `new`
+ * rather than nothing.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+function extractCalleeInfoRust(fn: any): { name: string; qualifier?: string } | null {
+  if (!fn) return null;
+  switch (fn.kind()) {
+    case "identifier":
+      return { name: fn.text() };
+    // `obj.method()` — the receiver is an expression, not a path, so there is
+    // nothing to narrow with. The name alone is what this call knows.
+    case "field_expression": {
+      const field = fn.field("field");
+      return field ? { name: field.text() } : null;
+    }
+    case "scoped_identifier": {
+      const name = fn.field("name");
+      if (!name) return null;
+      const path = fn.field("path");
+      const qualifier = path ? stripTurbofish(path.text()).trim() : "";
+      return qualifier ? { name: name.text(), qualifier } : { name: name.text() };
+    }
+    // `foo::<T>()` — the turbofish sits on the function itself.
+    case "generic_function":
+      return extractCalleeInfoRust(fn.field("function"));
+    default:
+      return null;
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+function collectRustUseBindings(decl: any, bindings: RustUseBinding[]): void {
+  const join = (prefix: string, rest: string): string => (prefix ? `${prefix}::${rest}` : rest);
+
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  const walk = (node: any, prefix: string): void => {
+    switch (node.kind()) {
+      case "use_as_clause": {
+        const pathNode = node.field("path");
+        const aliasNode = node.field("alias");
+        if (!pathNode || !aliasNode) return;
+        bindings.push({ local: aliasNode.text(), path: join(prefix, pathNode.text()) });
+        return;
+      }
+      case "scoped_use_list": {
+        const listNode = node.field("list");
+        if (!listNode) return;
+        const pathNode = node.field("path");
+        const inner = pathNode ? join(prefix, pathNode.text()) : prefix;
+        // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+        for (const child of listNode.children()) walk(child as any, inner);
+        return;
+      }
+      case "use_list": {
+        // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+        for (const child of node.children()) walk(child as any, prefix);
+        return;
+      }
+      case "identifier":
+      case "scoped_identifier": {
+        const text = node.text();
+        const local = text.split("::").pop() ?? text;
+        bindings.push({ local, path: join(prefix, text) });
+        return;
+      }
+      case "self": {
+        const last = prefix.split("::").pop();
+        if (last) bindings.push({ local: last, path: prefix });
+        return;
+      }
+      default:
+        // `use`, `;`, `{`, `}`, `,`, a visibility modifier, `use_wildcard`.
+        return;
+    }
+  };
+
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  for (const child of decl.children()) walk(child as any, "");
+}
+
 function extractFromRust(
   source: string,
   file: string,
@@ -1745,6 +1894,7 @@ function extractFromRust(
   // the only key that orders two declarations sharing a line. See the sort at
   // the end of this function.
   const declared: Array<{ sym: SymbolNode; offset: number }> = [];
+  const bindings: RustUseBinding[] = [];
 
   for (const fn of safeFindAll(root, "function_item")) {
     const nameNode = safeFind(fn, "identifier");
@@ -1778,10 +1928,16 @@ function extractFromRust(
   // `function_item`, and an associated `type` or `const` through this table —
   // under a bare name, without the implementing type, the way a method's name
   // is already bare. Two impls of one trait therefore yield two symbols of the
-  // same associated name; the trait's own `type Item;` yields none, being an
-  // `associated_type` rather than a `type_item`. Both are stated in the pull
-  // request as limits rather than fixed here: qualifying a name is a change to
-  // how every language in this file names a member.
+  // same associated name: reported as a limit rather than fixed, because
+  // qualifying a name is a change to how every language in this file names a
+  // member.
+  //
+  // A declaration without a body is still a declaration. `function_signature_item`
+  // covers both places Rust puts one — a method declared in a trait, and a `fn`
+  // inside an `extern` block — and `associated_type` is the trait's own
+  // `type Item;`, which is a different node from the `type_item` an impl writes.
+  // Reading only the definitions meant a reader who found a trait could not find
+  // anything the trait declares.
   //
   // A `use` is genuinely not an item: what it names is declared elsewhere, and
   // the file graph already carries that edge.
@@ -1804,13 +1960,26 @@ function extractFromRust(
     ["enum_item", "enum"],
     ["trait_item", "trait"],
     ["type_item", "type"],
+    ["associated_type", "type"],
     ["const_item", "variable"],
     ["static_item", "variable"],
+    ["function_signature_item", "function"],
   ]);
   // One pass, not one per kind: `findAll` walks the whole tree each time it is
-  // called, so seven calls read the file seven times. Measured on ripgrep's
-  // `crates/core/flags/defs.rs`, seven passes cost +51% over `main` on this
-  // function and one costs +18%.
+  // called, so one call per kind reads the file once per kind. Measured on
+  // ripgrep's `crates/core/flags/defs.rs`, seven separate passes cost +51% over
+  // reading no items at all, where one pass costs +18%.
+  // Only the `use` declarations at the top of the file, which are the ones
+  // whose names are in scope for the whole file. A `use` written inside a `fn`
+  // or a `mod x { }` binds a name **there**, and treating it as the file's
+  // would let it point a call in a different scope at a different type — a
+  // wrong answer stated as `unique`, which is worse than no answer. Reading
+  // `root.children()` costs nothing: it does not descend.
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  for (const child of root.children() as any[]) {
+    if (child.kind() === "use_declaration") collectRustUseBindings(child, bindings);
+  }
+
   for (const item of safeFindAllAny(root, [...RUST_ITEM_KINDS.keys()])) {
     const symbolKind = RUST_ITEM_KINDS.get(item.kind());
     if (!symbolKind) continue;
@@ -1836,14 +2005,15 @@ function extractFromRust(
 
   const rawCalls: ExtractedSymbols["rawCalls"] = [];
   for (const node of safeFindAll(root, "call_expression")) {
-    const calleeName = extractCalleeNameJs(node.text());
-    if (!calleeName) continue;
+    const callee = extractCalleeInfoRust(node.field("function"));
+    if (!callee) continue;
     const r = node.range();
     const callLine = r.start.line + 1;
     rawCalls.push({
       callerId: findCallerId(scopes, callLine, moduleSym.id),
-      calleeName,
+      calleeName: callee.name,
       kind: "call",
+      calleeQualifier: callee.qualifier,
       callSite: { file, line: callLine },
     });
   }
@@ -1878,7 +2048,7 @@ function extractFromRust(
   declared.sort((a, b) => a.offset - b.offset);
   const symbols: SymbolNode[] = [moduleSym, ...declared.map((d) => d.sym)];
 
-  return { symbols, rawCalls };
+  return { symbols, rawCalls, bindings };
 }
 
 // ── JVM (Java / Kotlin / Scala) ──────────────────────────────────────────
@@ -2468,6 +2638,7 @@ export function rawCallsToUnresolvedEdges(
     sourceModule: c.sourceModule,
     importedName: c.importedName,
     localAlias: c.localAlias,
+    calleeQualifier: c.calleeQualifier,
     callSite: c.callSite,
   }));
 }

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -1832,6 +1832,42 @@ function extractCalleeInfoRust(fn: any): { name: string; qualifier?: string } | 
   }
 }
 
+/**
+ * A qualifier rewritten as the file itself would have written it.
+ *
+ * `super` counts modules, not files, and an inline `mod` is a module: inside
+ * `#[cfg(test)] mod tests { … }` written in `b.rs`, `super::helper()` means
+ * `b.rs`'s own `helper`, and `super::super::sub::f()` means the `sub` of
+ * `b.rs`'s parent. Resolution knows only files, so it would read both as
+ * relative to the file and answer with the parent's `helper` and the
+ * grandparent's `sub` — not a wider answer, a different one.
+ *
+ * The hops an inline `mod` already accounts for are consumed here, where the
+ * nesting is still visible. A path consumed to nothing is `self`, which is
+ * what it then means. A path with segments left over is written bare, the way
+ * the file itself would write it: bare is the file's own namespace, which is
+ * both its child modules and the names its `use` declarations bring in, and
+ * `self::` would be read as the modules alone.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+function rustQualifierFromFile(node: any, qualifier: string): string {
+  const segments = qualifier.split("::");
+  if (segments[0] !== "super") return qualifier;
+
+  let inlineMods = 0;
+  for (let p = node.parent(); p; p = p.parent()) {
+    if (p.kind() === "mod_item") inlineMods += 1;
+  }
+  if (inlineMods === 0) return qualifier;
+
+  let consumed = 0;
+  while (consumed < inlineMods && segments[consumed] === "super") consumed += 1;
+  const rest = segments.slice(consumed);
+  // What is left may still climb above the file, and then it is a
+  // file-relative `super::` path, which is exactly how it now reads.
+  return rest.length === 0 ? "self" : rest.join("::");
+}
+
 // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
 function collectRustUseBindings(decl: any, bindings: RustUseBinding[]): void {
   const join = (prefix: string, rest: string): string => (prefix ? `${prefix}::${rest}` : rest);
@@ -2013,7 +2049,9 @@ function extractFromRust(
       callerId: findCallerId(scopes, callLine, moduleSym.id),
       calleeName: callee.name,
       kind: "call",
-      calleeQualifier: callee.qualifier,
+      calleeQualifier: callee.qualifier
+        ? rustQualifierFromFile(node, callee.qualifier)
+        : undefined,
       callSite: { file, line: callLine },
     });
   }

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -70,7 +70,7 @@ export interface ExtractedSymbols {
    * beside the symbols and is never a field on one, so nothing about it is
    * persisted and a graph built before this still reads.
    */
-  inlineModSymbolIds?: Array<[id: string, outermostInlineMod: string]>;
+  inlineModSymbolIds?: Array<[id: string, inlineModPath: string]>;
 }
 
 /** Build a stable SymbolNode.id. */
@@ -1865,23 +1865,22 @@ function rustInlineModDepth(node: any): number {
 }
 
 /**
- * The name of the outermost inline `mod` around a node, or `null` when there
- * is none.
+ * The full path of inline `mod`s around a node, outermost first, or `null`
+ * when there is none.
  *
- * That is the one the file's own top level can name, and so the only one a
- * `use imp::*;` written there can read from: a `pub use imp::*;` carries what
- * `imp` exports and nothing from a sibling `mod altro { … }`, which rustc
- * refuses with E0425.
+ * The whole path matters to re-exports: `pub use imp::*;` carries direct
+ * exports from `imp`, but it does not flatten a private `imp::hidden` module
+ * into the file's top level.
  */
 // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
-function rustOutermostInlineMod(node: any): string | null {
-  let outermost: string | null = null;
+function rustInlineModPath(node: any): string | null {
+  const modules: string[] = [];
   for (let p = node.parent(); p; p = p.parent()) {
     if (p.kind() !== "mod_item") continue;
     const nameNode = p.field("name");
-    if (nameNode) outermost = nameNode.text();
+    if (nameNode) modules.unshift(nameNode.text());
   }
-  return outermost;
+  return modules.length > 0 ? modules.join("::") : null;
 }
 
 /**
@@ -1971,7 +1970,7 @@ function collectRustUseBindings(decl: any, bindings: RustUseBinding[]): void {
         const target = pathNode.text();
         bindings.push({
           local: aliasNode.text(),
-          path: target === "self" ? prefix : join(prefix, target),
+          path: target === "self" ? (prefix || "self") : join(prefix, target),
         });
         return;
       }
@@ -2055,7 +2054,7 @@ function extractFromRust(
       name, qualifiedName: name, kind: "function", file, line: startLine, endLine, language,
     };
     declared.push({ sym, offset: r.start.index });
-    const fnInlineMod = rustOutermostInlineMod(fn);
+    const fnInlineMod = rustInlineModPath(fn);
     if (fnInlineMod) inlineModSymbolIds.push([sym.id, fnInlineMod]);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
   }
@@ -2151,7 +2150,7 @@ function extractFromRust(
       },
       offset: r.start.index,
     });
-    const itemInlineMod = rustOutermostInlineMod(item);
+    const itemInlineMod = rustInlineModPath(item);
     if (itemInlineMod) inlineModSymbolIds.push([id, itemInlineMod]);
   }
 

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -1862,6 +1862,15 @@ function rustQualifierFromFile(node: any, qualifier: string): string {
 
   let consumed = 0;
   while (consumed < inlineMods && segments[consumed] === "super") consumed += 1;
+
+  // Fewer `super` than inline modules: the path never climbed out of them, so
+  // it is rooted in a module that lives inside this file and has no file of
+  // its own. `mod a { mod b { super::c::f() } }` names the `c` declared beside
+  // `b`, and writing what is left bare hands it to a `mod c;` on the file —
+  // another file entirely, answered as `unique`. The file is what is certain
+  // here, so the file is all this says.
+  if (consumed < inlineMods) return "self";
+
   const rest = segments.slice(consumed);
   // What is left may still climb above the file, and then it is a
   // file-relative `super::` path, which is exactly how it now reads.

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -1973,8 +1973,21 @@ function collectRustUseBindings(decl: any, bindings: RustUseBinding[]): void {
         if (last) bindings.push({ local: last, path: prefix });
         return;
       }
+      case "use_wildcard": {
+        // `use imp::*;` binds names this cannot enumerate — the module it
+        // reads from need not even be a file. It is recorded under `*` all the
+        // same, because "some name arrives at this file's top level from that
+        // module" is exactly what separates "the top level cannot reach that
+        // symbol" from "it might, and nothing here can tell". tokio's
+        // `runtime/scheduler/multi_thread/counters.rs` re-exports an inline
+        // `mod` this way, and 34 calls depend on it.
+        const text = node.text();
+        const from = text.endsWith("::*") ? text.slice(0, -3) : "";
+        bindings.push({ local: "*", path: join(prefix, from) });
+        return;
+      }
       default:
-        // `use`, `;`, `{`, `}`, `,`, a visibility modifier, `use_wildcard`.
+        // `use`, `;`, `{`, `}`, `,`, a visibility modifier.
         return;
     }
   };

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -48,6 +48,15 @@ export interface ExtractedSymbols {
      * `Vec::new()`, `std::fs` in `std::fs::copy()`. Absent on a bare call.
      */
     calleeQualifier?: string;
+    /**
+     * The qualifier is rooted in an inline `mod`, which has no file to point
+     * at and no spelling resolution can follow. Set only for Rust, and only
+     * for the shape that cannot be rewritten as file-relative; resolution
+     * leaves such a call unresolved rather than answering out of the wrong
+     * scope. In memory only — it reaches resolution beside the edges and is
+     * never part of one.
+     */
+    qualifierRootedInInlineMod?: boolean;
     callSite: { file: string; line: number };
   }>;
   /** Rust `use` bindings declared by this file. Absent for every other language. */
@@ -1848,39 +1857,50 @@ function extractCalleeInfoRust(fn: any): { name: string; qualifier?: string } | 
  * the file itself would write it: bare is the file's own namespace, which is
  * both its child modules and the names its `use` declarations bring in, and
  * `self::` would be read as the modules alone.
+ *
+ * `rootedInInlineMod` says the rewrite could not be made: the path never
+ * climbed out of the inline modules, and what it is rooted in has no file.
+ * The qualifier then comes back as it was written, for a reader, and
+ * resolution refuses it rather than answering out of a scope that is not the
+ * one the path names.
  */
-// biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
-function rustQualifierFromFile(node: any, qualifier: string): string {
+function rustQualifierFromFile(
+  // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+  node: any,
+  qualifier: string,
+): { qualifier: string; rootedInInlineMod: boolean } {
+  const asWritten = { qualifier, rootedInInlineMod: false };
   const segments = qualifier.split("::");
-  if (segments[0] !== "super") return qualifier;
+  if (segments[0] !== "super") return asWritten;
 
   let inlineMods = 0;
   for (let p = node.parent(); p; p = p.parent()) {
     if (p.kind() === "mod_item") inlineMods += 1;
   }
-  if (inlineMods === 0) return qualifier;
+  if (inlineMods === 0) return asWritten;
 
   let consumed = 0;
   while (consumed < inlineMods && segments[consumed] === "super") consumed += 1;
 
   // Fewer `super` than inline modules: the path never climbed out of them, so
-  // it is rooted in a module that lives inside this file. `mod a { mod b {
-  // super::c::f() } }` names the `c` declared beside `b`, and writing what is
-  // left bare hands it to a `mod c;` on the file — another file entirely,
-  // answered as `unique`.
+  // it is rooted in a module that lives inside this file and has no file of
+  // its own to name. `mod a { mod b { super::c::f() } }` means the `c` beside
+  // `b`, and writing what is left bare hands it to a `mod c;` on the file —
+  // another file entirely, answered as `unique`.
   //
-  // What is left is dropped rather than followed, because two shapes are
-  // spelled the same and only one has a file to point at: `c` may be an inline
-  // module, and it may be a file module that an inline module declares —
-  // `mod a { pub mod c; }` in `x.rs` is `x/a/c.rs`, which tokio writes 23
-  // times. The file is what is certain either way, so the file is all this
-  // says, and the second shape is left unresolved rather than answered wrong.
-  if (consumed < inlineMods) return "self";
+  // Answering with the file instead is no better: the file holds the sibling
+  // inline modules too, so `super::helper()` would collect a `helper` that
+  // Rust cannot see from there and hand it to whoever walks the candidates.
+  // Nothing here can name that scope — a path may even be rooted at a file
+  // module an inline module declares, since `mod a { pub mod c; }` in `x.rs`
+  // is `x/a/c.rs`, which tokio writes 23 times — so the call goes unresolved
+  // and keeps the qualifier as the source wrote it.
+  if (consumed < inlineMods) return { qualifier, rootedInInlineMod: true };
 
   const rest = segments.slice(consumed);
   // What is left may still climb above the file, and then it is a
   // file-relative `super::` path, which is exactly how it now reads.
-  return rest.length === 0 ? "self" : rest.join("::");
+  return { qualifier: rest.length === 0 ? "self" : rest.join("::"), rootedInInlineMod: false };
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
@@ -2060,13 +2080,15 @@ function extractFromRust(
     if (!callee) continue;
     const r = node.range();
     const callLine = r.start.line + 1;
+    const qualifier = callee.qualifier
+      ? rustQualifierFromFile(node, callee.qualifier)
+      : undefined;
     rawCalls.push({
       callerId: findCallerId(scopes, callLine, moduleSym.id),
       calleeName: callee.name,
       kind: "call",
-      calleeQualifier: callee.qualifier
-        ? rustQualifierFromFile(node, callee.qualifier)
-        : undefined,
+      calleeQualifier: qualifier?.qualifier,
+      qualifierRootedInInlineMod: qualifier?.rootedInInlineMod ? true : undefined,
       callSite: { file, line: callLine },
     });
   }

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -61,6 +61,16 @@ export interface ExtractedSymbols {
   }>;
   /** Rust `use` bindings declared by this file. Absent for every other language. */
   bindings?: RustUseBinding[];
+  /**
+   * The ids of the symbols this file declares *inside* an inline `mod` — the
+   * ones a path anchored at the file's own module cannot reach. Set only for
+   * Rust, and only for the files that have any.
+   *
+   * In memory only, like `qualifierRootedInInlineMod`: it reaches resolution
+   * beside the symbols and is never a field on one, so nothing about it is
+   * persisted and a graph built before this still reads.
+   */
+  inlineModSymbolIds?: string[];
 }
 
 /** Build a stable SymbolNode.id. */
@@ -1842,6 +1852,19 @@ function extractCalleeInfoRust(fn: any): { name: string; qualifier?: string } | 
 }
 
 /**
+ * How many inline `mod`s a node is written inside. Zero means the file's own
+ * module, which is the one resolution can name.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+function rustInlineModDepth(node: any): number {
+  let depth = 0;
+  for (let p = node.parent(); p; p = p.parent()) {
+    if (p.kind() === "mod_item") depth += 1;
+  }
+  return depth;
+}
+
+/**
  * A qualifier rewritten as the file itself would have written it.
  *
  * `super` counts modules, not files, and an inline `mod` is a module: inside
@@ -1863,6 +1886,15 @@ function extractCalleeInfoRust(fn: any): { name: string; qualifier?: string } | 
  * The qualifier then comes back as it was written, for a reader, and
  * resolution refuses it rather than answering out of a scope that is not the
  * one the path names.
+ *
+ * A `self::` path written inside an inline `mod` is rooted the same way and is
+ * refused the same way. `self` is the module the path is written in, so inside
+ * `mod tests { … }` it is `tests` — checked against rustc, where
+ * `self::helper()` beside a `mod tests`-level `helper` calls that one and not
+ * the file's. `tests` has no file, so this is the same refusal, not a new one.
+ * Lowercase only: `Self::` is the implementing type, not a module, and
+ * `Self::poll()` inside a `#[cfg(test)] mod tests` is a call this still
+ * answers.
  */
 function rustQualifierFromFile(
   // biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
@@ -1871,13 +1903,11 @@ function rustQualifierFromFile(
 ): { qualifier: string; rootedInInlineMod: boolean } {
   const asWritten = { qualifier, rootedInInlineMod: false };
   const segments = qualifier.split("::");
-  if (segments[0] !== "super") return asWritten;
+  if (segments[0] !== "super" && segments[0] !== "self") return asWritten;
 
-  let inlineMods = 0;
-  for (let p = node.parent(); p; p = p.parent()) {
-    if (p.kind() === "mod_item") inlineMods += 1;
-  }
+  const inlineMods = rustInlineModDepth(node);
   if (inlineMods === 0) return asWritten;
+  if (segments[0] === "self") return { qualifier, rootedInInlineMod: true };
 
   let consumed = 0;
   while (consumed < inlineMods && segments[consumed] === "super") consumed += 1;
@@ -1966,6 +1996,11 @@ function extractFromRust(
   // the end of this function.
   const declared: Array<{ sym: SymbolNode; offset: number }> = [];
   const bindings: RustUseBinding[] = [];
+  // The declarations that sit inside an inline `mod`. Collected here because
+  // this is the only place the nesting is still visible: by the time
+  // resolution has the symbols, an inline module has left no trace on them.
+  // Ids, not nodes, because that is what a candidate list holds.
+  const inlineModSymbolIds: string[] = [];
 
   for (const fn of safeFindAll(root, "function_item")) {
     const nameNode = safeFind(fn, "identifier");
@@ -1979,6 +2014,7 @@ function extractFromRust(
       name, qualifiedName: name, kind: "function", file, line: startLine, endLine, language,
     };
     declared.push({ sym, offset: r.start.index });
+    if (rustInlineModDepth(fn) > 0) inlineModSymbolIds.push(sym.id);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
   }
 
@@ -2059,9 +2095,10 @@ function extractFromRust(
     const name = nameNode.text();
     const r = item.range();
     const startLine = r.start.line + 1;
+    const id = makeId(file, name, startLine);
     declared.push({
       sym: {
-        id: makeId(file, name, startLine),
+        id,
         name,
         qualifiedName: name,
         kind: symbolKind,
@@ -2072,6 +2109,7 @@ function extractFromRust(
       },
       offset: r.start.index,
     });
+    if (rustInlineModDepth(item) > 0) inlineModSymbolIds.push(id);
   }
 
   const rawCalls: ExtractedSymbols["rawCalls"] = [];
@@ -2123,7 +2161,7 @@ function extractFromRust(
   declared.sort((a, b) => a.offset - b.offset);
   const symbols: SymbolNode[] = [moduleSym, ...declared.map((d) => d.sym)];
 
-  return { symbols, rawCalls, bindings };
+  return { symbols, rawCalls, bindings, inlineModSymbolIds };
 }
 
 // ── JVM (Java / Kotlin / Scala) ──────────────────────────────────────────

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -70,7 +70,7 @@ export interface ExtractedSymbols {
    * beside the symbols and is never a field on one, so nothing about it is
    * persisted and a graph built before this still reads.
    */
-  inlineModSymbolIds?: string[];
+  inlineModSymbolIds?: Array<[id: string, outermostInlineMod: string]>;
 }
 
 /** Build a stable SymbolNode.id. */
@@ -1865,6 +1865,26 @@ function rustInlineModDepth(node: any): number {
 }
 
 /**
+ * The name of the outermost inline `mod` around a node, or `null` when there
+ * is none.
+ *
+ * That is the one the file's own top level can name, and so the only one a
+ * `use imp::*;` written there can read from: a `pub use imp::*;` carries what
+ * `imp` exports and nothing from a sibling `mod altro { … }`, which rustc
+ * refuses with E0425.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: ast-grep node type leaks through
+function rustOutermostInlineMod(node: any): string | null {
+  let outermost: string | null = null;
+  for (let p = node.parent(); p; p = p.parent()) {
+    if (p.kind() !== "mod_item") continue;
+    const nameNode = p.field("name");
+    if (nameNode) outermost = nameNode.text();
+  }
+  return outermost;
+}
+
+/**
  * A qualifier rewritten as the file itself would have written it.
  *
  * `super` counts modules, not files, and an inline `mod` is a module: inside
@@ -1944,7 +1964,15 @@ function collectRustUseBindings(decl: any, bindings: RustUseBinding[]): void {
         const pathNode = node.field("path");
         const aliasNode = node.field("alias");
         if (!pathNode || !aliasNode) return;
-        bindings.push({ local: aliasNode.text(), path: join(prefix, pathNode.text()) });
+        // `use crate::a::{self as A};` names `crate::a`, not `crate::a::self`:
+        // inside a list, `self` is the module the list hangs off. Recorded
+        // literally, `A::run()` matched no module and went unresolved. cargo
+        // 1.98 compiles that fixture with `A::run()` returning `a`'s own.
+        const target = pathNode.text();
+        bindings.push({
+          local: aliasNode.text(),
+          path: target === "self" ? prefix : join(prefix, target),
+        });
         return;
       }
       case "scoped_use_list": {
@@ -2013,7 +2041,7 @@ function extractFromRust(
   // this is the only place the nesting is still visible: by the time
   // resolution has the symbols, an inline module has left no trace on them.
   // Ids, not nodes, because that is what a candidate list holds.
-  const inlineModSymbolIds: string[] = [];
+  const inlineModSymbolIds: Array<[string, string]> = [];
 
   for (const fn of safeFindAll(root, "function_item")) {
     const nameNode = safeFind(fn, "identifier");
@@ -2027,7 +2055,8 @@ function extractFromRust(
       name, qualifiedName: name, kind: "function", file, line: startLine, endLine, language,
     };
     declared.push({ sym, offset: r.start.index });
-    if (rustInlineModDepth(fn) > 0) inlineModSymbolIds.push(sym.id);
+    const fnInlineMod = rustOutermostInlineMod(fn);
+    if (fnInlineMod) inlineModSymbolIds.push([sym.id, fnInlineMod]);
     scopes.push({ name, startLine, endLine, symbolId: sym.id });
   }
 
@@ -2122,7 +2151,8 @@ function extractFromRust(
       },
       offset: r.start.index,
     });
-    if (rustInlineModDepth(item) > 0) inlineModSymbolIds.push(id);
+    const itemInlineMod = rustOutermostInlineMod(item);
+    if (itemInlineMod) inlineModSymbolIds.push([id, itemInlineMod]);
   }
 
   const rawCalls: ExtractedSymbols["rawCalls"] = [];

--- a/src/services/graph-symbols.ts
+++ b/src/services/graph-symbols.ts
@@ -1864,11 +1864,17 @@ function rustQualifierFromFile(node: any, qualifier: string): string {
   while (consumed < inlineMods && segments[consumed] === "super") consumed += 1;
 
   // Fewer `super` than inline modules: the path never climbed out of them, so
-  // it is rooted in a module that lives inside this file and has no file of
-  // its own. `mod a { mod b { super::c::f() } }` names the `c` declared beside
-  // `b`, and writing what is left bare hands it to a `mod c;` on the file —
-  // another file entirely, answered as `unique`. The file is what is certain
-  // here, so the file is all this says.
+  // it is rooted in a module that lives inside this file. `mod a { mod b {
+  // super::c::f() } }` names the `c` declared beside `b`, and writing what is
+  // left bare hands it to a `mod c;` on the file — another file entirely,
+  // answered as `unique`.
+  //
+  // What is left is dropped rather than followed, because two shapes are
+  // spelled the same and only one has a file to point at: `c` may be an inline
+  // module, and it may be a file module that an inline module declares —
+  // `mod a { pub mod c; }` in `x.rs` is `x/a/c.rs`, which tokio writes 23
+  // times. The file is what is certain either way, so the file is all this
+  // says, and the second shape is left unresolved rather than answered wrong.
   if (consumed < inlineMods) return "self";
 
   const rest = segments.slice(consumed);

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,6 +169,18 @@ export interface SymbolEdge {
    * or the exported alias for re-export edges (e.g. `Y` in `export { X as Y }` or `export * as Y from './mod'`).
    */
   localAlias?: string;
+  /**
+   * The path qualifying the callee at the call site, terminal name excluded:
+   * `Vec` in `Vec::new()`, `std::fs` in `std::fs::copy()`. Absent on a bare
+   * call, and absent from every graph persisted before it existed — resolution
+   * treats an edge without one exactly as it always did.
+   *
+   * It is kept because the name alone cannot be resolved safely: `new` names
+   * 191 symbols on tokio, so a qualified call matched by name would either
+   * pick one arbitrarily or list them all. With the qualifier, resolution can
+   * narrow to the scope the call actually names, or say it could not.
+   */
+  calleeQualifier?: string;
   callSite: { file: string; line: number };
 }
 

--- a/tests/unit/code-graph-rust-crate-scope.test.ts
+++ b/tests/unit/code-graph-rust-crate-scope.test.ts
@@ -91,14 +91,28 @@ pub fn go_aliased() -> u32 { root::helper() }
       '[package]\nname = "alpha"\nedition = "2021"\n\n[dependencies]\nbeta = { path = "inner/beta" }\n',
     );
     write("crates/alpha/src/lib.rs", `pub mod config;
+pub mod sotto;
 use beta::config as bcfg;
 
 pub fn go() -> u32 {
     let _ = bcfg::load();
     crate::config::load()
 }
+
+pub fn out_of_the_crate() -> u32 {
+    crate::sotto::x::f()
+}
 `);
     write("crates/alpha/src/config.rs", "pub fn load() -> u32 { 3 }\n");
+    // A crate whose directory sits where a module of `alpha` would file its
+    // own children: `sotto.rs` belongs to `alpha`, and `sotto/` holds a crate
+    // of its own, so `sotto/x.rs` does not. A walk asks the file graph, which
+    // has the `mod x;` edge and no notion of a crate boundary, so `alpha`'s
+    // `crate::sotto::x` would otherwise land in another crate — which is what
+    // the confinement is there to stop, and what nothing exercised.
+    write("crates/alpha/src/sotto.rs", "pub mod x;\n");
+    write("crates/alpha/src/sotto/Cargo.toml", '[package]\nname = "sotto"\nedition = "2021"\n');
+    write("crates/alpha/src/sotto/x.rs", "pub fn f() -> u32 { 9 }\n");
     // ── One directory holding a library and a binary, which is two crates ──
     // `crate::` in `main.rs` is the binary's own root, and answering with the
     // library is a different file. Cargo gives `src/bin/x.rs` a crate too.
@@ -346,6 +360,14 @@ pub fn go() -> u32 { crate::config::load() }
     // must not, or a crate laid out by `[lib] path` would lose every
     // `crate::` edge it has.
     expect(await candidatesOf("odd/core/root.rs")).toEqual(["odd/core/config.rs::load#1"]);
+  });
+
+  it("stops a walk at the crate boundary, not only a suffix match", async () => {
+    // The file graph records `mod x;` and knows nothing of crates, so the walk
+    // reaches `sotto/x.rs` in two honest hops — and that file belongs to the
+    // crate whose `Cargo.toml` sits in `sotto/`, not to `alpha`. `crate::`
+    // means the caller's own crate, so the answer is nothing.
+    expect(await candidatesOf("crates/alpha/src/lib.rs", "f", "crate::sotto::x")).toEqual([]);
   });
 
   it("keeps a crate's `crate::` out of a crate nested inside its own directory", async () => {

--- a/tests/unit/code-graph-rust-crate-scope.test.ts
+++ b/tests/unit/code-graph-rust-crate-scope.test.ts
@@ -99,6 +99,29 @@ pub fn go() -> u32 {
 }
 `);
     write("crates/alpha/src/config.rs", "pub fn load() -> u32 { 3 }\n");
+    // ── One directory holding a library and a binary, which is two crates ──
+    // `crate::` in `main.rs` is the binary's own root, and answering with the
+    // library is a different file. Cargo gives `src/bin/x.rs` a crate too.
+    write("tool/Cargo.toml", '[package]\nname = "tool"\nedition = "2021"\n');
+    write("tool/src/lib.rs", "pub mod shared;\n\npub fn helper() -> u32 { 10 }\n");
+    write("tool/src/shared.rs", "pub fn f() -> u32 { 11 }\n");
+    write("tool/src/main.rs", `mod cli;
+
+pub fn helper() -> u32 { 12 }
+
+fn main() {
+    let _ = crate::helper();
+    let _ = cli::run();
+}
+`);
+    write("tool/src/cli.rs", "pub fn run() -> u32 { crate::helper() }\n");
+    write("tool/src/bin/x.rs", `pub fn helper() -> u32 { 13 }
+
+fn main() {
+    let _ = crate::helper();
+}
+`);
+
     write("crates/alpha/inner/beta/Cargo.toml", '[package]\nname = "beta"\nedition = "2021"\n');
     write("crates/alpha/inner/beta/src/lib.rs", "pub mod config;\n");
     write("crates/alpha/inner/beta/src/config.rs", "pub fn load() -> u32 { 4 }\n");
@@ -123,6 +146,28 @@ pub fn go() -> u32 {
     // reach the same file — not the caller's own scope, which answers nothing.
     expect(await candidatesOf("src/deep/inner.rs", "helper", "root")).toEqual([
       "src/lib.rs::helper#5",
+    ]);
+  });
+
+  it("reads `crate::` in a binary as the binary's own root", async () => {
+    // `tool/src/lib.rs` declares a `helper` too, and is what taking the first
+    // root module in the directory answers with — another file, as `unique`.
+    expect(await candidatesOf("tool/src/main.rs", "helper", "crate")).toEqual([
+      "tool/src/main.rs::helper#3",
+    ]);
+  });
+
+  it("gives a `src/bin` file a crate root of its own", async () => {
+    expect(await candidatesOf("tool/src/bin/x.rs", "helper", "crate")).toEqual([
+      "tool/src/bin/x.rs::helper#1",
+    ]);
+  });
+
+  it("follows the root that reaches the caller when a directory holds two", async () => {
+    // `cli.rs` is declared by `main.rs` alone, so `crate::` there is the
+    // binary — which the library's own `helper` must not answer.
+    expect(await candidatesOf("tool/src/cli.rs", "helper", "crate")).toEqual([
+      "tool/src/main.rs::helper#3",
     ]);
   });
 

--- a/tests/unit/code-graph-rust-crate-scope.test.ts
+++ b/tests/unit/code-graph-rust-crate-scope.test.ts
@@ -44,6 +44,8 @@ describe("Rust crate scope for `crate::`", () => {
       graph.rustBindingsByFile,
       graph.rustCrateRootByFile,
       graph.rustInlineScopedCalls,
+      graph.rustInlineDeclaredSymbols,
+      graph.rustCrateRootsByFile,
     );
     const edge = (graph.outgoingCallsByFile.get(callerRel) ?? []).find(
       (e) => e.calleeName === name && e.calleeQualifier === qualifier,
@@ -116,13 +118,14 @@ pub fn out_of_the_crate() -> u32 {
     // ── One directory holding a library and a binary, which is two crates ──
     // `crate::` in `main.rs` is the binary's own root, and answering with the
     // library is a different file. Cargo gives `src/bin/x.rs` a crate too.
-    // The two `[[bin]]` entries are targets no convention would find: one
-    // inside `src/bin/` with no `main.rs` beside it, one outside it entirely.
-    // `cargo metadata` lists both (cargo 1.98), and nothing but the manifest
-    // says so — which is why the resolver leaves them unresolved below.
+    // The three `[[bin]]` entries are targets no convention would find: one
+    // inside `src/bin/` with no `main.rs` beside it, two outside it entirely.
+    // `cargo metadata` lists all three (cargo 1.98), and nothing but the
+    // manifest says so. The resolver must therefore carry the parsed target
+    // roots through to `crate::` resolution instead of guessing by filename.
     write(
       "tool/Cargo.toml",
-      '[package]\nname = "tool"\nedition = "2021"\n\n[[bin]]\nname = "custom"\npath = "src/bin/custom/helper.rs"\n\n[[bin]]\nname = "launcher"\npath = "launcher/main.rs"\n',
+      '[package]\nname = "tool"\nedition = "2021"\n\n[[bin]]\nname = "custom"\npath = "src/bin/custom/helper.rs"\n\n[[bin]]\nname = "launcher"\npath = "launcher/main.rs"\n\n[[bin]]\nname = "flat-launcher"\npath = "launcher.rs"\n',
     );
     write("tool/src/lib.rs", "pub mod shared;\n\npub fn helper() -> u32 { 10 }\n");
     write("tool/src/shared.rs", "pub fn f() -> u32 { 11 }\n");
@@ -209,9 +212,18 @@ fn main() {
     let _ = crate::helper();
 }
 `);
-    // A `[[bin]] path` outside every conventional directory. No root reaches
-    // it, and it is named `main.rs`, which `mod x;` never resolves to.
+    // A `[[bin]] path` outside every conventional directory. Only the manifest
+    // identifies it as a target root.
     write("tool/launcher/main.rs", `pub fn helper() -> u32 { 61 }
+
+fn main() {
+    let _ = crate::helper();
+}
+`);
+    // A custom target whose filename has none of Cargo's conventional root
+    // shapes. Before the manifest roots reached resolution, `crate::helper()`
+    // here could be answered from `src/lib.rs` instead.
+    write("tool/launcher.rs", `pub fn helper() -> u32 { 62 }
 
 fn main() {
     let _ = crate::helper();
@@ -219,10 +231,8 @@ fn main() {
 `);
 
     // ── A crate whose root module sits where no convention looks ──────────
-    // `[lib] path` is not read here, so nothing is known about this crate's
-    // roots — which is the same absence of information as having no crate map
-    // at all, and keeps `crate::` reading the caller's own scope rather than
-    // turning into a verdict of "unresolved".
+    // `[lib] path` is the only source of truth for this crate root, just as a
+    // custom binary path is for the roots above.
     write("odd/Cargo.toml", '[package]\nname = "odd"\nedition = "2021"\n\n[lib]\npath = "core/root.rs"\n');
     write("odd/core/root.rs", `pub mod config;
 
@@ -324,19 +334,16 @@ pub fn go() -> u32 { crate::config::load() }
     ]);
   });
 
-  it("leaves a `src/bin` directory with no `main.rs` unresolved", async () => {
-    // `[[bin]] path = "src/bin/custom/helper.rs"` is the only thing that makes
-    // this file a target, and the manifest is not read here. The library and
-    // the `src/main.rs` binary both declare `helper`, and neither is it.
-    expect(await candidatesOf("tool/src/bin/custom/helper.rs", "helper", "crate")).toEqual([]);
+  it("uses a manifest-declared file as its own crate root", async () => {
+    expect(await candidatesOf("tool/src/bin/custom/helper.rs", "helper", "crate")).toEqual([
+      "tool/src/bin/custom/helper.rs::helper#3",
+    ]);
   });
 
-  it("does not read an unprovable target's `crate::` in its own scope", async () => {
-    // `crate::thing::run()` would find `custom/thing.rs` through the caller's
-    // own dependencies. Right answer, wrong reason: whether the crate root is
-    // `helper.rs` is exactly what cannot be established here, so the honest
-    // answer is none.
-    expect(await candidatesOf("tool/src/bin/custom/helper.rs", "run", "crate::thing")).toEqual([]);
+  it("walks modules from a manifest-declared crate root", async () => {
+    expect(await candidatesOf("tool/src/bin/custom/helper.rs", "run", "crate::thing")).toEqual([
+      "tool/src/bin/custom/thing.rs::run#1",
+    ]);
   });
 
   it("leaves a shared `tests/common/mod.rs` unresolved", async () => {
@@ -346,19 +353,19 @@ pub fn go() -> u32 { crate::config::load() }
     expect(await candidatesOf("tool/tests/common/mod.rs", "helper", "crate")).toEqual([]);
   });
 
-  it("leaves a `main.rs` no root reaches unresolved", async () => {
-    // `launcher/main.rs` is a `[[bin]] path` target outside every conventional
-    // directory. `mod x;` reads `x.rs` or `x/mod.rs` and never `x/main.rs`, so
-    // this is no module of the library either — answering with every root
-    // would name the library, which is a different crate.
-    expect(await candidatesOf("tool/launcher/main.rs", "helper", "crate")).toEqual([]);
+  it("uses a custom `main.rs` path as its own crate root", async () => {
+    expect(await candidatesOf("tool/launcher/main.rs", "helper", "crate")).toEqual([
+      "tool/launcher/main.rs::helper#1",
+    ]);
   });
 
-  it("keeps reading `crate::` in its own scope when a crate shows no root", async () => {
-    // Knowing nothing is not the same verdict as knowing the caller is out of
-    // reach: the empty answer above leaves an edge unresolved, and this one
-    // must not, or a crate laid out by `[lib] path` would lose every
-    // `crate::` edge it has.
+  it("does not send a custom single-file binary's `crate::` to the library", async () => {
+    expect(await candidatesOf("tool/launcher.rs", "helper", "crate")).toEqual([
+      "tool/launcher.rs::helper#1",
+    ]);
+  });
+
+  it("uses a manifest-declared library root outside conventional paths", async () => {
     expect(await candidatesOf("odd/core/root.rs")).toEqual(["odd/core/config.rs::load#1"]);
   });
 
@@ -415,6 +422,8 @@ describe("Rust multi-hop module paths", () => {
       graph.rustBindingsByFile,
       graph.rustCrateRootByFile,
       graph.rustInlineScopedCalls,
+      graph.rustInlineDeclaredSymbols,
+      graph.rustCrateRootsByFile,
     );
     const edge = (graph.outgoingCallsByFile.get(callerRel) ?? []).find(
       (e) => e.calleeName === name && e.calleeQualifier === qualifier,

--- a/tests/unit/code-graph-rust-crate-scope.test.ts
+++ b/tests/unit/code-graph-rust-crate-scope.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildCodeGraph } from "../../src/services/code-graph.js";
+import { resolveCallSites } from "../../src/services/graph-symbol-resolution.js";
+
+/**
+ * What `crate::` reaches, through the real `buildCodeGraph` pass.
+ *
+ * The resolution tests hand `resolveCallSites` a crate map written by hand,
+ * which cannot catch a break in the map itself: a boundary drawn from the
+ * wrong manifest, or from the path instead of the manifest, passes those tests
+ * and produces a graph where `crate::config::load()` names another crate's
+ * `config.rs`. So the map gets built here the way a real build builds it.
+ *
+ * Both fixtures are layouts where a boundary compared as a *prefix* is wrong,
+ * because one crate's directory contains another's: a package at the project
+ * root beside a crate in `sub/`, and a crate nested inside another crate's
+ * tree. `""` and `crates/alpha/` are prefixes of both sides.
+ */
+describe("Rust crate scope for `crate::`", () => {
+  let root: string;
+
+  const write = (rel: string, body: string): void => {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+  };
+
+  /** Resolve `callerRel`'s only qualified call and return its candidates. */
+  async function candidatesOf(callerRel: string): Promise<string[]> {
+    const graph = await buildCodeGraph(root);
+    resolveCallSites(
+      graph,
+      graph.symbolsByFile,
+      graph.outgoingCallsByFile,
+      graph.rustBindingsByFile,
+      graph.rustCrateRootByFile,
+    );
+    const edge = (graph.outgoingCallsByFile.get(callerRel) ?? []).find(
+      (e) => e.calleeName === "load" && e.calleeQualifier === "crate::config",
+    );
+    expect(edge, `no qualified call to crate::config::load in ${callerRel}`).toBeDefined();
+    return (edge?.calleeCandidates ?? []).slice().sort();
+  }
+
+  beforeAll(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-rust-crate-"));
+
+    // ── A package at the project root, with a crate beside it in `sub/` ──
+    // The root package's boundary is the whole tree, so a prefix comparison
+    // puts `sub/src/config.rs` inside it.
+    write("Cargo.toml", '[package]\nname = "rootpkg"\nedition = "2021"\n\n[dependencies]\nsub = { path = "sub" }\n');
+    write("src/lib.rs", `pub mod config;
+use sub::config as subcfg;
+
+pub fn go() -> u32 {
+    let _ = subcfg::load();
+    crate::config::load()
+}
+`);
+    write("src/config.rs", "pub fn load() -> u32 { 1 }\n");
+    write("sub/Cargo.toml", '[package]\nname = "sub"\nedition = "2021"\n');
+    write("sub/src/lib.rs", "pub mod config;\n");
+    write("sub/src/config.rs", "pub fn load() -> u32 { 2 }\n");
+
+    // ── A crate nested inside another crate's directory ──────────────────
+    write(
+      "crates/alpha/Cargo.toml",
+      '[package]\nname = "alpha"\nedition = "2021"\n\n[dependencies]\nbeta = { path = "inner/beta" }\n',
+    );
+    write("crates/alpha/src/lib.rs", `pub mod config;
+use beta::config as bcfg;
+
+pub fn go() -> u32 {
+    let _ = bcfg::load();
+    crate::config::load()
+}
+`);
+    write("crates/alpha/src/config.rs", "pub fn load() -> u32 { 3 }\n");
+    write("crates/alpha/inner/beta/Cargo.toml", '[package]\nname = "beta"\nedition = "2021"\n');
+    write("crates/alpha/inner/beta/src/lib.rs", "pub mod config;\n");
+    write("crates/alpha/inner/beta/src/config.rs", "pub fn load() -> u32 { 4 }\n");
+  });
+
+  afterAll(() => {
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("keeps a root package's `crate::` out of a crate beside it", async () => {
+    expect(await candidatesOf("src/lib.rs")).toEqual(["src/config.rs::load#1"]);
+  });
+
+  it("keeps a crate's `crate::` out of a crate nested inside its own directory", async () => {
+    expect(await candidatesOf("crates/alpha/src/lib.rs")).toEqual([
+      "crates/alpha/src/config.rs::load#1",
+    ]);
+  });
+});

--- a/tests/unit/code-graph-rust-crate-scope.test.ts
+++ b/tests/unit/code-graph-rust-crate-scope.test.ts
@@ -442,14 +442,18 @@ describe("Rust multi-hop module paths", () => {
     );
     // The homonym: same last two segments, a different module.
     write("src/other/mod.rs", "pub mod a;\n");
-    write("src/other/a/mod.rs", "pub mod b;\n");
+    // A module the caller imports whose path ends in `a/missing`, which is
+    // what a suffix match reaches for `crate::a::missing` — a path that does
+    // not name it, since `src/a/` has no `missing`.
+    write("src/other/a/mod.rs", "pub mod b;\npub mod missing;\n");
+    write("src/other/a/missing.rs", "pub fn f() -> u32 { 51 }\n");
     write(
       "src/other/a/b.rs",
       "pub fn f() -> u32 { 2 }\n\npub struct Tipo;\n\nimpl Tipo {\n    pub fn metodo() -> u32 { 42 }\n}\n",
     );
     write(
       "src/caller.rs",
-      "use crate::other::a::b;\n\npub fn go() -> u32 {\n    let _ = b::f();\n    crate::a::b::f()\n}\n\npub fn deeper() -> u32 {\n    crate::deep::leaf::g()\n}\n\npub fn by_path() -> u32 {\n    crate::a::b::Tipo::metodo()\n}\n",
+      "use crate::other::a::{b, missing as _m};\n\npub fn go() -> u32 {\n    let _ = b::f();\n    crate::a::b::f()\n}\n\npub fn deeper() -> u32 {\n    crate::deep::leaf::g()\n}\n\npub fn by_path() -> u32 {\n    crate::a::b::Tipo::metodo()\n}\n\npub fn half_walked() -> u32 {\n    crate::a::missing::f()\n}\n",
     );
     // A `crate::` written in an integration test is the test's own crate, and
     // its modules are filed beside it. The library has a `support` of its own,
@@ -523,5 +527,16 @@ describe("Rust multi-hop module paths", () => {
     expect(await candidatesOf("src/caller.rs", "metodo", "crate::a::b::Tipo")).toEqual([
       "src/a/b.rs::metodo#6",
     ]);
+  });
+
+  it("does not fall back to a suffix after the walk entered a module", async () => {
+    // Two empty answers that are not the same. The walk reaches `src/a/`,
+    // which declares no `missing`, so the path names nothing — rustc:
+    // `error[E0433]: cannot find missing in a`. Falling back to the suffix
+    // there picks `src/other/a/missing.rs`, which the caller does import and
+    // whose path ends the same way, and reports it `unique`. The fallback is
+    // for where the walk never entered a module at all, which is a different
+    // silence.
+    expect(await candidatesOf("src/caller.rs", "f", "crate::a::missing")).toEqual([]);
   });
 });

--- a/tests/unit/code-graph-rust-crate-scope.test.ts
+++ b/tests/unit/code-graph-rust-crate-scope.test.ts
@@ -354,3 +354,132 @@ pub fn go() -> u32 { crate::config::load() }
     ]);
   });
 });
+
+/**
+ * A module path walked one segment at a time, through the real `buildCodeGraph`
+ * pass.
+ *
+ * The layout is the one that tells a walk from a suffix match: `crate::a::b`
+ * and `other::a::b` end in the same two segments, and the caller imports the
+ * second. Matching the whole qualifier against the caller's dependencies picks
+ * the imported one — the path `crate::a::b` does not name it, and the graph
+ * reported it as `unique`.
+ *
+ * Checked against cargo 1.90.0: the fixture compiles, `crate::a::b::f()`
+ * returns 1 (`src/a/b.rs`) and the imported `b::f()` returns 2
+ * (`src/other/a/b.rs`), so the two calls in `caller.rs` are two different
+ * functions and a test that let them share an answer would be describing a
+ * program rustc rejects.
+ */
+describe("Rust multi-hop module paths", () => {
+  let root: string;
+
+  const write = (rel: string, body: string): void => {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+  };
+
+  async function candidatesOf(
+    callerRel: string,
+    name: string,
+    qualifier: string,
+  ): Promise<string[]> {
+    const graph = await buildCodeGraph(root);
+    resolveCallSites(
+      graph,
+      graph.symbolsByFile,
+      graph.outgoingCallsByFile,
+      graph.rustBindingsByFile,
+      graph.rustCrateRootByFile,
+      graph.rustInlineScopedCalls,
+    );
+    const edge = (graph.outgoingCallsByFile.get(callerRel) ?? []).find(
+      (e) => e.calleeName === name && e.calleeQualifier === qualifier,
+    );
+    expect(edge, `no qualified call to ${qualifier}::${name} in ${callerRel}`).toBeDefined();
+    return (edge?.calleeCandidates ?? []).slice().sort();
+  }
+
+  beforeAll(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-rust-walk-"));
+
+    write("Cargo.toml", '[package]\nname = "sib"\nedition = "2021"\n');
+    write(
+      "src/lib.rs",
+      "pub mod a;\npub mod caller;\npub mod deep;\npub mod leaf;\npub mod other;\npub mod support;\n",
+    );
+    // The module the path names. Nothing in the crate imports `a/b.rs`
+    // directly — `a/mod.rs` declares it — so only a walk reaches it.
+    write("src/a/mod.rs", "pub mod b;\n");
+    write("src/a/b.rs", "pub fn f() -> u32 { 1 }\n");
+    // The homonym: same last two segments, a different module.
+    write("src/other/mod.rs", "pub mod a;\n");
+    write("src/other/a/mod.rs", "pub mod b;\n");
+    write("src/other/a/b.rs", "pub fn f() -> u32 { 2 }\n");
+    write(
+      "src/caller.rs",
+      "use crate::other::a::b;\n\npub fn go() -> u32 {\n    let _ = b::f();\n    crate::a::b::f()\n}\n\npub fn deeper() -> u32 {\n    crate::deep::leaf::g()\n}\n",
+    );
+    // A `crate::` written in an integration test is the test's own crate, and
+    // its modules are filed beside it. The library has a `support` of its own,
+    // which is what reading the test's `crate::` as the library answers with.
+    write("src/support.rs", "pub fn helper() -> u32 { 10 }\n");
+    write("tests/support.rs", "pub fn helper() -> u32 { 20 }\n");
+    write(
+      "tests/t.rs",
+      "mod support;\n\n#[test]\nfn t() {\n    let got = crate::support::helper();\n    assert_eq!(got, 20);\n}\n",
+    );
+    // An ordinary module written as `deep.rs`, whose child is filed under the
+    // directory named after it, and a homonym of that child sitting beside
+    // `deep.rs` itself. A crate root takes its children from its own directory
+    // whatever it is called, so a module mistaken for one answers with the
+    // homonym.
+    write("src/deep.rs", "pub mod leaf;\n");
+    write("src/deep/leaf.rs", "pub fn g() -> u32 { 1 }\n");
+    write("src/leaf.rs", "pub fn g() -> u32 { 2 }\n");
+  });
+
+  afterAll(() => {
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("reaches a sibling module the caller never imports, and not its homonym", async () => {
+    // The regression: `crate::a::b::f()` is `src/a/b.rs`. `src/other/a/b.rs`
+    // is a dependency of the caller and its path ends in `a/b`, which is what
+    // a suffix match answers with — a file this path does not name.
+    expect(await candidatesOf("src/caller.rs", "f", "crate::a::b")).toEqual([
+      "src/a/b.rs::f#1",
+    ]);
+  });
+
+  it("keeps the imported homonym reachable under the name it was bound to", async () => {
+    // The other half of the same fixture: narrowing `crate::a::b` must not
+    // move `b::f()`, which really is the imported `other::a::b`.
+    expect(await candidatesOf("src/caller.rs", "f", "b")).toEqual([
+      "src/other/a/b.rs::f#1",
+    ]);
+  });
+
+  it("files an integration test's modules beside the test, not under its name", async () => {
+    // cargo 1.90.0 runs this fixture's `tests/t.rs` green asserting 20, so
+    // `crate::support` there is `tests/support.rs`. Reading the test as an
+    // ordinary module files its children under `tests/t/` and finds nothing;
+    // reading its `crate::` as the library answers `src/support.rs`.
+    expect(await candidatesOf("tests/t.rs", "helper", "crate::support")).toEqual([
+      "tests/support.rs::helper#1",
+    ]);
+  });
+
+  it("files an ordinary module's children under its own name, not beside it", async () => {
+    // The other side of the same question, and the one a walk needs at every
+    // hop: `src/deep.rs` is not a crate root, so `mod leaf;` written in it is
+    // `src/deep/leaf.rs` and not the `src/leaf.rs` sitting beside it. cargo
+    // 1.98.0 on this fixture returns 1 for `crate::deep::leaf::g()` and 2 for
+    // `crate::leaf::g()`, so answering with the second is a different
+    // function, reported as `unique`.
+    expect(await candidatesOf("src/caller.rs", "g", "crate::deep::leaf")).toEqual([
+      "src/deep/leaf.rs::g#1",
+    ]);
+  });
+});

--- a/tests/unit/code-graph-rust-crate-scope.test.ts
+++ b/tests/unit/code-graph-rust-crate-scope.test.ts
@@ -102,7 +102,14 @@ pub fn go() -> u32 {
     // ── One directory holding a library and a binary, which is two crates ──
     // `crate::` in `main.rs` is the binary's own root, and answering with the
     // library is a different file. Cargo gives `src/bin/x.rs` a crate too.
-    write("tool/Cargo.toml", '[package]\nname = "tool"\nedition = "2021"\n');
+    // The two `[[bin]]` entries are targets no convention would find: one
+    // inside `src/bin/` with no `main.rs` beside it, one outside it entirely.
+    // `cargo metadata` lists both (cargo 1.98), and nothing but the manifest
+    // says so — which is why the resolver leaves them unresolved below.
+    write(
+      "tool/Cargo.toml",
+      '[package]\nname = "tool"\nedition = "2021"\n\n[[bin]]\nname = "custom"\npath = "src/bin/custom/helper.rs"\n\n[[bin]]\nname = "launcher"\npath = "launcher/main.rs"\n',
+    );
     write("tool/src/lib.rs", "pub mod shared;\n\npub fn helper() -> u32 { 10 }\n");
     write("tool/src/shared.rs", "pub fn f() -> u32 { 11 }\n");
     write("tool/src/main.rs", `mod cli;
@@ -121,6 +128,93 @@ fn main() {
     let _ = crate::helper();
 }
 `);
+
+    // ── A multi-file binary: `src/bin/packer/main.rs` roots it, and every
+    // file beside it is one of its modules, however deep. Checked with cargo
+    // 1.98: `crate::helper()` in `packer/nested.rs` is the binary's `helper`,
+    // and with that one removed the build fails with E0425 rather than falling
+    // back to the library's.
+    write("tool/src/bin/packer/main.rs", `mod nested;
+mod sub;
+
+pub fn helper() -> u32 { 14 }
+
+fn main() {
+    let _ = nested::go() + sub::deep::go();
+}
+`);
+    write("tool/src/bin/packer/nested.rs", "pub fn go() -> u32 { crate::helper() }\n");
+    write("tool/src/bin/packer/sub/mod.rs", "pub mod deep;\n");
+    write("tool/src/bin/packer/sub/deep.rs", "pub fn go() -> u32 { crate::helper() }\n");
+
+    // A `src/bin/` directory with no `main.rs`: a target only because the
+    // manifest names the file, which is not readable from the resolver.
+    write("tool/src/bin/custom/helper.rs", `mod thing;
+
+pub fn helper() -> u32 { 21 }
+
+fn main() {
+    let _ = crate::helper();
+    let _ = crate::thing::run();
+}
+`);
+    write("tool/src/bin/custom/thing.rs", "pub fn run() -> u32 { 22 }\n");
+
+    // ── Integration tests, benchmarks and examples: each a crate of its own,
+    // and none of them reachable from the library, which never imports its
+    // own tests.
+    write("tool/tests/it.rs", `pub fn helper() -> u32 { 31 }
+
+#[test]
+fn t() {
+    let _ = crate::helper();
+}
+`);
+    write("tool/tests/dirtest/main.rs", `mod nested;
+
+pub fn helper() -> u32 { 32 }
+
+#[test]
+fn t() {
+    let _ = nested::go();
+}
+`);
+    write("tool/tests/dirtest/nested.rs", "pub fn go() -> u32 { crate::helper() }\n");
+    // The shared-helper idiom: `tests/common/` holds no `main.rs`, so it is no
+    // target, and `crate::` in it means whichever test wrote `mod common;`.
+    write("tool/tests/common/mod.rs", "pub fn shared() -> u32 { crate::helper() }\n");
+    write("tool/benches/b.rs", `pub fn helper() -> u32 { 41 }
+
+fn main() {
+    let _ = crate::helper();
+}
+`);
+    write("tool/examples/e.rs", `pub fn helper() -> u32 { 51 }
+
+fn main() {
+    let _ = crate::helper();
+}
+`);
+    // A `[[bin]] path` outside every conventional directory. No root reaches
+    // it, and it is named `main.rs`, which `mod x;` never resolves to.
+    write("tool/launcher/main.rs", `pub fn helper() -> u32 { 61 }
+
+fn main() {
+    let _ = crate::helper();
+}
+`);
+
+    // ── A crate whose root module sits where no convention looks ──────────
+    // `[lib] path` is not read here, so nothing is known about this crate's
+    // roots — which is the same absence of information as having no crate map
+    // at all, and keeps `crate::` reading the caller's own scope rather than
+    // turning into a verdict of "unresolved".
+    write("odd/Cargo.toml", '[package]\nname = "odd"\nedition = "2021"\n\n[lib]\npath = "core/root.rs"\n');
+    write("odd/core/root.rs", `pub mod config;
+
+pub fn go() -> u32 { crate::config::load() }
+`);
+    write("odd/core/config.rs", "pub fn load() -> u32 { 91 }\n");
 
     write("crates/alpha/inner/beta/Cargo.toml", '[package]\nname = "beta"\nedition = "2021"\n');
     write("crates/alpha/inner/beta/src/lib.rs", "pub mod config;\n");
@@ -169,6 +263,89 @@ fn main() {
     expect(await candidatesOf("tool/src/cli.rs", "helper", "crate")).toEqual([
       "tool/src/main.rs::helper#3",
     ]);
+  });
+
+  it("reads `crate::` in a binary's nested module as that binary's `main.rs`", async () => {
+    // `src/bin/packer/nested.rs` is a module of the `packer` binary, not a
+    // crate root of its own. Three files declare `helper` here: the library,
+    // the `src/main.rs` binary, and `packer/main.rs` — and only the last one
+    // is what rustc reads.
+    expect(await candidatesOf("tool/src/bin/packer/nested.rs", "helper", "crate")).toEqual([
+      "tool/src/bin/packer/main.rs::helper#4",
+    ]);
+  });
+
+  it("maps a file nested deeper under a binary to the same `main.rs`", async () => {
+    // Cargo autodiscovers `src/bin/<name>/main.rs` and nothing below it, so
+    // `packer/sub/deep.rs` belongs to `packer`, not to a `sub` of its own.
+    expect(await candidatesOf("tool/src/bin/packer/sub/deep.rs", "helper", "crate")).toEqual([
+      "tool/src/bin/packer/main.rs::helper#4",
+    ]);
+  });
+
+  it("reads `crate::` in an integration test as the test's own root", async () => {
+    // A library never imports its own tests, so no root reaches `tests/it.rs`
+    // and every root used to be the answer — which collapses onto the library
+    // as soon as the library alone declares the name.
+    expect(await candidatesOf("tool/tests/it.rs", "helper", "crate")).toEqual([
+      "tool/tests/it.rs::helper#1",
+    ]);
+  });
+
+  it("reads `crate::` in a benchmark as the benchmark's own root", async () => {
+    expect(await candidatesOf("tool/benches/b.rs", "helper", "crate")).toEqual([
+      "tool/benches/b.rs::helper#1",
+    ]);
+  });
+
+  it("reads `crate::` in an example as the example's own root", async () => {
+    expect(await candidatesOf("tool/examples/e.rs", "helper", "crate")).toEqual([
+      "tool/examples/e.rs::helper#1",
+    ]);
+  });
+
+  it("reads a folder test's module as that test's `main.rs`", async () => {
+    expect(await candidatesOf("tool/tests/dirtest/nested.rs", "helper", "crate")).toEqual([
+      "tool/tests/dirtest/main.rs::helper#3",
+    ]);
+  });
+
+  it("leaves a `src/bin` directory with no `main.rs` unresolved", async () => {
+    // `[[bin]] path = "src/bin/custom/helper.rs"` is the only thing that makes
+    // this file a target, and the manifest is not read here. The library and
+    // the `src/main.rs` binary both declare `helper`, and neither is it.
+    expect(await candidatesOf("tool/src/bin/custom/helper.rs", "helper", "crate")).toEqual([]);
+  });
+
+  it("does not read an unprovable target's `crate::` in its own scope", async () => {
+    // `crate::thing::run()` would find `custom/thing.rs` through the caller's
+    // own dependencies. Right answer, wrong reason: whether the crate root is
+    // `helper.rs` is exactly what cannot be established here, so the honest
+    // answer is none.
+    expect(await candidatesOf("tool/src/bin/custom/helper.rs", "run", "crate::thing")).toEqual([]);
+  });
+
+  it("leaves a shared `tests/common/mod.rs` unresolved", async () => {
+    // No `main.rs` beside it, so `tests/common/` is no target: this file is a
+    // module of whichever integration tests write `mod common;`, and `crate::`
+    // in it means a different root for each of them.
+    expect(await candidatesOf("tool/tests/common/mod.rs", "helper", "crate")).toEqual([]);
+  });
+
+  it("leaves a `main.rs` no root reaches unresolved", async () => {
+    // `launcher/main.rs` is a `[[bin]] path` target outside every conventional
+    // directory. `mod x;` reads `x.rs` or `x/mod.rs` and never `x/main.rs`, so
+    // this is no module of the library either — answering with every root
+    // would name the library, which is a different crate.
+    expect(await candidatesOf("tool/launcher/main.rs", "helper", "crate")).toEqual([]);
+  });
+
+  it("keeps reading `crate::` in its own scope when a crate shows no root", async () => {
+    // Knowing nothing is not the same verdict as knowing the caller is out of
+    // reach: the empty answer above leaves an edge unresolved, and this one
+    // must not, or a crate laid out by `[lib] path` would lose every
+    // `crate::` edge it has.
+    expect(await candidatesOf("odd/core/root.rs")).toEqual(["odd/core/config.rs::load#1"]);
   });
 
   it("keeps a crate's `crate::` out of a crate nested inside its own directory", async () => {

--- a/tests/unit/code-graph-rust-crate-scope.test.ts
+++ b/tests/unit/code-graph-rust-crate-scope.test.ts
@@ -412,14 +412,22 @@ describe("Rust multi-hop module paths", () => {
     // The module the path names. Nothing in the crate imports `a/b.rs`
     // directly — `a/mod.rs` declares it — so only a walk reaches it.
     write("src/a/mod.rs", "pub mod b;\n");
-    write("src/a/b.rs", "pub fn f() -> u32 { 1 }\n");
+    // A type by the same name lives in both, so the module prefix of a type
+    // qualifier is what decides which one — and it is walked, not suffixed.
+    write(
+      "src/a/b.rs",
+      "pub fn f() -> u32 { 1 }\n\npub struct Tipo;\n\nimpl Tipo {\n    pub fn metodo() -> u32 { 41 }\n}\n",
+    );
     // The homonym: same last two segments, a different module.
     write("src/other/mod.rs", "pub mod a;\n");
     write("src/other/a/mod.rs", "pub mod b;\n");
-    write("src/other/a/b.rs", "pub fn f() -> u32 { 2 }\n");
+    write(
+      "src/other/a/b.rs",
+      "pub fn f() -> u32 { 2 }\n\npub struct Tipo;\n\nimpl Tipo {\n    pub fn metodo() -> u32 { 42 }\n}\n",
+    );
     write(
       "src/caller.rs",
-      "use crate::other::a::b;\n\npub fn go() -> u32 {\n    let _ = b::f();\n    crate::a::b::f()\n}\n\npub fn deeper() -> u32 {\n    crate::deep::leaf::g()\n}\n",
+      "use crate::other::a::b;\n\npub fn go() -> u32 {\n    let _ = b::f();\n    crate::a::b::f()\n}\n\npub fn deeper() -> u32 {\n    crate::deep::leaf::g()\n}\n\npub fn by_path() -> u32 {\n    crate::a::b::Tipo::metodo()\n}\n",
     );
     // A `crate::` written in an integration test is the test's own crate, and
     // its modules are filed beside it. The library has a `support` of its own,
@@ -480,6 +488,18 @@ describe("Rust multi-hop module paths", () => {
     // function, reported as `unique`.
     expect(await candidatesOf("src/caller.rs", "g", "crate::deep::leaf")).toEqual([
       "src/deep/leaf.rs::g#1",
+    ]);
+  });
+
+  it("walks the module prefix of a type qualifier too, not just a plain path", async () => {
+    // The other half of the walk, and the one that had no test: the prefix of
+    // `crate::a::b::Tipo::metodo()` says *which* `Tipo`. Matched by suffix, it
+    // reaches `src/other/a/b.rs` as well — the caller imports that file and
+    // its path ends in `a/b` — and the answer becomes two types Rust never
+    // confuses. cargo 1.98 on this fixture: the path form returns 41 and the
+    // imported form returns 42, two different functions.
+    expect(await candidatesOf("src/caller.rs", "metodo", "crate::a::b::Tipo")).toEqual([
+      "src/a/b.rs::metodo#6",
     ]);
   });
 });

--- a/tests/unit/code-graph-rust-crate-scope.test.ts
+++ b/tests/unit/code-graph-rust-crate-scope.test.ts
@@ -30,8 +30,12 @@ describe("Rust crate scope for `crate::`", () => {
     fs.writeFileSync(abs, body);
   };
 
-  /** Resolve `callerRel`'s only qualified call and return its candidates. */
-  async function candidatesOf(callerRel: string): Promise<string[]> {
+  /** Resolve one qualified call written in `callerRel` and return its candidates. */
+  async function candidatesOf(
+    callerRel: string,
+    name = "load",
+    qualifier = "crate::config",
+  ): Promise<string[]> {
     const graph = await buildCodeGraph(root);
     resolveCallSites(
       graph,
@@ -39,11 +43,12 @@ describe("Rust crate scope for `crate::`", () => {
       graph.outgoingCallsByFile,
       graph.rustBindingsByFile,
       graph.rustCrateRootByFile,
+      graph.rustInlineScopedCalls,
     );
     const edge = (graph.outgoingCallsByFile.get(callerRel) ?? []).find(
-      (e) => e.calleeName === "load" && e.calleeQualifier === "crate::config",
+      (e) => e.calleeName === name && e.calleeQualifier === qualifier,
     );
-    expect(edge, `no qualified call to crate::config::load in ${callerRel}`).toBeDefined();
+    expect(edge, `no qualified call to ${qualifier}::${name} in ${callerRel}`).toBeDefined();
     return (edge?.calleeCandidates ?? []).slice().sort();
   }
 
@@ -55,7 +60,10 @@ describe("Rust crate scope for `crate::`", () => {
     // puts `sub/src/config.rs` inside it.
     write("Cargo.toml", '[package]\nname = "rootpkg"\nedition = "2021"\n\n[dependencies]\nsub = { path = "sub" }\n');
     write("src/lib.rs", `pub mod config;
+pub mod deep;
 use sub::config as subcfg;
+
+pub fn helper() -> u32 { 7 }
 
 pub fn go() -> u32 {
     let _ = subcfg::load();
@@ -63,6 +71,11 @@ pub fn go() -> u32 {
 }
 `);
     write("src/config.rs", "pub fn load() -> u32 { 1 }\n");
+    // A nested module calling the crate root. `deep/inner.rs` never imports
+    // `lib.rs` — the import runs the other way — so `crate::helper()` is only
+    // reachable by starting the path where Rust starts it.
+    write("src/deep/mod.rs", "pub mod inner;\n");
+    write("src/deep/inner.rs", "pub fn go() -> u32 { crate::helper() }\n");
     write("sub/Cargo.toml", '[package]\nname = "sub"\nedition = "2021"\n');
     write("sub/src/lib.rs", "pub mod config;\n");
     write("sub/src/config.rs", "pub fn load() -> u32 { 2 }\n");
@@ -92,6 +105,12 @@ pub fn go() -> u32 {
 
   it("keeps a root package's `crate::` out of a crate beside it", async () => {
     expect(await candidatesOf("src/lib.rs")).toEqual(["src/config.rs::load#1"]);
+  });
+
+  it("reads `crate::` from the crate root, which a nested module never imports", async () => {
+    expect(await candidatesOf("src/deep/inner.rs", "helper", "crate")).toEqual([
+      "src/lib.rs::helper#5",
+    ]);
   });
 
   it("keeps a crate's `crate::` out of a crate nested inside its own directory", async () => {

--- a/tests/unit/code-graph-rust-crate-scope.test.ts
+++ b/tests/unit/code-graph-rust-crate-scope.test.ts
@@ -75,7 +75,12 @@ pub fn go() -> u32 {
     // `lib.rs` — the import runs the other way — so `crate::helper()` is only
     // reachable by starting the path where Rust starts it.
     write("src/deep/mod.rs", "pub mod inner;\n");
-    write("src/deep/inner.rs", "pub fn go() -> u32 { crate::helper() }\n");
+    write("src/deep/inner.rs", `use crate as root;
+
+pub fn go() -> u32 { crate::helper() }
+
+pub fn go_aliased() -> u32 { root::helper() }
+`);
     write("sub/Cargo.toml", '[package]\nname = "sub"\nedition = "2021"\n');
     write("sub/src/lib.rs", "pub mod config;\n");
     write("sub/src/config.rs", "pub fn load() -> u32 { 2 }\n");
@@ -109,6 +114,14 @@ pub fn go() -> u32 {
 
   it("reads `crate::` from the crate root, which a nested module never imports", async () => {
     expect(await candidatesOf("src/deep/inner.rs", "helper", "crate")).toEqual([
+      "src/lib.rs::helper#5",
+    ]);
+  });
+
+  it("reads an alias for the crate root the same way", async () => {
+    // `use crate as root;` is the same path under another name, so it must
+    // reach the same file — not the caller's own scope, which answers nothing.
+    expect(await candidatesOf("src/deep/inner.rs", "helper", "root")).toEqual([
       "src/lib.rs::helper#5",
     ]);
   });

--- a/tests/unit/code-graph-rust-inline-mod.test.ts
+++ b/tests/unit/code-graph-rust-inline-mod.test.ts
@@ -38,7 +38,7 @@ describe("Rust `super::` written inside an inline mod", () => {
 
     write("Cargo.toml", '[package]\nname = "inlinemod"\nedition = "2021"\n');
     write("src/lib.rs", "pub mod a;\npub mod sub;\n");
-    write("src/sub.rs", "pub fn f() -> u32 { 1 }\n");
+    write("src/sub.rs", "pub fn f() -> u32 { 1 }\npub fn h() -> u32 { 8 }\n");
     write("src/a.rs", `pub mod b;
 pub mod sub;
 
@@ -46,12 +46,12 @@ pub fn helper() -> u32 { 2 }
 `);
     write("src/a/sub.rs", "pub fn f() -> u32 { 3 }\n");
     write("src/a/b/sub.rs", "pub fn g() -> u32 { 5 }\n");
+    write("src/a/b/inner.rs", "pub fn probe() -> u32 { 7 }\n");
     write("src/a/b.rs", `pub mod sub;
+pub mod inner;
 use crate::sub as aliased;
 
 pub fn helper() -> u32 { 4 }
-
-pub fn use_the_alias() -> u32 { aliased::f() }
 
 #[cfg(test)]
 mod tests {
@@ -66,8 +66,24 @@ mod tests {
     }
 
     #[test]
+    fn one_hop_then_an_imported_name() {
+        let _ = super::aliased::h();
+    }
+
+    #[test]
     fn two_hops_is_the_parent() {
         let _ = super::super::sub::f();
+    }
+
+    mod deeper {
+        #[test]
+        fn fewer_hops_than_modules() {
+            let _ = super::inner::probe();
+        }
+    }
+
+    mod inner {
+        pub fn probe() -> u32 { 6 }
     }
 }
 `);
@@ -93,7 +109,7 @@ mod tests {
   it("reads one `super` as the file the inline mod is written in", () => {
     // Read one module too high, this answers `src/a.rs::helper` — a file that
     // does declare a `helper`, so the wrong answer arrives as `unique`.
-    expect(candidates.get("helper")).toEqual(["src/a/b.rs::helper#4"]);
+    expect(candidates.get("helper")).toEqual(["src/a/b.rs::helper#5"]);
   });
 
   it("reads two `super` as that file's parent", () => {
@@ -102,9 +118,23 @@ mod tests {
   });
 
   it("keeps what is left of the path relative to that file", () => {
-    // `super::sub` inside the inline mod is `b.rs`'s own `sub` module. `b.rs`
-    // also has `use crate::sub as aliased;`, so a leftover path read as a bare
-    // one would be looked up among the file's bindings before its modules.
+    // `super::sub` inside the inline mod is `b.rs`'s own `sub` module.
     expect(candidates.get("g")).toEqual(["src/a/b/sub.rs::g#1"]);
+  });
+
+  it("lets what is left reach a name the file imported", () => {
+    // `super::aliased` is the file's own `use crate::sub as aliased;`. In Rust
+    // a module's namespace holds the names its `use` declarations bring in, so
+    // the leftover has to stay bare: read as `self::aliased` it would be
+    // matched against the file's modules alone, and answer nothing.
+    expect(candidates.get("h")).toEqual(["src/sub.rs::h#2"]);
+  });
+
+  it("answers with the file when the path never leaves the inline modules", () => {
+    // Two inline modules deep and only one `super`: the path is rooted in
+    // `tests`, which has no file of its own. `b.rs` also declares `mod inner;`
+    // — a different file — so a leftover written bare lands there and says
+    // `unique`. The file is what is certain, and is all this claims.
+    expect(candidates.get("probe")).toEqual(["src/a/b.rs::probe#37"]);
   });
 });

--- a/tests/unit/code-graph-rust-inline-mod.test.ts
+++ b/tests/unit/code-graph-rust-inline-mod.test.ts
@@ -40,7 +40,39 @@ describe("Rust `super::` written inside an inline mod", () => {
     root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-rust-inline-mod-"));
 
     write("Cargo.toml", '[package]\nname = "inlinemod"\nedition = "2021"\n');
-    write("src/lib.rs", "pub mod a;\npub mod sub;\n");
+    // The crate root reaches `a::c` by naming modules, and `only_inside` is
+    // not in `c`'s own module — it is in `c`'s inline `mod holder`. rustc:
+    // `error[E0425]: cannot find function only_inside in module crate::a::c`.
+    write(
+      "src/lib.rs",
+      `pub mod a;
+pub mod sub;
+pub mod tipo;
+
+pub fn from_root() -> u32 { crate::a::c::only_inside() }
+`,
+    );
+    // The same reach written as `super::`, from a sibling of `c`. Same module,
+    // same refusal — the spelling of the path is not what decides it.
+    write("src/tipo.rs", `pub fn from_sibling() -> u32 { super::a::c::only_inside() }
+
+#[cfg(test)]
+mod tests {
+    pub struct Local;
+
+    impl Local {
+        pub fn make() -> u32 { 7 }
+    }
+
+    // Written outside the assert: a macro body is one token tree, so a call
+    // inside it is never extracted at all.
+    #[test]
+    fn reaches_its_own_inline_type() {
+        let got = Local::make();
+        assert_eq!(got, 7);
+    }
+}
+`);
     write("src/sub.rs", "pub fn f() -> u32 { 1 }\npub fn h() -> u32 { 8 }\n");
     write("src/a.rs", `pub mod b;
 pub mod c;
@@ -169,7 +201,7 @@ mod tests {
         .filter((s) => s.name !== "<module>")
         .map((s) => s.id);
     qualified = new Map();
-    for (const file of ["src/a/b.rs", "src/a/c.rs", "src/a/d.rs"]) {
+    for (const file of ["src/a/b.rs", "src/a/c.rs", "src/a/d.rs", "src/lib.rs", "src/tipo.rs"]) {
       for (const edge of graph.outgoingCallsByFile.get(file) ?? []) {
         if (!edge.calleeQualifier) continue;
         const caller = edge.callerId.split("::").pop()?.split("#")[0] ?? "";
@@ -309,5 +341,45 @@ mod tests {
     const edge = edgeFor("fewer_hops_than_modules", "super::inner", "probe");
     expect(edge.calleeCandidates).toEqual([]);
     expect(edge.confidence).toBe("unresolved");
+  });
+
+  it("refuses an inline-mod symbol reached through `crate::`, not only `self`", () => {
+    // The rule is the path, not the spelling. `crate::a::c` names `c`'s own
+    // module, and `only_inside` is declared in `c`'s inline `mod holder` —
+    // cargo 1.98 on this shape: `error[E0425]: cannot find function
+    // only_inside in module crate::a::c`.
+    //
+    // The file is the scope this resolution has, so the id comes back with the
+    // rest; refusing it is what keeps a `unique` off a symbol Rust cannot call
+    // from here. Before this, the filter asked whether the qualifier was
+    // literally `self`, and every other spelling of the same reach answered
+    // `unique`.
+    const edge = edgeFor("from_root", "crate::a::c", "only_inside");
+    expect(edge.calleeCandidates).toEqual([]);
+    expect(edge.confidence).toBe("unresolved");
+  });
+
+  it("refuses it through `super::` too", () => {
+    // Same module reached by climbing instead of by rooting. A rule written
+    // per spelling would need one branch per spelling, and would keep missing
+    // the next one.
+    const edge = edgeFor("from_sibling", "super::a::c", "only_inside");
+    expect(edge.calleeCandidates).toEqual([]);
+    expect(edge.confidence).toBe("unresolved");
+  });
+
+  it("still reaches a type an inline mod declares, from inside that mod", () => {
+    // The other side, and the reason the refusal follows the path rather than
+    // the symbol: `Local` is declared inside `mod tests` and `Local::make()`
+    // is written inside the same `mod`, where Rust does reach it — cargo 1.98
+    // runs this fixture's assertion green. A bare type qualifier is not a
+    // module path, so nothing is dropped from it; refusing here would turn a
+    // correct `unique` into `unresolved`.
+    // `local` because the symbol is in the caller's own file, which is what
+    // that label has always meant here — what is under test is the candidate,
+    // which must still be there.
+    const edge = edgeFor("reaches_its_own_inline_type", "Local", "make");
+    expect(edge.calleeCandidates).toEqual(["src/tipo.rs::make#8"]);
+    expect(edge.confidence).toBe("local");
   });
 });

--- a/tests/unit/code-graph-rust-inline-mod.test.ts
+++ b/tests/unit/code-graph-rust-inline-mod.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildCodeGraph } from "../../src/services/code-graph.js";
 import { resolveCallSites } from "../../src/services/graph-symbol-resolution.js";
+import type { SymbolEdge } from "../../src/types.js";
 
 /**
  * What `super::` means when the call is written inside an inline `mod`.
@@ -25,7 +26,7 @@ import { resolveCallSites } from "../../src/services/graph-symbol-resolution.js"
  */
 describe("Rust `super::` written inside an inline mod", () => {
   let root: string;
-  let candidates: Map<string, string[]>;
+  let qualified: Map<string, SymbolEdge>;
 
   const write = (rel: string, body: string): void => {
     const abs = path.join(root, rel);
@@ -75,11 +76,22 @@ mod tests {
         let _ = super::super::sub::f();
     }
 
+    pub fn helper() -> u32 { 9 }
+
     mod deeper {
         #[test]
         fn fewer_hops_than_modules() {
             let _ = super::inner::probe();
         }
+
+        #[test]
+        fn a_scope_with_no_file() {
+            let _ = super::helper();
+        }
+    }
+
+    mod sibling {
+        pub fn helper() -> u32 { 10 }
     }
 
     mod inner {
@@ -95,12 +107,28 @@ mod tests {
       graph.outgoingCallsByFile,
       graph.rustBindingsByFile,
       graph.rustCrateRootByFile,
+      graph.rustInlineScopedCalls,
     );
-    candidates = new Map();
+    // Keyed by callee and qualifier, because two calls here are written
+    // `super::helper()` and differ only in how deep they sit.
+    qualified = new Map();
     for (const edge of graph.outgoingCallsByFile.get("src/a/b.rs") ?? []) {
-      if (edge.calleeQualifier) candidates.set(edge.calleeName, edge.calleeCandidates.slice().sort());
+      if (edge.calleeQualifier) {
+        qualified.set(`${edge.calleeName}@${edge.calleeQualifier}`, edge);
+      }
     }
   });
+
+  /** The one qualified call written as `name` with `qualifier`. */
+  const edgeFor = (name: string, qualifier: string): SymbolEdge => {
+    const edge = qualified.get(`${name}@${qualifier}`);
+    expect(edge, `no call to ${qualifier}::${name}`).toBeDefined();
+    return edge as SymbolEdge;
+  };
+
+  /** Its candidates, sorted. */
+  const candidatesOf = (name: string, qualifier: string): string[] =>
+    edgeFor(name, qualifier).calleeCandidates.slice().sort();
 
   afterAll(() => {
     if (root) fs.rmSync(root, { recursive: true, force: true });
@@ -109,17 +137,24 @@ mod tests {
   it("reads one `super` as the file the inline mod is written in", () => {
     // Read one module too high, this answers `src/a.rs::helper` — a file that
     // does declare a `helper`, so the wrong answer arrives as `unique`.
-    expect(candidates.get("helper")).toEqual(["src/a/b.rs::helper#5"]);
+    //
+    // The answer is the file, at the granularity `local` has always had here:
+    // the file's other `helper`s come along, exactly as they do for a bare
+    // `helper()` written in the same place. `#5` is the one Rust means.
+    const edge = edgeFor("helper", "self");
+    expect(edge.confidence).toBe("local");
+    expect(candidatesOf("helper", "self")).toContain("src/a/b.rs::helper#5");
+    expect(candidatesOf("helper", "self").every((id) => id.startsWith("src/a/b.rs::"))).toBe(true);
   });
 
   it("reads two `super` as that file's parent", () => {
     // `src/sub.rs` also declares `f`, and is what one hop too many reaches.
-    expect(candidates.get("f")).toEqual(["src/a/sub.rs::f#1"]);
+    expect(candidatesOf("f", "super::sub")).toEqual(["src/a/sub.rs::f#1"]);
   });
 
   it("keeps what is left of the path relative to that file", () => {
     // `super::sub` inside the inline mod is `b.rs`'s own `sub` module.
-    expect(candidates.get("g")).toEqual(["src/a/b/sub.rs::g#1"]);
+    expect(candidatesOf("g", "sub")).toEqual(["src/a/b/sub.rs::g#1"]);
   });
 
   it("lets what is left reach a name the file imported", () => {
@@ -127,14 +162,25 @@ mod tests {
     // a module's namespace holds the names its `use` declarations bring in, so
     // the leftover has to stay bare: read as `self::aliased` it would be
     // matched against the file's modules alone, and answer nothing.
-    expect(candidates.get("h")).toEqual(["src/sub.rs::h#2"]);
+    expect(candidatesOf("h", "aliased")).toEqual(["src/sub.rs::h#2"]);
   });
 
-  it("answers with the file when the path never leaves the inline modules", () => {
-    // Two inline modules deep and only one `super`: the path is rooted in
-    // `tests`, which has no file of its own. `b.rs` also declares `mod inner;`
-    // — a different file — so a leftover written bare lands there and says
-    // `unique`. The file is what is certain, and is all this claims.
-    expect(candidates.get("probe")).toEqual(["src/a/b.rs::probe#37"]);
+  it("leaves a path rooted in an inline mod unresolved, with its qualifier", () => {
+    // Two inline modules deep and one `super`: the path is rooted in `tests`,
+    // which has no file. Answering with `b.rs` would hand back every `helper`
+    // the file holds — including `tests::sibling`'s, which Rust cannot reach
+    // from `tests::deeper` — and whoever walks the candidates would follow it.
+    const edge = edgeFor("helper", "super");
+    expect(edge.calleeCandidates).toEqual([]);
+    expect(edge.confidence).toBe("unresolved");
+  });
+
+  it("does not answer a rooted path with the file either", () => {
+    // The same rule for a path that continues: `super::inner` is `tests`'s own
+    // `inner`, and `b.rs` declares a `mod inner;` of its own — a different
+    // file — so neither that file nor the caller's is an answer.
+    const edge = edgeFor("probe", "super::inner");
+    expect(edge.calleeCandidates).toEqual([]);
+    expect(edge.confidence).toBe("unresolved");
   });
 });

--- a/tests/unit/code-graph-rust-inline-mod.test.ts
+++ b/tests/unit/code-graph-rust-inline-mod.test.ts
@@ -57,6 +57,10 @@ pub fn by_glob() -> u32 { crate::glob::only_via_glob() }
 pub fn past_the_glob() -> u32 { crate::glob::nascosto() }
 pub fn by_self_alias() -> u32 { A::helper() }
 use crate::a::{self as A};
+use self as ThisModule;
+pub fn local_helper() -> u32 { 41 }
+pub fn by_bare_self_alias() -> u32 { ThisModule::local_helper() }
+pub fn past_nested_glob() -> u32 { crate::glob::troppo_profondo() }
 `,
     );
     // The two ways a file lifts a name out of its own inline `mod` to its top
@@ -73,6 +77,10 @@ pub(crate) use self::imp::per_nome;
 `);
     write("src/glob.rs", `mod imp {
     pub fn only_via_glob() -> u32 { 31 }
+
+    mod hidden {
+        pub fn troppo_profondo() -> u32 { 33 }
+    }
 }
 
 mod altro {
@@ -445,6 +453,16 @@ mod tests {
     expect(edge.confidence).toBe("unresolved");
   });
 
+  it("does not let a glob flatten a nested inline mod", () => {
+    // `pub use imp::*;` carries the names exported directly by `imp`; it does
+    // not flatten `imp::hidden` into the file's top level. Treating only the
+    // outermost owner as the source makes this look callable when rustc does
+    // not expose it there.
+    const edge = edgeFor("past_nested_glob", "crate::glob", "troppo_profondo");
+    expect(edge.calleeCandidates).toEqual([]);
+    expect(edge.confidence).toBe("unresolved");
+  });
+
   it("reads `use crate::a::{self as A};` as the module, not as `a::self`", () => {
     // Inside a use list, `self` is the module the list hangs off, so the
     // binding names `crate::a`. Recorded literally as `crate::a::self` it
@@ -454,5 +472,12 @@ mod tests {
     const edge = edgeFor("by_self_alias", "A", "helper");
     expect(edge.calleeCandidates).toEqual(["src/a.rs::helper#6"]);
     expect(edge.confidence).toBe("unique");
+  });
+
+  it("reads `use self as ThisModule;` as the file's own module", () => {
+    // A top-level bare `self` is a real anchor, not an empty use path.
+    const edge = edgeFor("by_bare_self_alias", "ThisModule", "local_helper");
+    expect(edge.calleeCandidates).toEqual(["src/lib.rs::local_helper#14"]);
+    expect(edge.confidence).toBe("local");
   });
 });

--- a/tests/unit/code-graph-rust-inline-mod.test.ts
+++ b/tests/unit/code-graph-rust-inline-mod.test.ts
@@ -48,10 +48,32 @@ describe("Rust `super::` written inside an inline mod", () => {
       `pub mod a;
 pub mod sub;
 pub mod tipo;
+pub mod riesporta;
+pub mod glob;
 
 pub fn from_root() -> u32 { crate::a::c::only_inside() }
+pub fn by_name() -> u32 { crate::riesporta::per_nome() }
+pub fn by_glob() -> u32 { crate::glob::only_via_glob() }
 `,
     );
+    // The two ways a file lifts a name out of its own inline `mod` to its top
+    // level. From the file's module Rust reaches both — cargo 1.98 runs a
+    // crate of this shape green — so refusing them because the symbol sits
+    // inside an inline `mod` withdraws answers that are right. tokio does the
+    // explicit form in `net/unix/ucred.rs` and the glob in
+    // `runtime/scheduler/multi_thread/counters.rs`, 35 calls between them.
+    write("src/riesporta.rs", `mod imp {
+    pub fn per_nome() -> u32 { 22 }
+}
+
+pub(crate) use self::imp::per_nome;
+`);
+    write("src/glob.rs", `mod imp {
+    pub fn only_via_glob() -> u32 { 31 }
+}
+
+pub use imp::*;
+`);
     // The same reach written as `super::`, from a sibling of `c`. Same module,
     // same refusal — the spelling of the path is not what decides it.
     write("src/tipo.rs", `pub fn from_sibling() -> u32 { super::a::c::only_inside() }
@@ -381,5 +403,27 @@ mod tests {
     const edge = edgeFor("reaches_its_own_inline_type", "Local", "make");
     expect(edge.calleeCandidates).toEqual(["src/tipo.rs::make#8"]);
     expect(edge.confidence).toBe("local");
+  });
+
+  it("keeps a name an inline mod re-exports by name to the file's top level", () => {
+    // From a file's own module Rust reaches what the top level declares *and
+    // what it imports*: `pub(crate) use self::imp::per_nome;` puts `per_nome`
+    // there as surely as writing it there. cargo 1.98 runs the assertion
+    // green. Refusing it on the grounds that the declaration sits inside
+    // `mod imp` withdrew 1 right answer in tokio's `net/unix/ucred.rs`.
+    const edge = edgeFor("by_name", "crate::riesporta", "per_nome");
+    expect(edge.calleeCandidates).toEqual(["src/riesporta.rs::per_nome#2"]);
+    expect(edge.confidence).toBe("unique");
+  });
+
+  it("keeps one the file re-exports with a glob, which cannot be enumerated", () => {
+    // `pub use imp::*;` carries names this cannot list — the module it reads
+    // from need not be a file — so the glob is recorded under `*` and read as
+    // "this might be reachable". That keeps the refusal to what is provably
+    // out of reach, and it is what tokio's `counters.rs` needs: 34 calls to
+    // `super::counters::inc_num_inc_notify_local()` and its neighbours.
+    const edge = edgeFor("by_glob", "crate::glob", "only_via_glob");
+    expect(edge.calleeCandidates).toEqual(["src/glob.rs::only_via_glob#2"]);
+    expect(edge.confidence).toBe("unique");
   });
 });

--- a/tests/unit/code-graph-rust-inline-mod.test.ts
+++ b/tests/unit/code-graph-rust-inline-mod.test.ts
@@ -54,6 +54,9 @@ pub mod glob;
 pub fn from_root() -> u32 { crate::a::c::only_inside() }
 pub fn by_name() -> u32 { crate::riesporta::per_nome() }
 pub fn by_glob() -> u32 { crate::glob::only_via_glob() }
+pub fn past_the_glob() -> u32 { crate::glob::nascosto() }
+pub fn by_self_alias() -> u32 { A::helper() }
+use crate::a::{self as A};
 `,
     );
     // The two ways a file lifts a name out of its own inline `mod` to its top
@@ -70,6 +73,10 @@ pub(crate) use self::imp::per_nome;
 `);
     write("src/glob.rs", `mod imp {
     pub fn only_via_glob() -> u32 { 31 }
+}
+
+mod altro {
+    pub fn nascosto() -> u32 { 32 }
 }
 
 pub use imp::*;
@@ -424,6 +431,28 @@ mod tests {
     // `super::counters::inc_num_inc_notify_local()` and its neighbours.
     const edge = edgeFor("by_glob", "crate::glob", "only_via_glob");
     expect(edge.calleeCandidates).toEqual(["src/glob.rs::only_via_glob#2"]);
+    expect(edge.confidence).toBe("unique");
+  });
+
+  it("does not let a glob carry a sibling inline mod it never reads from", () => {
+    // The other half of the exemption above, and the one it was missing:
+    // `pub use imp::*;` exports what `imp` exports, so `nascosto` in a sibling
+    // `mod altro { … }` stays out. cargo 1.98 on this shape:
+    // `error[E0425]: cannot find function nascosto in module crate::glob`.
+    // Exempting on "the file has some glob" answered it `unique`.
+    const edge = edgeFor("past_the_glob", "crate::glob", "nascosto");
+    expect(edge.calleeCandidates).toEqual([]);
+    expect(edge.confidence).toBe("unresolved");
+  });
+
+  it("reads `use crate::a::{self as A};` as the module, not as `a::self`", () => {
+    // Inside a use list, `self` is the module the list hangs off, so the
+    // binding names `crate::a`. Recorded literally as `crate::a::self` it
+    // matched no module and `A::helper()` went unresolved. cargo 1.98
+    // compiles the form and tokio writes it — `use super::unix::{self as
+    // os_impl};` in `signal/ctrl_c.rs`, which this recovers.
+    const edge = edgeFor("by_self_alias", "A", "helper");
+    expect(edge.calleeCandidates).toEqual(["src/a.rs::helper#6"]);
     expect(edge.confidence).toBe("unique");
   });
 });

--- a/tests/unit/code-graph-rust-inline-mod.test.ts
+++ b/tests/unit/code-graph-rust-inline-mod.test.ts
@@ -27,6 +27,8 @@ import type { SymbolEdge } from "../../src/types.js";
 describe("Rust `super::` written inside an inline mod", () => {
   let root: string;
   let qualified: Map<string, SymbolEdge>;
+  /** Kept so a test can check the fixture still declares what it is about. */
+  let symbolsOf: (file: string) => string[];
 
   const write = (rel: string, body: string): void => {
     const abs = path.join(root, rel);
@@ -41,9 +43,39 @@ describe("Rust `super::` written inside an inline mod", () => {
     write("src/lib.rs", "pub mod a;\npub mod sub;\n");
     write("src/sub.rs", "pub fn f() -> u32 { 1 }\npub fn h() -> u32 { 8 }\n");
     write("src/a.rs", `pub mod b;
+pub mod c;
+pub mod d;
 pub mod sub;
 
 pub fn helper() -> u32 { 2 }
+`);
+    // The name exists in this file only inside an inline `mod`, so from
+    // `tests` there is nothing for `super::only_inside()` to reach. Checked
+    // against rustc, which answers E0425 for exactly this shape.
+    write("src/a/c.rs", `mod holder {
+    pub fn only_inside() -> u32 { 11 }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn nothing_at_the_file_top_level() {
+        let _ = super::only_inside();
+    }
+}
+`);
+    // The common shape, and the one that must not be lost: a `super::` call in
+    // `mod tests` in a file with no homonym inside any inline `mod`. It is 5
+    // edges on tokio 1.40.0 and 4 on the private tree.
+    write("src/a/d.rs", `pub fn lone() -> u32 { 12 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn the_common_shape_still_resolves() {
+        let _ = super::lone();
+    }
+}
 `);
     write("src/a/sub.rs", "pub fn f() -> u32 { 3 }\n");
     write("src/a/b/sub.rs", "pub fn g() -> u32 { 5 }\n");
@@ -62,6 +94,11 @@ mod tests {
     }
 
     #[test]
+    fn self_is_the_inline_mod() {
+        let _ = self::helper();
+    }
+
+    #[test]
     fn one_hop_then_a_module() {
         let _ = super::sub::g();
     }
@@ -77,6 +114,16 @@ mod tests {
     }
 
     pub fn helper() -> u32 { 9 }
+
+    struct Probe;
+
+    impl Probe {
+        fn twin() -> u32 { 11 }
+
+        fn calls_its_own() -> u32 {
+            Self::twin()
+        }
+    }
 
     mod deeper {
         #[test]
@@ -108,27 +155,41 @@ mod tests {
       graph.rustBindingsByFile,
       graph.rustCrateRootByFile,
       graph.rustInlineScopedCalls,
+      graph.rustInlineDeclaredSymbols,
     );
-    // Keyed by callee and qualifier, because two calls here are written
-    // `super::helper()` and differ only in how deep they sit.
+    // Keyed by the function the call is written in as well as by callee and
+    // qualifier. `super::helper()` and `self::helper()` both reach resolution
+    // as `helper@self` — the first because the rewrite consumed its one
+    // `super`, the second because that is how it was written — so on the callee
+    // and qualifier alone they would be one entry, and whichever came last
+    // would silently stand for both. Two files also write `super::` calls of
+    // their own, and the caller keeps those apart too.
+    symbolsOf = (file) =>
+      (graph.symbolsByFile.get(file) ?? [])
+        .filter((s) => s.name !== "<module>")
+        .map((s) => s.id);
     qualified = new Map();
-    for (const edge of graph.outgoingCallsByFile.get("src/a/b.rs") ?? []) {
-      if (edge.calleeQualifier) {
-        qualified.set(`${edge.calleeName}@${edge.calleeQualifier}`, edge);
+    for (const file of ["src/a/b.rs", "src/a/c.rs", "src/a/d.rs"]) {
+      for (const edge of graph.outgoingCallsByFile.get(file) ?? []) {
+        if (!edge.calleeQualifier) continue;
+        const caller = edge.callerId.split("::").pop()?.split("#")[0] ?? "";
+        const key = `${caller}|${edge.calleeQualifier}::${edge.calleeName}`;
+        expect(qualified.has(key), `two calls share the key ${key}`).toBe(false);
+        qualified.set(key, edge);
       }
     }
   });
 
-  /** The one qualified call written as `name` with `qualifier`. */
-  const edgeFor = (name: string, qualifier: string): SymbolEdge => {
-    const edge = qualified.get(`${name}@${qualifier}`);
-    expect(edge, `no call to ${qualifier}::${name}`).toBeDefined();
+  /** The one qualified call `caller` writes as `qualifier::name`. */
+  const edgeFor = (caller: string, qualifier: string, name: string): SymbolEdge => {
+    const edge = qualified.get(`${caller}|${qualifier}::${name}`);
+    expect(edge, `no call to ${qualifier}::${name} in ${caller}`).toBeDefined();
     return edge as SymbolEdge;
   };
 
   /** Its candidates, sorted. */
-  const candidatesOf = (name: string, qualifier: string): string[] =>
-    edgeFor(name, qualifier).calleeCandidates.slice().sort();
+  const candidatesOf = (caller: string, qualifier: string, name: string): string[] =>
+    edgeFor(caller, qualifier, name).calleeCandidates.slice().sort();
 
   afterAll(() => {
     if (root) fs.rmSync(root, { recursive: true, force: true });
@@ -137,24 +198,89 @@ mod tests {
   it("reads one `super` as the file the inline mod is written in", () => {
     // Read one module too high, this answers `src/a.rs::helper` — a file that
     // does declare a `helper`, so the wrong answer arrives as `unique`.
-    //
-    // The answer is the file, at the granularity `local` has always had here:
-    // the file's other `helper`s come along, exactly as they do for a bare
-    // `helper()` written in the same place. `#5` is the one Rust means.
-    const edge = edgeFor("helper", "self");
+    const edge = edgeFor("one_hop_is_this_file", "self", "helper");
     expect(edge.confidence).toBe("local");
-    expect(candidatesOf("helper", "self")).toContain("src/a/b.rs::helper#5");
-    expect(candidatesOf("helper", "self").every((id) => id.startsWith("src/a/b.rs::"))).toBe(true);
+    expect(candidatesOf("one_hop_is_this_file", "self", "helper"))
+      .toContain("src/a/b.rs::helper#5");
+  });
+
+  it("answers it with the file's top level and nothing an inline mod holds", () => {
+    // The maintainer's case. First that the fixture is still the case: `b.rs`
+    // has to declare three `helper`s for this to prove anything — `#5` at its
+    // top level, `#34` in `tests`, `#59` in `tests::sibling` — and a fixture
+    // that quietly lost one of them would leave the assertion below green and
+    // empty.
+    expect(symbolsOf("src/a/b.rs").filter((id) => id.includes("::helper#"))).toEqual([
+      "src/a/b.rs::helper#5",
+      "src/a/b.rs::helper#34",
+      "src/a/b.rs::helper#59",
+    ]);
+
+    // From `tests`, `super::helper()` names the file's own module, and rustc
+    // binds the top-level one: a crate of this shape compiles with that
+    // assertion passing, and with the top-level `helper` removed it is E0425.
+    //
+    // So `#34` and `#59` are not a wider answer, they are calls Rust cannot
+    // make from where this one is written. Handing them back put two symbols
+    // in front of whoever walks the candidates for an impact analysis.
+    expect(candidatesOf("one_hop_is_this_file", "self", "helper"))
+      .toEqual(["src/a/b.rs::helper#5"]);
+  });
+
+  it("refuses a `self::` path written inside an inline mod", () => {
+    // `self` is the module the path is written in, so here it is `tests`, and
+    // rustc binds `tests::helper` — not the file's. `tests` has no file and no
+    // spelling resolution can follow, which is the refusal already in place
+    // for a `super::` path rooted the same way.
+    //
+    // Without it this path would be read as the file's own module and answered
+    // with the top-level `#5`, which is the one `helper` Rust does *not* mean
+    // here: a wrong answer stated as `local`.
+    const edge = edgeFor("self_is_the_inline_mod", "self", "helper");
+    expect(edge.calleeQualifier).toBe("self");
+    expect(edge.calleeCandidates).toEqual([]);
+    expect(edge.confidence).toBe("unresolved");
+  });
+
+  it("refuses the call when the file's top level declares nothing of that name", () => {
+    // `c.rs` declares `only_inside` inside `mod holder` and nowhere else, so
+    // from `tests` there is nothing to reach: rustc answers E0425 for exactly
+    // this shape. The edge keeps its qualifier and goes unresolved rather than
+    // pointing at the one declaration in the file that Rust cannot call.
+    const edge = edgeFor("nothing_at_the_file_top_level", "self", "only_inside");
+    expect(edge.calleeQualifier).toBe("self");
+    expect(edge.calleeCandidates).toEqual([]);
+    expect(edge.confidence).toBe("unresolved");
+  });
+
+  it("still resolves the common shape, where no inline mod declares the name", () => {
+    // The form this must not cost anything: `super::lone()` in `mod tests`, in
+    // a file whose only `lone` is at its top level. It is 5 edges on tokio
+    // 1.40.0 and 4 on the private tree, and all 9 are still answered.
+    const edge = edgeFor("the_common_shape_still_resolves", "self", "lone");
+    expect(edge.confidence).toBe("local");
+    expect(edge.calleeCandidates).toEqual(["src/a/d.rs::lone#1"]);
+  });
+
+  it("leaves `Self::` alone: it is the implementing type, not a module", () => {
+    // `Self::twin()` inside `#[cfg(test)] mod tests` names the type the `impl`
+    // is for, which is right there in the inline mod. Reading `Self` as the
+    // lowercase `self` would refuse it and drop a call the graph can answer —
+    // and tokio writes this shape inside its test modules.
+    const edge = edgeFor("calls_its_own", "Self", "twin");
+    expect(edge.confidence).toBe("local");
+    expect(edge.calleeCandidates).toEqual(["src/a/b.rs::twin#39"]);
   });
 
   it("reads two `super` as that file's parent", () => {
     // `src/sub.rs` also declares `f`, and is what one hop too many reaches.
-    expect(candidatesOf("f", "super::sub")).toEqual(["src/a/sub.rs::f#1"]);
+    expect(candidatesOf("two_hops_is_the_parent", "super::sub", "f"))
+      .toEqual(["src/a/sub.rs::f#1"]);
   });
 
   it("keeps what is left of the path relative to that file", () => {
     // `super::sub` inside the inline mod is `b.rs`'s own `sub` module.
-    expect(candidatesOf("g", "sub")).toEqual(["src/a/b/sub.rs::g#1"]);
+    expect(candidatesOf("one_hop_then_a_module", "sub", "g")).toEqual(["src/a/b/sub.rs::g#1"]);
   });
 
   it("lets what is left reach a name the file imported", () => {
@@ -162,7 +288,8 @@ mod tests {
     // a module's namespace holds the names its `use` declarations bring in, so
     // the leftover has to stay bare: read as `self::aliased` it would be
     // matched against the file's modules alone, and answer nothing.
-    expect(candidatesOf("h", "aliased")).toEqual(["src/sub.rs::h#2"]);
+    expect(candidatesOf("one_hop_then_an_imported_name", "aliased", "h"))
+      .toEqual(["src/sub.rs::h#2"]);
   });
 
   it("leaves a path rooted in an inline mod unresolved, with its qualifier", () => {
@@ -170,7 +297,7 @@ mod tests {
     // which has no file. Answering with `b.rs` would hand back every `helper`
     // the file holds — including `tests::sibling`'s, which Rust cannot reach
     // from `tests::deeper` — and whoever walks the candidates would follow it.
-    const edge = edgeFor("helper", "super");
+    const edge = edgeFor("a_scope_with_no_file", "super", "helper");
     expect(edge.calleeCandidates).toEqual([]);
     expect(edge.confidence).toBe("unresolved");
   });
@@ -179,7 +306,7 @@ mod tests {
     // The same rule for a path that continues: `super::inner` is `tests`'s own
     // `inner`, and `b.rs` declares a `mod inner;` of its own — a different
     // file — so neither that file nor the caller's is an answer.
-    const edge = edgeFor("probe", "super::inner");
+    const edge = edgeFor("fewer_hops_than_modules", "super::inner", "probe");
     expect(edge.calleeCandidates).toEqual([]);
     expect(edge.confidence).toBe("unresolved");
   });

--- a/tests/unit/code-graph-rust-inline-mod.test.ts
+++ b/tests/unit/code-graph-rust-inline-mod.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildCodeGraph } from "../../src/services/code-graph.js";
+import { resolveCallSites } from "../../src/services/graph-symbol-resolution.js";
+
+/**
+ * What `super::` means when the call is written inside an inline `mod`.
+ *
+ * `super` counts modules, and an inline `mod` is one: inside
+ * `#[cfg(test)] mod tests { … }` written in `a/b.rs`, `super::helper()` is
+ * `b.rs`'s own `helper` and `super::super::sub::f()` is the `sub` of `b.rs`'s
+ * parent. Resolution knows only files, so unless the nesting is accounted for
+ * where it is still visible — in the extractor — both answer one module too
+ * high: the parent's `helper`, and the grandparent's `sub`. Not a wider
+ * answer, a different one, and reported as `unique`.
+ *
+ * This goes through the real `buildCodeGraph` pass rather than handing a
+ * qualifier to `resolveCallSites`, because the qualifier is exactly what is
+ * under test: by the time resolution sees it, it must already read as the file
+ * would have written it.
+ */
+describe("Rust `super::` written inside an inline mod", () => {
+  let root: string;
+  let candidates: Map<string, string[]>;
+
+  const write = (rel: string, body: string): void => {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body);
+  };
+
+  beforeAll(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-rust-inline-mod-"));
+
+    write("Cargo.toml", '[package]\nname = "inlinemod"\nedition = "2021"\n');
+    write("src/lib.rs", "pub mod a;\npub mod sub;\n");
+    write("src/sub.rs", "pub fn f() -> u32 { 1 }\n");
+    write("src/a.rs", `pub mod b;
+pub mod sub;
+
+pub fn helper() -> u32 { 2 }
+`);
+    write("src/a/sub.rs", "pub fn f() -> u32 { 3 }\n");
+    write("src/a/b/sub.rs", "pub fn g() -> u32 { 5 }\n");
+    write("src/a/b.rs", `pub mod sub;
+use crate::sub as aliased;
+
+pub fn helper() -> u32 { 4 }
+
+pub fn use_the_alias() -> u32 { aliased::f() }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn one_hop_is_this_file() {
+        let _ = super::helper();
+    }
+
+    #[test]
+    fn one_hop_then_a_module() {
+        let _ = super::sub::g();
+    }
+
+    #[test]
+    fn two_hops_is_the_parent() {
+        let _ = super::super::sub::f();
+    }
+}
+`);
+
+    const graph = await buildCodeGraph(root);
+    resolveCallSites(
+      graph,
+      graph.symbolsByFile,
+      graph.outgoingCallsByFile,
+      graph.rustBindingsByFile,
+      graph.rustCrateRootByFile,
+    );
+    candidates = new Map();
+    for (const edge of graph.outgoingCallsByFile.get("src/a/b.rs") ?? []) {
+      if (edge.calleeQualifier) candidates.set(edge.calleeName, edge.calleeCandidates.slice().sort());
+    }
+  });
+
+  afterAll(() => {
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("reads one `super` as the file the inline mod is written in", () => {
+    // Read one module too high, this answers `src/a.rs::helper` — a file that
+    // does declare a `helper`, so the wrong answer arrives as `unique`.
+    expect(candidates.get("helper")).toEqual(["src/a/b.rs::helper#4"]);
+  });
+
+  it("reads two `super` as that file's parent", () => {
+    // `src/sub.rs` also declares `f`, and is what one hop too many reaches.
+    expect(candidates.get("f")).toEqual(["src/a/sub.rs::f#1"]);
+  });
+
+  it("keeps what is left of the path relative to that file", () => {
+    // `super::sub` inside the inline mod is `b.rs`'s own `sub` module. `b.rs`
+    // also has `use crate::sub as aliased;`, so a leftover path read as a bare
+    // one would be looked up among the file's bindings before its modules.
+    expect(candidates.get("g")).toEqual(["src/a/b/sub.rs::g#1"]);
+  });
+});

--- a/tests/unit/graph-symbol-resolution.test.ts
+++ b/tests/unit/graph-symbol-resolution.test.ts
@@ -6,6 +6,7 @@ import {
   computeUnresolvedPct,
   resolveCallSites,
 } from "../../src/services/graph-symbol-resolution.js";
+import type { RustUseBinding } from "../../src/services/graph-symbols.js";
 import type { CodeGraph, SymbolEdge, SymbolNode } from "../../src/types.js";
 
 function mkGraph(): CodeGraph {
@@ -829,5 +830,362 @@ describe("graph-symbol-resolution", () => {
     const indexLocalEdge = outgoing.get("src/index.ts")?.[1];
     expect(indexLocalEdge?.confidence).toBe("local");
     expect(indexLocalEdge?.calleeCandidates).toEqual(["src/index.ts::helper#1"]);
+  });
+});
+
+describe("Rust qualified calls", () => {
+  const LIB = "crates/x/src/lib.rs";
+  const A = "crates/x/src/a.rs";
+  const B = "crates/x/src/b.rs";
+  const INNER = "crates/x/src/deep/inner.rs";
+  const DEEP = "crates/x/src/deep/mod.rs";
+
+  function rustGraph(): CodeGraph {
+    return {
+      nodes: [
+        { relativePath: LIB, imports: [], exports: [], dependencies: [A, B], dependents: [] },
+        { relativePath: A, imports: [], exports: [], dependencies: [], dependents: [LIB] },
+        { relativePath: B, imports: [], exports: [], dependencies: [], dependents: [LIB] },
+        { relativePath: DEEP, imports: [], exports: [], dependencies: [INNER], dependents: [LIB] },
+        // The crate root imports the nested file too, which is ordinary — and
+        // is what makes "a dependent called `lib`" the wrong way to find a
+        // parent: `lib.rs` is a dependent of half the crate.
+        { relativePath: INNER, imports: [], exports: [], dependencies: [], dependents: [DEEP, LIB] },
+      ],
+      edges: [],
+    };
+  }
+
+  function sym(file: string, name: string, line: number, kind: SymbolNode["kind"]): SymbolNode {
+    return {
+      id: `${file}::${name}#${line}`,
+      name,
+      qualifiedName: name,
+      kind,
+      file,
+      line,
+      endLine: line,
+      language: "rust",
+    };
+  }
+
+  function rustSymbols(): Map<string, SymbolNode[]> {
+    return new Map<string, SymbolNode[]>([
+      [LIB, [sym(LIB, "caller", 1, "function"), sym(LIB, "helper", 20, "function")]],
+      [A, [sym(A, "Type", 1, "struct"), sym(A, "method", 5, "function"), sym(A, "run", 9, "function")]],
+      [B, [sym(B, "Type", 1, "struct"), sym(B, "method", 5, "function")]],
+      [DEEP, [sym(DEEP, "shared", 3, "function")]],
+      [INNER, [sym(INNER, "inner_caller", 1, "function")]],
+    ]);
+  }
+
+  /** One qualified call from `caller`, resolved. Returns the edge. */
+  function resolveOne(
+    calleeName: string,
+    calleeQualifier: string | undefined,
+    opts: { from?: string; bindings?: RustUseBinding[] } = {},
+  ): SymbolEdge {
+    const from = opts.from ?? LIB;
+    const edge: SymbolEdge = {
+      callerId: from === LIB ? `${LIB}::caller#1` : `${INNER}::inner_caller#1`,
+      calleeName,
+      calleeCandidates: [],
+      confidence: "unresolved",
+      kind: "call",
+      calleeQualifier,
+      callSite: { file: from, line: 2 },
+    };
+    const outgoing = new Map<string, SymbolEdge[]>([[from, [edge]]]);
+    const bindings = opts.bindings
+      ? new Map<string, RustUseBinding[]>([[from, opts.bindings]])
+      : undefined;
+    resolveCallSites(rustGraph(), rustSymbols(), outgoing, bindings);
+    return edge;
+  }
+
+  it("narrows a `crate::` path to the module it names", () => {
+    const edge = resolveOne("run", "crate::a");
+    expect(edge.confidence).toBe("unique");
+    expect(edge.calleeCandidates).toEqual([`${A}::run#9`]);
+  });
+
+  it("narrows a bare module path to the module it names", () => {
+    const edge = resolveOne("run", "a");
+    expect(edge.confidence).toBe("unique");
+    expect(edge.calleeCandidates).toEqual([`${A}::run#9`]);
+  });
+
+  it("reads `self::` as the caller's own file", () => {
+    const edge = resolveOne("helper", "self");
+    expect(edge.confidence).toBe("local");
+    expect(edge.calleeCandidates).toEqual([`${LIB}::helper#20`]);
+  });
+
+  it("reads `super::` as the parent module, which is a dependent and not a dependency", () => {
+    // `mod inner;` is written in the parent, so the parent imports the child:
+    // the only route from `inner.rs` to `deep/mod.rs` is the reverse edge.
+    const edge = resolveOne("shared", "super", { from: INNER });
+    expect(edge.confidence).toBe("unique");
+    expect(edge.calleeCandidates).toEqual([`${DEEP}::shared#3`]);
+  });
+
+  it("narrows a type qualifier to the file that declares the type", () => {
+    // `method` exists in both a.rs and b.rs. The qualifier is what says which.
+    const edge = resolveOne("method", "Type");
+    expect(edge.confidence).toBe("multiple-candidates");
+    expect(edge.calleeCandidates.sort()).toEqual([`${A}::method#5`, `${B}::method#5`]);
+  });
+
+  it("follows a `use ... as ...` alias to exactly what the original type reaches", () => {
+    // `Type` alone is ambiguous across a.rs and b.rs; the alias names one of
+    // them, so the call must reach that one and nothing else.
+    const edge = resolveOne("method", "Alias", {
+      bindings: [{ local: "Alias", path: "crate::a::Type" }],
+    });
+    expect(edge.confidence).toBe("unique");
+    expect(edge.calleeCandidates).toEqual([`${A}::method#5`]);
+  });
+
+  it("keeps an external path unresolved, with its qualifier", () => {
+    const edge = resolveOne("copy", "std::fs");
+    expect(edge.confidence).toBe("unresolved");
+    expect(edge.calleeCandidates).toEqual([]);
+    expect(edge.calleeQualifier).toBe("std::fs");
+  });
+
+  it("never falls back to a bare-name match when the qualifier does not resolve", () => {
+    // `run` is declared in a.rs, which the caller depends on, so an unqualified
+    // call to it resolves. Qualified by something this project cannot place, it
+    // must NOT: that fallback is how `Vec::new()` would land on every `new`.
+    const qualified = resolveOne("run", "Unknown");
+    expect(qualified.confidence).toBe("unresolved");
+    expect(qualified.calleeCandidates).toEqual([]);
+
+    const bare = resolveOne("run", undefined);
+    expect(bare.confidence).toBe("unique");
+    expect(bare.calleeCandidates).toEqual([`${A}::run#9`]);
+  });
+
+  it("refuses a qualifier carrying type syntax rather than guessing at it", () => {
+    const edge = resolveOne("go", "<T as Tr>");
+    expect(edge.confidence).toBe("unresolved");
+    expect(edge.calleeCandidates).toEqual([]);
+  });
+
+  it("reads `super::` from the caller's path, not from whatever imports it", () => {
+    // `lib.rs` is a dependent of every file in the crate, because it declares
+    // them. Choosing the parent by name — "a dependent called lib" — therefore
+    // makes the crate root the parent of every file, and `super::` in a nested
+    // module reaches a function Rust cannot see from there.
+    const edge = resolveOne("caller", "super", { from: INNER });
+    expect(edge.confidence).toBe("unresolved");
+    expect(edge.calleeCandidates).toEqual([]);
+  });
+
+  it("keeps `self::` inside the caller's own file", () => {
+    // `run` is in a dependency, not here. `self::` must not reach it: the whole
+    // value of a qualifier is that it excludes.
+    const edge = resolveOne("run", "self");
+    expect(edge.confidence).toBe("unresolved");
+    expect(edge.calleeCandidates).toEqual([]);
+  });
+
+  it("reads a qualifier as Rust only when the caller is Rust", () => {
+    // `rawCallsToUnresolvedEdges` carries the field for every language, and
+    // everything in this branch reads `::`, `crate`, `self` and `super` the way
+    // Rust means them. No other extractor fills it today; the guard is what
+    // keeps the first one that does from silently inheriting Rust's semantics.
+    const graph = rustGraph();
+    graph.nodes.push({
+      relativePath: "src/app.ts",
+      imports: [],
+      exports: [],
+      dependencies: [A],
+      dependents: [],
+    });
+    const symbols = rustSymbols();
+    symbols.set("src/app.ts", [
+      {
+        id: "src/app.ts::caller#1",
+        name: "caller",
+        qualifiedName: "caller",
+        kind: "function",
+        file: "src/app.ts",
+        line: 1,
+        endLine: 1,
+        language: "typescript",
+      },
+    ]);
+    const edge: SymbolEdge = {
+      callerId: "src/app.ts::caller#1",
+      calleeName: "run",
+      calleeCandidates: [],
+      confidence: "unresolved",
+      kind: "call",
+      calleeQualifier: "Unknown",
+      callSite: { file: "src/app.ts", line: 2 },
+    };
+    resolveCallSites(graph, symbols, new Map([["src/app.ts", [edge]]]));
+    // The Rust branch would refuse an unplaceable qualifier; the path every
+    // other language takes finds `run` in the dependency, as it always has.
+    expect(edge.confidence).toBe("unique");
+    expect(edge.calleeCandidates).toEqual([`${A}::run#9`]);
+  });
+
+  it("matches a module path written as a directory's mod.rs", () => {
+    // `deep::shared()` from lib.rs names `crates/x/src/deep/mod.rs`, whose own
+    // stem is `mod`: matching the file name alone would never find it.
+    const graph = rustGraph();
+    for (const node of graph.nodes) {
+      if (node.relativePath === LIB) node.dependencies = [A, B, DEEP];
+      if (node.relativePath === DEEP) node.dependents = [LIB];
+    }
+    const edge: SymbolEdge = {
+      callerId: `${LIB}::caller#1`,
+      calleeName: "shared",
+      calleeCandidates: [],
+      confidence: "unresolved",
+      kind: "call",
+      calleeQualifier: "deep",
+      callSite: { file: LIB, line: 2 },
+    };
+    resolveCallSites(graph, rustSymbols(), new Map([[LIB, [edge]]]));
+    expect(edge.confidence).toBe("unique");
+    expect(edge.calleeCandidates).toEqual([`${DEEP}::shared#3`]);
+  });
+});
+
+describe("Rust qualified calls, across a workspace", () => {
+  const ALPHA = "crates/alpha/src/lib.rs";
+  const ALPHA_CFG = "crates/alpha/src/config.rs";
+  const BETA_CFG = "crates/beta/src/config.rs";
+
+  function sym(file: string, name: string, line: number): SymbolNode {
+    return {
+      id: `${file}::${name}#${line}`,
+      name,
+      qualifiedName: name,
+      kind: "function",
+      file,
+      line,
+      endLine: line,
+      language: "rust",
+    };
+  }
+
+  /**
+   * One caller, two `config` modules with a `load`, and a crate boundary drawn
+   * by `crateRoots`. Returns the resolved edge for `<qualifier>::load()`.
+   */
+  function twoCrates(
+    caller: string,
+    ownCfg: string,
+    otherCfg: string,
+    qualifier: string,
+    crateRoots?: Map<string, string>,
+    bindings?: RustUseBinding[],
+  ): SymbolEdge {
+    const graph: CodeGraph = {
+      nodes: [
+        {
+          relativePath: caller,
+          imports: [],
+          exports: [],
+          dependencies: [ownCfg, otherCfg],
+          dependents: [],
+        },
+        { relativePath: ownCfg, imports: [], exports: [], dependencies: [], dependents: [caller] },
+        { relativePath: otherCfg, imports: [], exports: [], dependencies: [], dependents: [caller] },
+      ],
+      edges: [],
+    };
+    const symbols = new Map<string, SymbolNode[]>([
+      [caller, [sym(caller, "go", 1)]],
+      [ownCfg, [sym(ownCfg, "load", 1)]],
+      [otherCfg, [sym(otherCfg, "load", 1)]],
+    ]);
+    const edge: SymbolEdge = {
+      callerId: `${caller}::go#1`,
+      calleeName: "load",
+      calleeCandidates: [],
+      confidence: "unresolved",
+      kind: "call",
+      calleeQualifier: qualifier,
+      callSite: { file: caller, line: 2 },
+    };
+    resolveCallSites(
+      graph,
+      symbols,
+      new Map([[caller, [edge]]]),
+      bindings ? new Map([[caller, bindings]]) : undefined,
+      crateRoots,
+    );
+    return edge;
+  }
+
+  it("keeps `crate::` inside the caller's own crate", () => {
+    // `alpha` depends on `beta`, and both have a `config` module with a `load`.
+    // `crate::config::load()` in alpha has exactly one right answer; reaching
+    // across the boundary it comes back ambiguous, naming a file from another
+    // crate that the caller's `crate::` cannot mean.
+    const roots = new Map([
+      [ALPHA, "crates/alpha/"],
+      [ALPHA_CFG, "crates/alpha/"],
+      [BETA_CFG, "crates/beta/"],
+    ]);
+    const edge = twoCrates(ALPHA, ALPHA_CFG, BETA_CFG, "crate::config", roots);
+    expect(edge.confidence).toBe("unique");
+    expect(edge.calleeCandidates).toEqual([`${ALPHA_CFG}::load#1`]);
+  });
+
+  it("confines an alias whose path starts at `crate` too", () => {
+    // The boundary has to hold on the route through a binding, not only on a
+    // `crate::` written at the call site.
+    const roots = new Map([
+      [ALPHA, "crates/alpha/"],
+      [ALPHA_CFG, "crates/alpha/"],
+      [BETA_CFG, "crates/beta/"],
+    ]);
+    const edge = twoCrates(ALPHA, ALPHA_CFG, BETA_CFG, "Cfg", roots, [
+      { local: "Cfg", path: "crate::config" },
+    ]);
+    expect(edge.confidence).toBe("unique");
+    expect(edge.calleeCandidates).toEqual([`${ALPHA_CFG}::load#1`]);
+  });
+
+  it("confines nothing when the whole project is one crate at the root", () => {
+    // tokio's layout: one manifest, sources under `src/`. Every file is in the
+    // same crate, so `crate::` excludes nothing — and a boundary guessed from
+    // the path would cut the crate into one piece per directory and lose the
+    // call entirely.
+    const caller = "src/deep/nested/leaf.rs";
+    const roots = new Map([
+      [caller, ""],
+      ["src/util.rs", ""],
+      ["src/other.rs", ""],
+    ]);
+    const edge = twoCrates(caller, "src/util.rs", "src/other.rs", "crate::util", roots);
+    expect(edge.confidence).toBe("unique");
+    expect(edge.calleeCandidates).toEqual(["src/util.rs::load#1"]);
+  });
+
+  it("draws the boundary for a crate that has no `src` directory", () => {
+    // ripgrep's layout: `crates/core/main.rs`, `crates/core/util.rs`. The crate
+    // root is the manifest's directory, whatever the sources are called.
+    const caller = "crates/core/flags/defs.rs";
+    const roots = new Map([
+      [caller, "crates/core/"],
+      ["crates/core/util.rs", "crates/core/"],
+      ["crates/grep/util.rs", "crates/grep/"],
+    ]);
+    const edge = twoCrates(
+      caller,
+      "crates/core/util.rs",
+      "crates/grep/util.rs",
+      "crate::util",
+      roots,
+    );
+    expect(edge.confidence).toBe("unique");
+    expect(edge.calleeCandidates).toEqual(["crates/core/util.rs::load#1"]);
   });
 });

--- a/tests/unit/graph-symbol-resolution.test.ts
+++ b/tests/unit/graph-symbol-resolution.test.ts
@@ -1248,26 +1248,30 @@ describe("Rust qualified calls rooted in `super`", () => {
     calleeName: string,
     calleeQualifier: string,
     bindings?: RustUseBinding[],
+    from: string = INNER,
   ): SymbolEdge {
     const edge: SymbolEdge = {
-      callerId: `${INNER}::inner_caller#1`,
+      callerId: `${from}::caller#1`,
       calleeName,
       calleeCandidates: [],
       confidence: "unresolved",
       kind: "call",
       calleeQualifier,
-      callSite: { file: INNER, line: 2 },
+      callSite: { file: from, line: 2 },
     };
+    const symbols = new Map<string, SymbolNode[]>([
+      [INNER, [sym(INNER, "inner_caller", 1, "function")]],
+      [DEEP, [sym(DEEP, "Widget", 1, "struct"), sym(DEEP, "draw", 4, "function")]],
+      [SIBLING, [sym(SIBLING, "load", 3, "function")]],
+      [OWN_CHILD, [sym(OWN_CHILD, "load", 7, "function")]],
+    ]);
+    // The caller is a symbol in its own file, whatever file that is.
+    symbols.set(from, [...(symbols.get(from) ?? []), sym(from, "caller", 1, "function")]);
     resolveCallSites(
       superGraph(),
-      new Map<string, SymbolNode[]>([
-        [INNER, [sym(INNER, "inner_caller", 1, "function")]],
-        [DEEP, [sym(DEEP, "Widget", 1, "struct"), sym(DEEP, "draw", 4, "function")]],
-        [SIBLING, [sym(SIBLING, "load", 3, "function")]],
-        [OWN_CHILD, [sym(OWN_CHILD, "load", 7, "function")]],
-      ]),
-      new Map<string, SymbolEdge[]>([[INNER, [edge]]]),
-      bindings ? new Map<string, RustUseBinding[]>([[INNER, bindings]]) : undefined,
+      symbols,
+      new Map<string, SymbolEdge[]>([[from, [edge]]]),
+      bindings ? new Map<string, RustUseBinding[]>([[from, bindings]]) : undefined,
     );
     return edge;
   }
@@ -1290,6 +1294,22 @@ describe("Rust qualified calls rooted in `super`", () => {
   it("finds a type the parent module itself declares", () => {
     // `super::Widget` is not a module path: the parent declares the type.
     const edge = fromInner("draw", "super::Widget");
+    expect(edge.calleeCandidates).toEqual([`${DEEP}::draw#4`]);
+    expect(edge.confidence).toBe("unique");
+  });
+
+  it("climbs one module per leading `super`", () => {
+    // `deep/inner/config.rs` → `deep/inner.rs` → `deep/mod.rs`. Consuming only
+    // the first `super` leaves the second in the path, where it matches no
+    // module and the call is lost.
+    const edge = fromInner("draw", "super::super", undefined, OWN_CHILD);
+    expect(edge.calleeCandidates).toEqual([`${DEEP}::draw#4`]);
+    expect(edge.confidence).toBe("unique");
+  });
+
+  it("reads `use super as up;` as the parent module itself", () => {
+    // The bound path is exactly `super`, so `up::draw()` is `super::draw()`.
+    const edge = fromInner("draw", "up", [{ local: "up", path: "super" }]);
     expect(edge.calleeCandidates).toEqual([`${DEEP}::draw#4`]);
     expect(edge.confidence).toBe("unique");
   });

--- a/tests/unit/graph-symbol-resolution.test.ts
+++ b/tests/unit/graph-symbol-resolution.test.ts
@@ -1189,3 +1189,108 @@ describe("Rust qualified calls, across a workspace", () => {
     expect(edge.calleeCandidates).toEqual(["crates/core/util.rs::load#1"]);
   });
 });
+
+describe("Rust qualified calls rooted in `super`", () => {
+  // A module with both a parent and a child of the same name, which is what
+  // separates "read in the parent's scope" from "read in the caller's".
+  const LIB = "crates/x/src/lib.rs";
+  const DEEP = "crates/x/src/deep/mod.rs";
+  const INNER = "crates/x/src/deep/inner.rs";
+  const SIBLING = "crates/x/src/deep/config.rs";
+  const OWN_CHILD = "crates/x/src/deep/inner/config.rs";
+
+  function sym(file: string, name: string, line: number, kind: SymbolNode["kind"]): SymbolNode {
+    return {
+      id: `${file}::${name}#${line}`,
+      name,
+      qualifiedName: name,
+      kind,
+      file,
+      line,
+      endLine: line,
+      language: "rust",
+    };
+  }
+
+  function superGraph(): CodeGraph {
+    return {
+      nodes: [
+        { relativePath: LIB, imports: [], exports: [], dependencies: [DEEP], dependents: [] },
+        {
+          relativePath: DEEP,
+          imports: [],
+          exports: [],
+          dependencies: [INNER, SIBLING],
+          dependents: [LIB],
+        },
+        {
+          relativePath: INNER,
+          imports: [],
+          exports: [],
+          dependencies: [OWN_CHILD],
+          dependents: [DEEP],
+        },
+        { relativePath: SIBLING, imports: [], exports: [], dependencies: [], dependents: [DEEP] },
+        {
+          relativePath: OWN_CHILD,
+          imports: [],
+          exports: [],
+          dependencies: [],
+          dependents: [INNER],
+        },
+      ],
+      edges: [],
+    };
+  }
+
+  /** One qualified call from `inner.rs`, resolved. Returns the edge. */
+  function fromInner(
+    calleeName: string,
+    calleeQualifier: string,
+    bindings?: RustUseBinding[],
+  ): SymbolEdge {
+    const edge: SymbolEdge = {
+      callerId: `${INNER}::inner_caller#1`,
+      calleeName,
+      calleeCandidates: [],
+      confidence: "unresolved",
+      kind: "call",
+      calleeQualifier,
+      callSite: { file: INNER, line: 2 },
+    };
+    resolveCallSites(
+      superGraph(),
+      new Map<string, SymbolNode[]>([
+        [INNER, [sym(INNER, "inner_caller", 1, "function")]],
+        [DEEP, [sym(DEEP, "Widget", 1, "struct"), sym(DEEP, "draw", 4, "function")]],
+        [SIBLING, [sym(SIBLING, "load", 3, "function")]],
+        [OWN_CHILD, [sym(OWN_CHILD, "load", 7, "function")]],
+      ]),
+      new Map<string, SymbolEdge[]>([[INNER, [edge]]]),
+      bindings ? new Map<string, RustUseBinding[]>([[INNER, bindings]]) : undefined,
+    );
+    return edge;
+  }
+
+  it("reads a `use super::` binding in the parent's scope, not the caller's", () => {
+    // `use super::config;` binds the parent's `config`. Dropping the hop and
+    // matching `config` against the caller's own dependencies reaches the
+    // caller's own `inner/config.rs` — the wrong file, stated as `unique`.
+    const edge = fromInner("load", "config", [{ local: "config", path: "super::config" }]);
+    expect(edge.calleeCandidates).toEqual([`${SIBLING}::load#3`]);
+    expect(edge.confidence).toBe("unique");
+  });
+
+  it("reads a `super::` path written at the call site in the parent's scope", () => {
+    const edge = fromInner("load", "super::config");
+    expect(edge.calleeCandidates).toEqual([`${SIBLING}::load#3`]);
+    expect(edge.confidence).toBe("unique");
+  });
+
+  it("finds a type the parent module itself declares", () => {
+    // `super::Widget` is not a module path: the parent declares the type.
+    const edge = fromInner("draw", "super::Widget");
+    expect(edge.calleeCandidates).toEqual([`${DEEP}::draw#4`]);
+    expect(edge.confidence).toBe("unique");
+  });
+});

--- a/tests/unit/graph-symbol-resolution.test.ts
+++ b/tests/unit/graph-symbol-resolution.test.ts
@@ -872,8 +872,25 @@ describe("Rust qualified calls", () => {
   function rustSymbols(): Map<string, SymbolNode[]> {
     return new Map<string, SymbolNode[]>([
       [LIB, [sym(LIB, "caller", 1, "function"), sym(LIB, "helper", 20, "function")]],
-      [A, [sym(A, "Type", 1, "struct"), sym(A, "method", 5, "function"), sym(A, "run", 9, "function")]],
-      [B, [sym(B, "Type", 1, "struct"), sym(B, "method", 5, "function")]],
+      [
+        A,
+        [
+          sym(A, "Type", 1, "struct"),
+          sym(A, "method", 5, "function"),
+          sym(A, "run", 9, "function"),
+          sym(A, "Config", 12, "struct"),
+        ],
+      ],
+      // `Config` here is a const, not a type: it shares the spelling and
+      // nothing else, and Rust cannot write `Config::method()` against it.
+      [
+        B,
+        [
+          sym(B, "Type", 1, "struct"),
+          sym(B, "method", 5, "function"),
+          sym(B, "Config", 8, "variable"),
+        ],
+      ],
       [DEEP, [sym(DEEP, "shared", 3, "function")]],
       [INNER, [sym(INNER, "inner_caller", 1, "function")]],
     ]);
@@ -944,6 +961,16 @@ describe("Rust qualified calls", () => {
     });
     expect(edge.confidence).toBe("unique");
     expect(edge.calleeCandidates).toEqual([`${A}::method#5`]);
+  });
+
+  it("reads a type qualifier in the type namespace only", () => {
+    // `a.rs` declares `struct Config`; `b.rs` declares a const of the same
+    // name, and a `method` of its own. Counting the const puts `b.rs` in scope
+    // and answers with that `method` too — a file Rust cannot reach through
+    // `Config::`, since a name is a type or a value and never both.
+    const edge = resolveOne("method", "Config");
+    expect(edge.calleeCandidates).toEqual([`${A}::method#5`]);
+    expect(edge.confidence).toBe("unique");
   });
 
   it("keeps an external path unresolved, with its qualifier", () => {

--- a/tests/unit/graph-symbol-resolution.test.ts
+++ b/tests/unit/graph-symbol-resolution.test.ts
@@ -1393,3 +1393,200 @@ describe("Rust qualified calls rooted in `super`", () => {
     expect(edge.confidence).toBe("unique");
   });
 });
+
+/**
+ * Walking a module path one segment at a time.
+ *
+ * One crate, rooted at `src/lib.rs`, holding every shape the walk has to tell
+ * apart: a module reached in two hops, a file sitting at the right path that
+ * nothing declares, a segment naming nothing, one module written at both of
+ * its two legal spellings, and a module the file graph reaches without a
+ * `mod` chain to walk.
+ */
+describe("Rust module paths, walked segment by segment", () => {
+  const LIB = "src/lib.rs";
+  const AMOD = "src/a/mod.rs";
+  const AB = "src/a/b.rs";
+  const INNER = "src/a/inner.rs";
+  /** Sits exactly where `crate::a::ghost` would, and nothing declares it. */
+  const GHOST = "src/a/ghost.rs";
+  /** One module, both spellings — which rustc rejects and a graph reports. */
+  const TWIN_FILE = "src/a/twin.rs";
+  const TWIN_DIR = "src/a/twin/mod.rs";
+  /** Reached by the graph, with no `mod` chain from the root to walk down. */
+  const HIDDEN = "src/hidden/thing.rs";
+  /** Another `b`, one level further down, that the parent also imports. */
+  const DEEPER_B = "src/a/other/b.rs";
+  /** A binary: a crate root whose stem says nothing about it being one. */
+  const BIN = "src/bin/x.rs";
+  const BIN_HELPER = "src/bin/helper.rs";
+  /** Same module name, another directory, and the binary imports it. */
+  const DECOY = "src/other/helper.rs";
+
+  function graph(): CodeGraph {
+    const node = (
+      relativePath: string,
+      dependencies: string[],
+      dependents: string[],
+    ): CodeGraph["nodes"][number] => ({
+      relativePath,
+      imports: [],
+      exports: [],
+      dependencies,
+      dependents,
+    });
+    return {
+      nodes: [
+        node(LIB, [AMOD, HIDDEN], []),
+        node(AMOD, [AB, INNER, TWIN_FILE, TWIN_DIR, DEEPER_B], [LIB]),
+        node(AB, [], [AMOD]),
+        node(INNER, [], [AMOD]),
+        node(GHOST, [], []),
+        node(TWIN_FILE, [], [AMOD]),
+        node(TWIN_DIR, [], [AMOD]),
+        node(HIDDEN, [], [LIB]),
+        node(DEEPER_B, [], [AMOD]),
+        node(BIN, [BIN_HELPER, DECOY], []),
+        node(BIN_HELPER, [], [BIN]),
+        node(DECOY, [], [BIN]),
+      ],
+      edges: [],
+    };
+  }
+
+  function sym(file: string, name: string, line: number): SymbolNode {
+    return {
+      id: `${file}::${name}#${line}`,
+      name,
+      qualifiedName: name,
+      kind: "function",
+      file,
+      line,
+      endLine: line,
+      language: "rust",
+    };
+  }
+
+  function symbols(): Map<string, SymbolNode[]> {
+    return new Map<string, SymbolNode[]>([
+      [LIB, [sym(LIB, "caller", 1)]],
+      // `deep` here too: a walk that shrugged off a hop it could not make
+      // would stop at `a` and answer with this one.
+      [AMOD, [sym(AMOD, "deep", 2)]],
+      [AB, [sym(AB, "deep", 3)]],
+      [INNER, [sym(INNER, "inner_caller", 1)]],
+      // A name of its own, so that accepting this file and carrying on past a
+      // dead hop stay two different failures with two different tests.
+      [GHOST, [sym(GHOST, "ghost_fn", 4)]],
+      [TWIN_FILE, [sym(TWIN_FILE, "pick", 5)]],
+      [TWIN_DIR, [sym(TWIN_DIR, "pick", 6)]],
+      [HIDDEN, [sym(HIDDEN, "only_here", 7)]],
+      [DEEPER_B, [sym(DEEPER_B, "deep", 10)]],
+      [BIN, [sym(BIN, "caller", 1)]],
+      [BIN_HELPER, [sym(BIN_HELPER, "help", 8)]],
+      [DECOY, [sym(DECOY, "help", 9)]],
+    ]);
+  }
+
+  /** Every file is in one crate rooted at the project root, as tokio's is. */
+  function crateRoots(): Map<string, string> {
+    const m = new Map<string, string>();
+    for (const f of [
+      LIB, AMOD, AB, INNER, GHOST, TWIN_FILE, TWIN_DIR, HIDDEN, DEEPER_B, BIN, BIN_HELPER,
+      DECOY,
+    ]) {
+      m.set(f, "");
+    }
+    return m;
+  }
+
+  function resolveOne(calleeName: string, qualifier: string, from = LIB): SymbolEdge {
+    const edge: SymbolEdge = {
+      callerId: `${from}::caller#1`,
+      calleeName,
+      calleeCandidates: [],
+      confidence: "unresolved",
+      kind: "call",
+      calleeQualifier: qualifier,
+      callSite: { file: from, line: 2 },
+    };
+    resolveCallSites(
+      graph(),
+      symbols(),
+      new Map([[from, [edge]]]),
+      undefined,
+      crateRoots(),
+    );
+    return edge;
+  }
+
+  it("reaches a module two hops down that nothing imports directly", () => {
+    // Only `a/mod.rs` depends on `a/b.rs`. Matching `a::b` against the
+    // caller's own dependencies never sees it.
+    const edge = resolveOne("deep", "crate::a::b");
+    expect(edge.calleeCandidates).toEqual([`${AB}::deep#3`]);
+    expect(edge.confidence).toBe("unique");
+  });
+
+  it("walks a `super::` path on past the parent it climbs to", () => {
+    // `super::b` from `a/inner.rs` is the parent's `b`, which is one climb
+    // and then one hop — and `inner.rs` never imports `b.rs`. The parent also
+    // imports `a/other/b.rs`, whose path ends in `b` too, so only a hop that
+    // looks where the parent files its own children answers with one file.
+    const edge = resolveOne("deep", "super::b", INNER);
+    expect(edge.calleeCandidates).toEqual([`${AB}::deep#3`]);
+    expect(edge.confidence).toBe("unique");
+  });
+
+  it("refuses a file at the right path that no module declares", () => {
+    // `src/a/ghost.rs` is spelled exactly as `crate::a::ghost` would be, and
+    // carries a `deep`. Nothing declares it, so Rust cannot reach it and the
+    // hop must not either — the file existing is not the module existing.
+    const edge = resolveOne("ghost_fn", "crate::a::ghost");
+    expect(edge.calleeCandidates).toEqual([]);
+    expect(edge.confidence).toBe("unresolved");
+  });
+
+  it("stops at a hop that finds nothing instead of answering from halfway", () => {
+    // `a` resolves and `missing` does not. Carrying on with the frontier the
+    // last good hop left answers `a/mod.rs`'s own `deep` as `unique` — a
+    // function `crate::a::missing::deep()` does not name.
+    const edge = resolveOne("deep", "crate::a::missing");
+    expect(edge.calleeCandidates).toEqual([]);
+    expect(edge.confidence).toBe("unresolved");
+  });
+
+  it("keeps both spellings of one module rather than picking one", () => {
+    // `a/twin.rs` and `a/twin/mod.rs` are the same module written twice, which
+    // rustc rejects (E0761) and a file graph merely reports. Two answers is
+    // the honest reading; choosing either would be a `unique` that half the
+    // trees would find wrong.
+    const edge = resolveOne("pick", "crate::a::twin");
+    expect(edge.calleeCandidates.slice().sort()).toEqual([
+      `${TWIN_FILE}::pick#5`,
+      `${TWIN_DIR}::pick#6`,
+    ]);
+    expect(edge.confidence).toBe("multiple-candidates");
+  });
+
+  it("files a binary's modules beside the binary, and starts `crate::` there", () => {
+    // cargo 1.90.0 on `src/bin/x.rs` writing `mod helper;` answers `file not
+    // found … create file "src/bin/helper.rs"`, so a crate root's children sit
+    // in its own directory whatever its stem is. Reading `x.rs` as an ordinary
+    // module looks under `src/bin/x/`, finds nothing, and falls back to the
+    // suffix — which the imported `src/other/helper.rs` makes ambiguous.
+    const edge = resolveOne("help", "crate::helper", BIN);
+    expect(edge.calleeCandidates).toEqual([`${BIN_HELPER}::help#8`]);
+    expect(edge.confidence).toBe("unique");
+  });
+
+  it("still matches by suffix where there is no `mod` chain to walk", () => {
+    // The root reaches `src/hidden/thing.rs` without declaring a `hidden`
+    // module the walk can step through — which is what a `mod` written inside
+    // a macro, or an inline `mod` block, looks like from the file graph.
+    // Dropping the older match loses the edge and gains no truth.
+    const edge = resolveOne("only_here", "crate::hidden::thing");
+    expect(edge.calleeCandidates).toEqual([`${HIDDEN}::only_here#7`]);
+    expect(edge.confidence).toBe("unique");
+  });
+});

--- a/tests/unit/graph-symbol-resolution.test.ts
+++ b/tests/unit/graph-symbol-resolution.test.ts
@@ -1217,6 +1217,58 @@ describe("Rust qualified calls, across a workspace", () => {
   });
 });
 
+describe("Rust `super::` from a file at the project root", () => {
+  // A crate whose root module sits at the top of the tree: `lib.rs` beside
+  // `foo.rs`, no `src/`. The parent of `foo.rs` has no directory to be named
+  // after, and a path built by cutting the last character off the file name
+  // — which is what slicing to the last `/` does when there is none — matches
+  // nothing at all.
+  const LIB = "lib.rs";
+  const FOO = "foo.rs";
+
+  function sym(file: string, name: string, line: number): SymbolNode {
+    return {
+      id: `${file}::${name}#${line}`,
+      name,
+      qualifiedName: name,
+      kind: "function",
+      file,
+      line,
+      endLine: line,
+      language: "rust",
+    };
+  }
+
+  it("finds the crate root as the parent", () => {
+    const graph: CodeGraph = {
+      nodes: [
+        { relativePath: LIB, imports: [], exports: [], dependencies: [FOO], dependents: [] },
+        { relativePath: FOO, imports: [], exports: [], dependencies: [], dependents: [LIB] },
+      ],
+      edges: [],
+    };
+    const edge: SymbolEdge = {
+      callerId: `${FOO}::caller#1`,
+      calleeName: "helper",
+      calleeCandidates: [],
+      confidence: "unresolved",
+      kind: "call",
+      calleeQualifier: "super",
+      callSite: { file: FOO, line: 2 },
+    };
+    resolveCallSites(
+      graph,
+      new Map<string, SymbolNode[]>([
+        [LIB, [sym(LIB, "helper", 3)]],
+        [FOO, [sym(FOO, "caller", 1)]],
+      ]),
+      new Map<string, SymbolEdge[]>([[FOO, [edge]]]),
+    );
+    expect(edge.calleeCandidates).toEqual([`${LIB}::helper#3`]);
+    expect(edge.confidence).toBe("unique");
+  });
+});
+
 describe("Rust qualified calls rooted in `super`", () => {
   // A module with both a parent and a child of the same name, which is what
   // separates "read in the parent's scope" from "read in the caller's".

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -349,12 +349,138 @@ impl A { pub const MAX: u32 = 9; }
 `;
       const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
       const outs = out.symbols.filter((s) => s.name === "Out");
-      expect(outs).toHaveLength(2);
+      // Three: the trait's own declaration, and one per impl.
+      expect(outs).toHaveLength(3);
       expect(outs.every((s) => s.kind === "type")).toBe(true);
+      expect(outs.map((s) => s.line)).toEqual([2, 5, 6]);
       expect(out.symbols.some((s) => s.name === "MAX" && s.kind === "variable")).toBe(true);
-      // The trait's own declaration is an `associated_type`, not a `type_item`,
-      // so the declaration a reader looks for is the one that is missing.
-      expect(out.symbols.filter((s) => s.name === "Out").every((s) => s.line > 4)).toBe(true);
+    });
+
+    it("reads a declaration that has no body, in a trait and in an extern block", () => {
+      // A declaration without a definition is still what a reader looks up.
+      // Rust writes both as `function_signature_item`, and a trait's own
+      // associated type as `associated_type` — a different node from the
+      // `type_item` an impl writes, which is why reading definitions alone left
+      // a trait's contents unfindable.
+      const src = `
+pub trait Speaks {
+    fn say(&self) -> u32;
+    type Voice;
+}
+extern "C" {
+    pub fn c_open(path: u32) -> u32;
+    pub static C_LIMIT: u32;
+}
+`;
+      const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
+      const byName = new Map(out.symbols.map((s) => [s.name, s.kind]));
+      expect(byName.get("say")).toBe("function");
+      expect(byName.get("Voice")).toBe("type");
+      expect(byName.get("c_open")).toBe("function");
+      expect(byName.get("C_LIMIT")).toBe("variable");
+      // The kind is `function` because that is what every Rust `fn` gets here,
+      // an impl's methods included; a declared one is not a different species.
+      expect(out.symbols.find((s) => s.name === "say")?.line).toBe(3);
+    });
+
+    it("reads a qualified call as a terminal name plus its qualifier", () => {
+      // `extractCalleeNameJs` matched the chain pattern `[\w$.]+`, which stops
+      // at the `:` of `::`, so every one of these produced no edge at all.
+      const src = `
+fn f() {
+    let _ = plain();
+    let _ = obj.method();
+    let _ = Vec::new();
+    let _ = std::fs::copy(a, b);
+    let _ = Vec::<u8>::new();
+    let _ = Vec::<Option<u8>>::with_capacity(1);
+    let _ = self::helper();
+    let _ = crate::a::b::run();
+}
+`;
+      const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
+      const seen = out.rawCalls.map((c) => `${c.calleeQualifier ?? ""}|${c.calleeName}`);
+      expect(seen).toContain("|plain");
+      // A method on a receiver has no path to narrow with: the name is all it knows.
+      expect(seen).toContain("|method");
+      expect(seen).toContain("Vec|new");
+      expect(seen).toContain("std::fs|copy");
+      // The turbofish is not part of the qualifier, and a nested generic must
+      // not leave a stray `>` behind.
+      expect(seen).toContain("Vec|new");
+      expect(seen).toContain("Vec|with_capacity");
+      expect(seen).toContain("self|helper");
+      expect(seen).toContain("crate::a::b|run");
+    });
+
+    it("reads every link of a chain whose head is qualified", () => {
+      // The whole chain used to yield nothing: ast-grep reports one node per
+      // link and each node's text begins at the head, so the text-level
+      // extractor died on the head's `::` for every link.
+      const src = "fn f() { let _ = Path::new(p).components().all(g); }";
+      const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
+      const seen = out.rawCalls.map((c) => `${c.calleeQualifier ?? ""}|${c.calleeName}`);
+      expect(seen).toContain("Path|new");
+      expect(seen).toContain("|components");
+      expect(seen).toContain("|all");
+    });
+
+    it("does not invent a callee for a form it cannot read", () => {
+      // `<T as Tr>::go()` is a qualified path with syntax in it. It yields an
+      // edge named `go`, qualified by text that resolution will refuse — which
+      // is the point: an edge that says what it saw, not a guess.
+      const src = "fn f() { let _ = <T as Tr>::go(); }";
+      const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
+      const go = out.rawCalls.find((c) => c.calleeName === "go");
+      expect(go).toBeDefined();
+      expect(go?.calleeQualifier).toBe("<T as Tr>");
+    });
+
+    it("collects the name each use puts in scope, alias included", () => {
+      // The file graph cannot supply this: `rustUseLeafPath` strips ` as X`
+      // before the path is recorded, so `Alias` names nothing downstream.
+      const src = `
+use crate::a::Type as Alias;
+use crate::a::{Thing, Other as O};
+use std::fs;
+use crate::b::{self, Deep};
+use crate::c::*;
+`;
+      const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
+      const bindings = new Map((out.bindings ?? []).map((b) => [b.local, b.path]));
+      expect(bindings.get("Alias")).toBe("crate::a::Type");
+      expect(bindings.get("Thing")).toBe("crate::a::Thing");
+      expect(bindings.get("O")).toBe("crate::a::Other");
+      expect(bindings.get("fs")).toBe("std::fs");
+      // `self` in a list binds the prefix's own last segment.
+      expect(bindings.get("b")).toBe("crate::b");
+      expect(bindings.get("Deep")).toBe("crate::b::Deep");
+      // A wildcard binds no name: what it brings in cannot be known from this
+      // file, and guessing would widen resolution instead of narrowing it.
+      expect(bindings.has("c")).toBe(false);
+    });
+
+    it("does not let a use written inside a scope bind the whole file", () => {
+      // A `use` inside a `fn` or a `mod x { }` names something *there*. Taken
+      // for the file's own, it would point a call in a different scope at a
+      // different type — and resolution would state that as `unique`, which is
+      // worse than saying nothing. `safeFindAll` walks the whole tree, so this
+      // is what reading the file's top level rather than searching prevents.
+      const src = `
+use crate::a::Thing;
+
+pub fn scoped() {
+    use crate::b::Thing;
+    let _ = Thing::make();
+}
+
+mod inner {
+    use crate::c::Thing;
+}
+`;
+      const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
+      const paths = (out.bindings ?? []).filter((b) => b.local === "Thing").map((b) => b.path);
+      expect(paths).toEqual(["crate::a::Thing"]);
     });
   });
 

--- a/tests/unit/graph-symbols.test.ts
+++ b/tests/unit/graph-symbols.test.ts
@@ -445,6 +445,7 @@ use crate::a::{Thing, Other as O};
 use std::fs;
 use crate::b::{self, Deep};
 use crate::c::*;
+use self as ThisModule;
 `;
       const out = extractSymbolsAndCalls(src, "rust" as unknown as Lang, ".rs", "crates/x/src/lib.rs");
       const bindings = new Map((out.bindings ?? []).map((b) => [b.local, b.path]));
@@ -455,6 +456,9 @@ use crate::c::*;
       // `self` in a list binds the prefix's own last segment.
       expect(bindings.get("b")).toBe("crate::b");
       expect(bindings.get("Deep")).toBe("crate::b::Deep");
+      // At the file top level, bare `self` names the file's own module. It must
+      // keep that anchor rather than becoming an empty path.
+      expect(bindings.get("ThisModule")).toBe("self");
       // A wildcard binds no name: what it brings in cannot be known from this
       // file, and guessing would widen resolution instead of narrowing it.
       expect(bindings.has("c")).toBe(false);


### PR DESCRIPTION
## Summary

A Rust call written with a path produced no edge at all. `extractFromRust` derived its callee through `extractCalleeNameJs`, whose chain pattern `[\w$.]+` stops at the `:` of `::`, so the call was dropped before resolution ran. Chains whose head is qualified were dropped with it, since each link's node text begins at that head.

| call | `main` | this branch |
|---|---|---|
| `plain()` | `plain` | `plain` |
| `obj.method()` | `method` | `method` |
| `Vec::new()` | **none** | `new`, qualified `Vec` |
| `std::fs::copy(a, b)` | **none** | `copy`, qualified `std::fs` |
| `Vec::<Option<u8>>::new()` | **none** | `new`, qualified `Vec` |
| `Path::new(p).components().all(g)` | **none** | `new`, `components`, `all` |

Counted against `call_expression` plus `macro_invocation` nodes: **568** missing edges on ripgrep 14.1.1, **7,860** on tokio 1.40.0, **12,034** on a private 363-file tree. Roughly a third of all call sites.

This is the grouped scope #143 asked for, and it closes #140 with it.

## Changes

**Extraction.** The callee is read off the node's own `function` field instead of scanned out of its text, so a chain needs no special case: ast-grep reports one node per link and each link's field names only that link. The turbofish is stripped by scanning for the matching `>`, since `::<[^>]*>` leaves a stray `>` on a nested generic.

**The edge.** A new optional `calleeQualifier` on `SymbolEdge` holds the path with the terminal name excluded. `calleeName` stays the terminal name, so no existing consumer changes.

**The qualifier is written as the file would write it.** `super` counts modules, and an inline `mod` is one. Inside `#[cfg(test)] mod tests { … }` in `a/b.rs`, `super::helper()` is `b.rs`'s own `helper`. Resolution knows only files, so one leading `super` is consumed per enclosing inline `mod` at extraction, where the nesting is still visible. Read a module too high and those calls answer with the parent's `helper`, a different file reported as `unique`.

When the `super` run out before the inline modules do, the path is rooted in a scope with no file. The call is left unresolved with its qualifier, and the file is not an answer either, since it holds the sibling inline modules. The extractor says so through a set of edges held by identity, beside the edges: nothing new is persisted.

**Resolution** narrows by the qualifier and never widens.

- **`crate::`** starts at the crate root and stays inside the caller's crate. Parsed manifests supply every target root, including custom `[lib] path`, `[[bin]] path`, integration tests, examples, benchmarks and build scripts. If a manifest cannot be read, convention-shaped targets under `src/bin/`, `tests/`, `benches` and `examples` preserve the previous best-effort behavior. Cargo compiles each target as a separate crate. None is reachable from the library, so left to an "answer with every root" fallback they collapsed onto it: `crate::helper()` in `tests/it.rs` answered `src/lib.rs::helper` as `unique`, and rustc refuses that reading with E0308.

  The root is added to the caller's scope, not put in its place. Measured read-only-from-the-root on tokio, that cost 7 edges, one of them a real loss (`crate::sync::watch::channel()` in `sync/barrier.rs`); the union costs none. A directory holding two roots holds two crates: a root module is its own `crate::`, and otherwise the answer is the manifest-declared roots that reach the caller. If several roots exist and the graph cannot establish which one owns a module, the edge stays unresolved instead of crossing targets. With one declared root, that root remains available when macro expansion hides the module declaration.

  Two files are in the same crate when the map gives them the same answer, not when one path is a prefix of the other: a package at the project root has `""`, a prefix of every crate beside it, and `crates/alpha/` is a prefix of a crate nested at `crates/alpha/inner/beta`. The owning crate is the deepest directory containing the file, the rule #118 settled on.

- **`self::`** is the caller's own file, and only that.

- **`super::`** is computed from the caller's path: `a/b/leaf.rs` has parent `a/b/mod.rs` or `a/b.rs`. That answer is checked against the dependents. Picking a dependent by name makes the crate root the parent of every file in the crate, since it declares them all. The rest of the path is read in the parent's scope, and so is a binding rooted there: `use super::config;` then `config::load()` means the parent's `config`, and reading it in the caller's scope reaches the caller's own `inner/config.rs`.

- **A module path is walked one segment at a time**, from the scope it starts in: the crate roots for `crate::`, the climbed parent for `super::`, the caller for `self::` and a bare path. Each hop takes the files the current module declares at `<childDir>/<seg>.rs` or `<childDir>/<seg>/mod.rs`, recorded as one of its dependencies.

  Matching the whole qualifier as a suffix was wrong both ways. It missed `crate::a::b::f()`, since nothing depends on `a/b.rs` except `a/mod.rs`. And it answered where the path names nothing: `crate::task::yield_now()` in tokio's `src/runtime/tests/task.rs` came back as `src/runtime/task/mod.rs::yield_now#280`, a trait method taking `Notified<Self>`, where the path names the free `async fn` in `src/task/yield_now.rs`. Five times, as `unique`.

  A hop that finds nothing ends the walk. Where the walk finds nothing at all the suffix match still answers, because four things hide the module tree from the file graph: a `mod` inside a macro, an inline `mod`, a `use` re-binding in an ancestor, and a root named by `[[bin]] path`. Over the three trees, 46 resolving edges are ones the walk alone does not reach; the fallback recovers 40, and each of the 40 was read against the Rust source and was right.

- **A path that names modules answers with a module**, so what an inline `mod` inside that file encloses is not an answer: `crate::a::f()` names `a`'s own module, and an `f` in `mod holder { }` in `a.rs` is `crate::a::holder::f()`. rustc says so with E0425. This follows the path, so it covers `self`, `super::a`, `crate::a`, a bare `a::b` and the module prefix of a type qualifier, but not a bare `T::method()`, where `T` may be declared in the very inline `mod` the call sits in.

  What the file's top level imports counts as reachable. tokio's `counters.rs` declares inside `mod imp` and writes `pub(super) use imp::*;`; `ucred.rs` does it with seven explicit `use self::impl_<os>::get_peer_cred;`. A glob is recorded under `*`, since its names cannot be enumerated here, but it admits only symbols whose complete inline owner path matches the source module. `pub use imp::*;` therefore exposes direct exports of `imp`, not a sibling module or a private nested `imp::hidden` module.

- **A type qualifier** is the file declaring that type, with any module prefix deciding which one; without it, an alias for `crate::a::Type` would also reach `b.rs`'s `Type`. Only a `struct`, `enum`, `trait` or `type` counts: Rust keeps types and values in separate namespaces, so a `const Config` in reach says nothing about `Config::run()`.

When a qualifier names nothing this project can reach, such as `std::`, an external crate or `<T as Tr>::`, the edge stays unresolved and keeps its qualifier. It never falls back to a repository-wide name match, which is how `Vec::new()` would land on all 191 `new` in tokio.

The branch is gated on the caller being Rust, not on the field being present: `rawCallsToUnresolvedEdges` carries `calleeQualifier` for every language.

**Aliases**, which the file graph deletes. `rustUseLeafPath` strips ` as X` before the path is recorded and `ImportInfo` has no field for a local binding, so `use crate::a::Type as Alias;` left `Alias` naming nothing. They are collected from the file's own `use` declarations and carried to resolution in memory. This includes a bare `use self as ThisModule;`, which binds the caller's own module. Only top-level declarations are read: one inside a `fn` or a `mod x { }` binds a name there.

**Declaration-only items**, per #140 and #143: `function_signature_item` (a method declared in a trait, and a `fn` in an `extern` block) and `associated_type`.

## Storage: nothing to migrate

`calleeQualifier` is additive and optional, `schemaVersion` stays at 2, and no read path branches on it. A graph persisted before this reads as it did, with no qualified edges until it is rebuilt.

The alias map and the crate map are resolution inputs, not payload. `resolveCallSites` has one caller, and `updateChangedFilesSymbolGraph` asks for a full rebuild on any change rather than re-resolving, so neither needs storing: no new edges in the counts, no schema change, no reindex.

## What this does, measured

Edge by edge against `main` on three trees, each key carrying the multiset of its edges' outcomes.

Of the keys that already existed, 646 / 1,850 / 2,005 differ at all, almost always through de-duplication: the old text-level extractor emitted the same callee twice for nested calls, so `unique, unique` now reads `unique`. Counting only keys where the *set* of confidence labels changes leaves **0 / 5 / 18**. ripgrep has none; tokio's 5 are improvements; the private tree's 18 are 13 improvements and 5 falling from `unique` to `multiple-candidates`, the declaration-only trade #140 accepted. Two edges named `self` disappear.

New edges: **1,218 / 10,048 / 14,478**, of which 76 / 1,481 / 1,390 resolve. The file-import graph is byte-identical on all three, checked by hashing it on both sides.

Unresolved percentage, read from `computeUnresolvedPct`:

| tree | `main` | here |
|---|---|---|
| ripgrep 14.1.1 | 58.82% | **76.08%** |
| tokio 1.40.0 | 71.79% | **76.68%** |
| private tree | 70.83% | **78.55%** |

It goes up, and that is the honest direction: a third of the call sites stopped being invisible, most of them pointing at `std::` and other crates this project cannot resolve.

tokio's figure includes 13 keys that start resolving and 6 that stop. Five of the six were the `crate::task::yield_now()` answer above. The sixth is a real loss: `Runtime::from_parts` reached `src/runtime/runtime.rs::from_parts#139`, the right file, because the segment `runtime` suffix-matched the file `runtime/runtime.rs`. The walk stops at `src/runtime/mod.rs`, where `Runtime` is re-exported and not declared.

## What it costs

Extraction is 8–25% slower on the single files measured. Resolution: 17→23 ms on ripgrep, 25→71 ms on tokio, 45→100 ms on the private tree, in the run that produced the numbers above. It stays a small share of the build: 71 ms of 1,741 on tokio.

The whole build is **6–8% slower**, measured in pairs so the machine's drift divides out, with the order inside each pair alternating: median ratio over ten pairs on tokio **1.072**, this branch slower in **eight**. The same harness against `main` on both sides gives 1.019 and three of six, which is what says the effect is in the code.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test coverage improvement

## Testing

- [x] Unit tests pass (`npm run test:unit`)
- [x] Full suite passes (`npm test`): **2,131 passed**, 14 skipped; 91 files passed, 1 skipped
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Lint clean (`npm run lint`)
- [x] New tests added for new/changed functionality

**Extraction**: each qualified form including turbofish and a nested generic; a chain whose head is qualified; a qualifier carrying type syntax; the `use` bindings including an alias, a nested list, `self` in a list, a wildcard, and a `use` inside a scope that must not bind the file; the declaration-only items.

**Resolution**: `crate::` in each of the three Rust layouts, plus the same confinement through an alias; a bare module path and the same path as a directory's `mod.rs`; `self::` that must not reach a dependency; `super::` through a dependent and `super::` refusing the crate root; a `use super::` binding read in the parent's scope, `super::super::` climbing two modules, `use super as up;`; an ambiguous type qualifier; a type qualifier colliding with a const of the same name; an alias reaching exactly what the original type reaches; an external path staying unresolved; a qualifier that does not resolve while the same call unqualified does; a non-Rust caller carrying a qualifier.

Many of these go through **`buildCodeGraph` on fixture trees with real manifests**, because the crate map is built there:

- Crate layouts: a package at the project root with a crate beside it; a crate nested inside another crate's directory; a nested module calling `crate::helper()` declared in a root it never imports; the same through `use crate as root;`; a directory holding a library and a binary, with `crate::` in `main.rs`, in `src/bin/x.rs`, and in a module only the binary declares; a crate whose root is at the top of the tree.
- Cargo target layouts: `src/bin/x.rs`; a multi-file binary at `src/bin/packer/main.rs`; `tests/`, `tests/dirtest/main.rs`, `benches/`, `examples/`; explicit custom `[lib] path` and `[[bin]] path` targets; modules reached from those custom roots; an unreferenced `tests/common/mod.rs`, which correctly stays unresolved.
- The inline-`mod` rewrite, on real Rust: one `super` reaching the file's own `helper` (`a.rs` declares one too); two `super` reaching `a/sub.rs`; one `super` followed by a module; one followed by an aliased name; and one inline module deeper, a `super` that leaves neither, proved twice.
- The inline-`mod` refusal: refused through `crate::` and through `super::` (rustc: E0425), and kept where the file lifts the name to its top level, once by name and once with a glob, and where a bare type qualifier names a type the inline `mod` declares with the call inside that same `mod`; cargo 1.98 runs that green.
- The walk: `crate::a::b::f()` reaching `src/a/b.rs`, which nothing imports directly, and not `src/other/a/b.rs`, which the caller does import and whose path ends in the same two segments; the imported homonym still reachable under its bound name; a hop that finds nothing ending the walk; a file at the right path that no module declares, refused; both spellings of one module kept; the suffix match still answering where no `mod` chain is visible; an integration test's modules filed beside the test; `src/deep.rs` filing `mod leaf;` under `src/deep/` and not as the `src/leaf.rs` beside it (cargo returns 1 and 2 for those); the module prefix of a type qualifier walked, on two homonym `Tipo`s returning 41 and 42; and the walk stopped at a crate boundary it can cross, where a `Cargo.toml` inside another crate's `src/` puts a child in a different crate from its parent.

Every original rule above has a mutation that turns exactly its own test red: **56** of them, listed so the count can be checked. Three were green until a mutation or a review asked for the test: the `null` / `[]` distinction on an unprovable crate root, the module prefix of a type qualifier, and the crate confinement on the walk.

A second review round found three more answers rustc refuses, each reproduced on a cargo fixture before anything was changed. A glob exemption kept every inline symbol whenever the file had any top-level glob, so `crate::glob::nascosto()` answered `unique` where `nascosto` sits in a sibling `mod` the glob never reads from (E0425). The test covered the case that must pass but not the neighbour that must not. The suffix fallback spoke after the walk had already entered a module, so `crate::a::missing::f()` (E0433) answered with an imported `other/a/missing.rs`. And `use crate::a::{self as A};` was recorded as `crate::a::self`, which matched no module. Fixing all three loses no edge on the three trees and gains two on tokio, including `os_impl::ctrl_c()` in `signal/ctrl_c.rs`, written `use super::unix::{self as os_impl};`.

An adversarial review of the walk commits, by a reviewer that wrote none of them, found one wrong answer and two green mutants; all three are closed here with a test each. The wrong answer is the class this branch exists to prevent: the inline-`mod` refusal asked whether the qualifier was literally `self`, so `crate::a::f()` and `super::a::f()` still answered `unique` on a symbol rustc refuses. Fixing it by the path then withdrew 35 right answers on tokio, all re-exports, which is how the "what the top level imports" rule got measured into existence. Net change on the three trees after both: **one edge, an improvement**. `Reaper::new` in tokio moves from three candidates to one, with the other two declared inside a `mod test`.

The final review closed three additional cases with regressions: bare `use self as Alias;` now binds the caller's module, parsed Cargo target roots now drive custom target resolution instead of filename guesses, and a top-level glob no longer flattens symbols from a nested inline module.

## Known limits

Each is measured on the extractor or the resolver. All fail safe as `unresolved`, never a wrong `unique`, and none is a regression against `main`.

- **A raw identifier in a path.** `use crate::r#type::Raw;` records the binding with `r#type` in it, which no module path matches.
- **A qualified macro.** `crate::m::mac!()` yields an edge named `m`, because the macro branch takes the first descendant identifier. Unchanged from `main`.
- **A path rooted in an inline `mod`.** With fewer `super` than the inline modules around the call, the path is rooted in a scope with no file. It does not occur on the three trees.
- **An inline module's own namespace is still file-granular.** A bare `helper()` written inside an inline `mod`, with no qualifier, resolves as `local` to every `helper` in the file. `local` has always meant "in this file" here, in every language.
- **A call inside a macro body.** `cfg_if! { … }` is one `token_tree`, so no call inside it is extracted. Unchanged from `main`, and worth naming because tokio is full of `cfg_if!`.
- **A path through a re-export.** The walk follows `mod` declarations, not `pub use`. Exactly 1 edge across the three trees, `Runtime::from_parts` above, which is the whole measured price of the walk against the suffix match.
- **A name a module re-exports rather than declares.** Same cause from the other side: `crate::a::f()` where `a/mod.rs` writes `pub use inner::f;` reaches `a/mod.rs` and finds no `f`. The suffix fallback still answers, so this loses nothing against `main`.
- **A `crate::` path whose module the root declares invisibly.** When the root declares `mod a;` inside a macro, the root's `a` is not in the graph and a same-named child of the caller can answer instead. Present since the qualifier was first read.
- **`#[path = "…"]` and `[lib] path = "…"`** put a module's parent where the caller's path does not predict. Isolated on the two public trees: the new `parentModulesOf` changes no `super::` edge on real code.
- **Scoped `use` costs a few edges.** On ripgrep, three `use … as Separator` inside a `mod tests` no longer bind the file, and 4 edges that resolved by accident go unresolved.

## Related

Closes #143. Closes #140. Follows #141, which extracted the Rust items that are not functions, the symbols this change gives resolution something to match against.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved Rust code navigation for qualified calls using `crate`, `self`, `super`, module paths, aliases, and workspace crate boundaries.
  * Improved resolution across `mod.rs`, `lib.rs`, `main.rs`, binaries, tests, benchmarks, and examples.
  * Added more accurate handling of Rust type namespaces, associated items, `use` bindings, re-exports, and inline modules.
  * Improved module-path matching to prioritize exact paths and avoid incorrect matches from similarly named modules.
  * Added support for richer call-site details, improving graph accuracy and confidence indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->