### PR TITLE
feat: add manual indexing mode

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -249,6 +249,8 @@ All constants are defined in `src/constants.ts`:
 | `OLLAMA_CONTAINER_NAME` | `socraticode-ollama` | Docker container name |
 | `OLLAMA_IMAGE` | `ollama/ollama:latest` | Docker image |
 
+`getWatcherMode()` resolves `SOCRATICODE_WATCHER=auto|manual|off` at call time and rejects unknown values. `src/index.ts` invokes it during startup so invalid lifecycle configuration fails before tools are accepted.
+
 > **Note**: `EMBEDDING_MODEL`, `EMBEDDING_DIMENSIONS`, and `EMBEDDING_CONTEXT_LENGTH` are defined in `src/services/embedding-config.ts`, not in `src/constants.ts`. Defaults are `nomic-embed-text` / `768` for Ollama, `text-embedding-3-small` / `1536` for OpenAI, and `gemini-embedding-001` / `3072` for Google.
 
 ### Embedding batch size
@@ -827,17 +829,22 @@ Google Generative AI embedding provider. Requires `GOOGLE_API_KEY`.
 | `updateProjectIndex` | `(projectPath, onProgress?, extraExtensions?) → Promise<{ added, updated, removed, chunksCreated, cancelled }>` | Incremental update |
 | `removeProjectIndex` | `(projectPath) → Promise<void>` | Delete index, code graph, and context artifacts |
 
+### startup.ts
+
+`autoResumeIndexedProjects()` checks `SOCRATICODE_AUTO_RESUME=off` before Docker, Qdrant, explicit project lists, or any persisted-index access. Otherwise it preserves the existing current-project, explicit-list, and `all` modes. Watcher starts from startup pass through `startWatchingAutomatically`, so `manual` and `off` suppress the watcher without suppressing the catch-up update; combine watcher `off` with auto-resume `off` for a fully deliberate code-index snapshot.
+
 ### watcher.ts
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `startWatching` | `(projectPath, onProgress?) → Promise<boolean>` | Start @parcel/watcher native subscription. Returns `true` if now watching (or already was), `false` if another process holds the lock or subscription failed |
+| `startWatching` | `(projectPath, onProgress?) → Promise<boolean>` | Start @parcel/watcher native subscription. Permitted in `auto` and `manual`, rejected before lock acquisition in `off`. Returns `true` if now watching (or already was), `false` if disabled, another process holds the lock, or subscription failed |
+| `startWatchingAutomatically` | `(projectPath, onProgress?) → Promise<boolean>` | Start only in `SOCRATICODE_WATCHER=auto`; shared guard for startup and post-index/update paths |
 | `stopWatching` | `(projectPath) → Promise<void>` | Stop watcher |
 | `stopAllWatchers` | `() → Promise<void>` | Stop all watchers |
 | `isWatching` | `(projectPath) → boolean` | Check if a project is being watched **by this process** |
 | `isWatchedByAnyProcess` | `(projectPath) → Promise<boolean>` | Cross-process check: local subscriptions first, then file-based lock |
 | `getWatchedProjects` | `() → string[]` | List watched paths |
-| `ensureWatcherStarted` | `(projectPath) → void` | Fire-and-forget auto-start with TTL cache: checks not watching, not externally watched (60s cache), not indexing, collection exists |
+| `ensureWatcherStarted` | `(projectPath) → void` | Fire-and-forget auto-start in `auto` mode with TTL cache: checks not watching, not externally watched (60s cache), not indexing, collection exists. Returns before storage access in `manual`/`off` |
 | `clearExternalWatchCache` | `() → void` | Clear the external watch TTL cache (for testing) |
 
 Watcher settings:
@@ -847,13 +854,16 @@ Watcher settings:
 - Auto-stops after 10 consecutive errors
 - Cross-process lock prevents duplicate watchers
 - Cross-process status awareness: `codebase_status` and `codebase_search` detect watchers running in other MCP processes via file-based locks
-- Auto-starts on first tool interaction with an indexed project (search, status, update, graph), with 60-second TTL cache to avoid retrying when another process holds the lock
+- Auto-starts on first tool interaction with an indexed project (search, status, update, graph) only in `auto`, with 60-second TTL cache to avoid retrying when another process holds the lock
+- `manual` disables every automatic watcher start but leaves explicit `codebase_watch start` available; `off` rejects explicit starts too
+- Watcher mode is process-local. Every MCP process sharing a checkout must use the same snapshot setting; status warns when an `off` process detects another watcher
 
 ### code-graph.ts
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `buildCodeGraph` | `(projectPath, extraExtensions?, progress?) → Promise<CodeGraph>` | Build dependency graph via ast-grep with optional progress tracking |
+| `getExistingGraph` | `(projectPath) → Promise<CodeGraph \| null>` | Load a cached or persisted graph without creating one |
 | `getOrBuildGraph` | `(projectPath, extraExtensions?) → Promise<CodeGraph>` | Get cached graph or build new one |
 | `rebuildGraph` | `(projectPath, extraExtensions?) → Promise<CodeGraph>` | Force rebuild with concurrency guard (joins existing build if in progress) |
 | `invalidateGraphCache` | `(projectPath) → void` | Clear cached graph for project |
@@ -1140,6 +1150,8 @@ Parameters:
 
 Returns: Status message or list of watched projects
 ```
+
+`SOCRATICODE_WATCHER=manual` suppresses automatic starts but permits the `start` action. `off` rejects `start` before infrastructure or catch-up work and reports the watcher as disabled. `stop` remains available in all modes. Use `SOCRATICODE_AUTO_RESUME=off` as well when startup must not run an incremental catch-up or resume interrupted indexing.
 
 ### Query Tools
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Restart your host. With the default local configuration, first use pulls the req
 
 **First time on a project:** ask your AI: **"Index this codebase"**. Indexing runs in the background; ask **"What is the codebase index status?"** to monitor progress. Depending on codebase size and whether you're using GPU-accelerated Ollama or cloud embeddings, first-time indexing can take anywhere from a few seconds to a few minutes (it takes under 10 minutes to first-index +3 million lines of code on a Macbook Pro M4). Once complete it doesn't need to be run again, you can search, explore the dependency graph, and query context artifacts.
 
-**Every time after that:** just use the tools (search, graph, etc.). By default, on server startup SocratiCode automatically detects previously indexed projects, restarts the file watcher, and runs an incremental update to catch any changes made while the server was down. If indexing was interrupted, it resumes automatically from the last checkpoint. You can also explicitly start or restart the watcher with `codebase_watch { action: "start" }`.
+**Every time after that:** just use the tools (search, graph, etc.). By default, server startup resumes the indexed project represented by the MCP process's working directory: a complete index gets its watcher and an incremental catch-up update, while interrupted indexing resumes from the last checkpoint. `SOCRATICODE_AUTO_RESUME_PROJECTS` and `SOCRATICODE_AUTO_RESUME=all` can select additional projects. A completed indexed project not handled at startup gets a fallback watcher start on its first search, status, or graph interaction. You can also explicitly start or restart the watcher with `codebase_watch { action: "start" }`.
 
 **Prefer a deliberate index snapshot?** Set `SOCRATICODE_WATCHER=off` and `SOCRATICODE_AUTO_RESUME=off` for every MCP process that uses the checkout, then run `codebase_update` only when you want to refresh it. Existing indexes remain usable without rebuilding. Use `SOCRATICODE_WATCHER=manual` instead if explicit `codebase_watch { action: "start" }` should remain available. See [Indexing Behaviour](#indexing-behaviour) and [Passing env vars by host](#passing-env-vars-by-host).
 
@@ -574,8 +574,8 @@ On VS Code's 2.45M‑line codebase, SocratiCode answers architectural questions 
 - **Configurable infrastructure** — All ports, hosts, and API keys are configurable via environment variables. Qdrant API key support for enterprise deployments.
 - **Enterprise-ready simplicity** — No agent coordination tuning, no memory limit environment variables, no coordinator/conductor capacity knobs, no backpressure configuration. SocratiCode scales by relying on production-grade infrastructure (Qdrant, proven embedding APIs) rather than complex in-process orchestration.
 - **Auto-setup & zero configuration** — Just install the Claude Plugin/Skill or add the MCP server to your AI host config. On first use, the server automatically checks Docker, pulls images, starts Qdrant and Ollama containers, and downloads the embedding model. No config files, YAML, environment variables, or required native compilation. The optional GDScript parser falls back safely when no compatible native build is available. Works everywhere Docker runs.
-- **Session resume** — By default, when reopening a previously indexed project, the file watcher starts automatically on first tool use (search, status, update, or graph query). It catches any changes made since the last session and keeps the index live — no manual action needed.
-- **Auto-start watcher** — In the default `SOCRATICODE_WATCHER=auto` mode, the file watcher starts after `codebase_index`, after `codebase_update`, and on the first search, status, or graph interaction. `manual` permits only an explicit `codebase_watch { action: "start" }`; `off` disables watcher startup completely.
+- **Session resume** — By default, server startup resumes the indexed project represented by the MCP process's working directory. Complete indexes get a watcher plus an incremental catch-up update; interrupted indexes resume from the last checkpoint. Explicit project lists and `SOCRATICODE_AUTO_RESUME=all` extend this to other indexed projects.
+- **Auto-start watcher** — In the default `SOCRATICODE_WATCHER=auto` mode, the file watcher starts during startup resume and after `codebase_index` or `codebase_update`. A completed indexed project not selected at startup gets a fallback watcher start on its first search, status, or graph interaction. `manual` permits only an explicit `codebase_watch { action: "start" }`; `off` disables watcher startup completely.
 - **Manual index snapshots** — `SOCRATICODE_WATCHER=off` plus `SOCRATICODE_AUTO_RESUME=off` prevents implicit code-index updates, embeddings, and graph creation. Existing code indexes and graphs stay readable; refresh them explicitly with `codebase_index`, `codebase_update`, or `codebase_graph_build`.
 - **Auto-build code graph** — The code dependency graph is automatically built after indexing and rebuilt when watched files change. No need to call `codebase_graph_build` manually unless you want to force a rebuild.
 - **Multi-agent collaboration** — Multiple AI agents (each running their own MCP instance) can work on the same codebase simultaneously and share a single index. One agent triggers indexing, all agents search against the same data. Only one watcher runs per project — every agent benefits from real-time updates. Cross-process file locking coordinates indexing and watching automatically. Ideal for workflows like one agent writing tests while another fixes code, or a planning agent and an implementation agent working in parallel.
@@ -1677,9 +1677,12 @@ multiple sessions across hours or days, and no work is ever repeated or lost.
 
 ### I reopened my project but new/changed files aren't showing up in search results.
 
-In the default `SOCRATICODE_WATCHER=auto` mode, the file watcher auto-starts on first tool use for any previously indexed project. When it
-starts, it catches up all files modified while SocratiCode was down before watching for
-future changes.
+In the default `SOCRATICODE_WATCHER=auto` mode, server startup resumes the indexed project
+represented by the MCP process's working directory. It starts the watcher and catches up all
+files modified while SocratiCode was down before watching for future changes. Use
+`SOCRATICODE_AUTO_RESUME_PROJECTS` or `SOCRATICODE_AUTO_RESUME=all` to select additional
+projects at startup. A completed indexed project not selected at startup gets the same
+watcher-start fallback on its first search, status, or graph interaction.
 
 If you want to force an immediate catch-up before searching, ask your AI to *"start watching
 this project"* or *"update the index"* — both run an incremental update synchronously and

--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Restart your host. With the default local configuration, first use pulls the req
 
 **First time on a project:** ask your AI: **"Index this codebase"**. Indexing runs in the background; ask **"What is the codebase index status?"** to monitor progress. Depending on codebase size and whether you're using GPU-accelerated Ollama or cloud embeddings, first-time indexing can take anywhere from a few seconds to a few minutes (it takes under 10 minutes to first-index +3 million lines of code on a Macbook Pro M4). Once complete it doesn't need to be run again, you can search, explore the dependency graph, and query context artifacts.
 
-**Every time after that:** just use the tools (search, graph, etc.). On server startup SocratiCode automatically detects previously indexed projects, restarts the file watcher, and runs an incremental update to catch any changes made while the server was down. If indexing was interrupted, it resumes automatically from the last checkpoint. You can also explicitly start or restart the watcher with `codebase_watch { action: "start" }`.
+**Every time after that:** just use the tools (search, graph, etc.). By default, on server startup SocratiCode automatically detects previously indexed projects, restarts the file watcher, and runs an incremental update to catch any changes made while the server was down. If indexing was interrupted, it resumes automatically from the last checkpoint. You can also explicitly start or restart the watcher with `codebase_watch { action: "start" }`.
+
+**Prefer a deliberate index snapshot?** Set `SOCRATICODE_WATCHER=off` and `SOCRATICODE_AUTO_RESUME=off` for every MCP process that uses the checkout, then run `codebase_update` only when you want to refresh it. Existing indexes remain usable without rebuilding. Use `SOCRATICODE_WATCHER=manual` instead if explicit `codebase_watch { action: "start" }` should remain available. See [Indexing Behaviour](#indexing-behaviour) and [Passing env vars by host](#passing-env-vars-by-host).
 
 > **macOS / Windows on large codebases**: Docker containers can't use the GPU. For medium-to-large repos, [install native Ollama](https://ollama.com/download) (auto-detected, no config change needed) for Metal/CUDA acceleration, or use [OpenAI embeddings](#openai-embeddings) for speed without a local install. [Full details.](#embedding-performance-on-macos--windows)
 >
@@ -572,8 +574,9 @@ On VS Code's 2.45M‑line codebase, SocratiCode answers architectural questions 
 - **Configurable infrastructure** — All ports, hosts, and API keys are configurable via environment variables. Qdrant API key support for enterprise deployments.
 - **Enterprise-ready simplicity** — No agent coordination tuning, no memory limit environment variables, no coordinator/conductor capacity knobs, no backpressure configuration. SocratiCode scales by relying on production-grade infrastructure (Qdrant, proven embedding APIs) rather than complex in-process orchestration.
 - **Auto-setup & zero configuration** — Just install the Claude Plugin/Skill or add the MCP server to your AI host config. On first use, the server automatically checks Docker, pulls images, starts Qdrant and Ollama containers, and downloads the embedding model. No config files, YAML, environment variables, or required native compilation. The optional GDScript parser falls back safely when no compatible native build is available. Works everywhere Docker runs.
-- **Session resume** — When reopening a previously indexed project, the file watcher starts automatically on first tool use (search, status, update, or graph query). It catches any changes made since the last session and keeps the index live — no manual action needed.
-- **Auto-start watcher** — The file watcher is automatically activated when you use any SocratiCode tool on an indexed project. It starts after `codebase_index` completes, after `codebase_update`, and on the first `codebase_search`, `codebase_status`, or graph query. You can also start it manually with `codebase_watch { action: "start" }` if needed.
+- **Session resume** — By default, when reopening a previously indexed project, the file watcher starts automatically on first tool use (search, status, update, or graph query). It catches any changes made since the last session and keeps the index live — no manual action needed.
+- **Auto-start watcher** — In the default `SOCRATICODE_WATCHER=auto` mode, the file watcher starts after `codebase_index`, after `codebase_update`, and on the first search, status, or graph interaction. `manual` permits only an explicit `codebase_watch { action: "start" }`; `off` disables watcher startup completely.
+- **Manual index snapshots** — `SOCRATICODE_WATCHER=off` plus `SOCRATICODE_AUTO_RESUME=off` prevents implicit code-index updates, embeddings, and graph creation. Existing code indexes and graphs stay readable; refresh them explicitly with `codebase_index`, `codebase_update`, or `codebase_graph_build`.
 - **Auto-build code graph** — The code dependency graph is automatically built after indexing and rebuilt when watched files change. No need to call `codebase_graph_build` manually unless you want to force a rebuild.
 - **Multi-agent collaboration** — Multiple AI agents (each running their own MCP instance) can work on the same codebase simultaneously and share a single index. One agent triggers indexing, all agents search against the same data. Only one watcher runs per project — every agent benefits from real-time updates. Cross-process file locking coordinates indexing and watching automatically. Ideal for workflows like one agent writing tests while another fixes code, or a planning agent and an implementation agent working in parallel.
 - **Cross-process safety** — File-based locking (`proper-lockfile`) prevents multiple MCP instances from simultaneously indexing or watching the same project. Stale locks from crashed processes are automatically reclaimed. When another MCP process is already watching a project, `codebase_status` reports "active (watched by another process)" instead of incorrectly showing "inactive."
@@ -1516,8 +1519,9 @@ Code and context collections persist the settings that define their stored repre
 | `SOCRATICODE_PROJECT_ID` | *(none)* | Override the auto-generated project ID. When set, all paths resolve to the same Qdrant collections, allowing multiple directories (e.g. git worktrees of the same repo) to share a single index. Must match `[a-zA-Z0-9_-]+`. Takes precedence over the `projectId` field in `.socraticode.json`. |
 | `SOCRATICODE_BRANCH_AWARE` | `false` | When `true`, append the current git branch name to the project ID, creating separate Qdrant collections per branch. Ignored when `SOCRATICODE_PROJECT_ID` is set or when `projectId` is set in `.socraticode.json`. |
 | `SOCRATICODE_LINKED_PROJECTS` | *(none)* | Comma-separated list of additional project paths to include in cross-project search. Merged with paths from `.socraticode.json`. Non-existent paths are silently skipped. |
-| `SOCRATICODE_AUTO_RESUME` | *(none)* | When set to `all`, server startup auto-resumes the file watcher plus an incremental catch-up update for **every** indexed project that has a stored path, not just the current working directory. Projects resume one at a time (sequentially) to avoid overloading the embedding provider. Skipped projects (directory no longer exists, or indexed before path tracking was added) are logged at warn level. Useful when one MCP server session should keep many canonical checkouts fresh. |
-| `SOCRATICODE_AUTO_RESUME_PROJECTS` | *(none)* | Comma-separated list of project paths to auto-resume on server startup (sequentially), e.g. `/repos/api,/repos/web`. Takes precedence over `SOCRATICODE_AUTO_RESUME`. Paths that do not exist or are not indexed are skipped with a warning. |
+| `SOCRATICODE_WATCHER` | `auto` | File-watcher policy, case-insensitive: `auto` preserves the default auto-start paths; `manual` suppresses every automatic start but permits `codebase_watch { action: "start" }`; `off` also rejects explicit starts. In `manual` and `off`, graph query tools read an existing graph but do not create a missing one. Invalid values fail at startup. This is process-local, so configure every MCP process that shares the checkout and index. No re-index is required. |
+| `SOCRATICODE_AUTO_RESUME` | *(none)* | Startup policy: unset keeps the existing current-project catch-up/recovery behavior; `all` resumes every indexed project that has a stored path, sequentially; `off` skips all startup catch-up updates and interrupted-index recovery before any Docker or Qdrant access. `off` takes precedence over `SOCRATICODE_AUTO_RESUME_PROJECTS`. This does not disable watcher starts caused by later tool use; combine it with `SOCRATICODE_WATCHER=off` for a deliberate snapshot. |
+| `SOCRATICODE_AUTO_RESUME_PROJECTS` | *(none)* | Comma-separated list of project paths to auto-resume on server startup (sequentially), e.g. `/repos/api,/repos/web`. Takes precedence over the unset/`all` behavior, but not over `SOCRATICODE_AUTO_RESUME=off`. Paths that do not exist or are not indexed are skipped with a warning. |
 | `SOCRATICODE_LOG_LEVEL` | `info` | Log verbosity: `debug`, `info`, `warn`, `error` |
 | `SOCRATICODE_LOG_FILE` | *(none)* | Absolute path to a log file. When set, all log entries are appended to this file (a session separator is written on each server start). Useful for debugging when the MCP host doesn't surface log notifications. |
 
@@ -1673,7 +1677,7 @@ multiple sessions across hours or days, and no work is ever repeated or lost.
 
 ### I reopened my project but new/changed files aren't showing up in search results.
 
-The file watcher auto-starts on first tool use for any previously indexed project. When it
+In the default `SOCRATICODE_WATCHER=auto` mode, the file watcher auto-starts on first tool use for any previously indexed project. When it
 starts, it catches up all files modified while SocratiCode was down before watching for
 future changes.
 
@@ -1683,7 +1687,15 @@ then start watching.
 
 The watcher will not auto-start if a full index or incremental update is currently in
 progress, if the project has not been indexed yet, or if another MCP process is already
-watching the same project.
+watching the same project. It also will not auto-start in `manual` or `off` mode. In those
+modes, `codebase_status` and search output identify the index as a snapshot instead of
+asking an agent to restart the watcher.
+
+For a fully deliberate snapshot, set both `SOCRATICODE_WATCHER=off` and
+`SOCRATICODE_AUTO_RESUME=off` in every MCP process that uses the checkout. Existing indexes
+and graphs remain readable with no re-index. Run `codebase_update` to refresh the code index
+and `codebase_graph_build` to explicitly create or rebuild the graph. If explicit temporary
+watching is useful, use `SOCRATICODE_WATCHER=manual` instead.
 
 If you work across many indexed repos and want all of them resumed at server startup
 (watcher plus catch-up update), not just the one you opened, see the

--- a/skills/codebase-exploration/SKILL.md
+++ b/skills/codebase-exploration/SKILL.md
@@ -38,7 +38,7 @@ Use `codebase_graph_query` to see what a file imports and what depends on it **b
 - **`codebase_graph_circular`** — find circular dependencies (these cause subtle runtime bugs; check proactively when debugging unexpected behaviour)
 - **`codebase_graph_visualize`** — Mermaid diagram colour-coded by language, circular deps highlighted in red. Pass `mode: "interactive"` to open a self-contained HTML explorer (file + symbol views, blast-radius overlay, search, PNG export — works offline) instead.
 
-The graph is auto-built after indexing. Use `codebase_graph_status` to check if the graph is ready.
+The graph is auto-built after indexing. Use `codebase_graph_status` to check if the graph is ready. In `SOCRATICODE_WATCHER=manual` or `off`, graph queries do not create a missing graph; run `codebase_graph_build` explicitly when requested.
 
 ### 3. Read files only after narrowing via search
 
@@ -60,7 +60,8 @@ Run `codebase_context` early to see what's available. Use `codebase_context_sear
 
 - **`codebase_status`** — check index status, progress, watcher state, graph status
 - If search returns no results, the project may not be indexed yet
-- If the watcher is inactive, results may be stale — run `codebase_update` or start the watcher
+- If the watcher is inactive, results may be stale — run `codebase_update`; start the watcher only when status does not say it is disabled
+- In snapshot mode (`SOCRATICODE_WATCHER=off` plus `SOCRATICODE_AUTO_RESUME=off`), stale results are expected until an explicit update. Do not enable or start the watcher.
 
 ### 6. Get an overview of all tools
 

--- a/skills/codebase-exploration/references/tool-reference.md
+++ b/skills/codebase-exploration/references/tool-reference.md
@@ -18,7 +18,7 @@ Semantic search across an indexed codebase. Only use after `codebase_index` is c
 **Key behaviours:**
 - Uses hybrid semantic + keyword (BM25) search with Reciprocal Rank Fusion
 - Warns if indexing is in progress (results will be incomplete during full index)
-- Warns if file watcher is not active (results may be stale)
+- Reports inactive automatic watching as stale by default, or as a deliberate snapshot in `SOCRATICODE_WATCHER=manual`/`off`
 - Results below `minScore` are filtered out with a count of omitted results
 
 ---
@@ -37,7 +37,7 @@ Check index status: chunk count, indexing progress, last completed operation, fi
 - Last completed operation: type, files processed, chunks created, duration
 - Incomplete index detection (previous run interrupted)
 - Cross-process indexing detection (another process actively indexing)
-- File watcher status (active / watched by another process / inactive)
+- File watcher status (active / watched by another process / inactive / deliberately disabled)
 - Code graph status (files, edges, last built, cached in memory)
 - Context artifacts status
 
@@ -59,8 +59,8 @@ Query the dependency graph for a specific file.
 **Returns:** Two lists: what this file imports (→) and what depends on it (←).
 
 **Key behaviours:**
-- Requires graph to exist (auto-built after indexing, or use `codebase_graph_build`)
-- Auto-starts file watcher on query
+- Requires graph to exist (auto-built after indexing, or use `codebase_graph_build`); `manual`/`off` never create a missing graph as a query side effect
+- Auto-starts file watcher on query only in `SOCRATICODE_WATCHER=auto`
 - Use relative paths (not absolute)
 
 ---

--- a/skills/codebase-management/SKILL.md
+++ b/skills/codebase-management/SKILL.md
@@ -18,18 +18,20 @@ Set up, index, and manage SocratiCode codebase indexing, file watching, code gra
 2. **Start indexing**: `codebase_index` — runs in background, returns immediately
 3. **Poll progress**: `codebase_status` — call every ~60 seconds until 100% complete
    - This also keeps the MCP connection alive (some hosts disconnect idle connections)
-4. **Done**: Graph auto-builds after indexing. File watcher auto-starts. Ready to search.
+4. **Done**: Graph auto-builds after indexing. In the default watcher mode, the file watcher auto-starts. Ready to search.
 
 On first use, SocratiCode automatically pulls Docker images, starts containers, and downloads the embedding model (~5 min one-time setup).
 
 ## Incremental Updates & File Watching
 
-The file watcher keeps the index automatically updated. It auto-starts after indexing.
+The file watcher keeps the index automatically updated in the default `SOCRATICODE_WATCHER=auto` mode.
 
 - **`codebase_watch { action: "start" }`** — start the watcher (runs catch-up update first)
 - **`codebase_watch { action: "stop" }`** — stop the watcher
 - **`codebase_watch { action: "status" }`** — list watched projects (including cross-process)
 - **`codebase_update`** — manual incremental update (only changed files, synchronous). Usually not needed if watcher is active.
+
+For a deliberate code-index snapshot, configure every MCP process that uses the checkout with `SOCRATICODE_WATCHER=off` and `SOCRATICODE_AUTO_RESUME=off`. Search and graph tools keep reading the existing index and graph; run `codebase_update` and `codebase_graph_build` only when a refresh is wanted. Use watcher mode `manual` instead when explicit `codebase_watch { action: "start" }` should remain available. Never try to restart a watcher whose status says disabled.
 
 ## Managing Indexes
 
@@ -39,7 +41,7 @@ The file watcher keeps the index automatically updated. It auto-starts after ind
 
 ## Managing the Code Graph
 
-The dependency graph is auto-built after indexing. Manual management is rarely needed.
+The dependency graph is auto-built after indexing. In watcher modes `manual` and `off`, graph queries read an existing graph but will ask for an explicit build instead of creating a missing graph as a side effect.
 
 - **`codebase_graph_build`** — manually rebuild (background, async). Poll with `codebase_graph_status`.
 - **`codebase_graph_remove`** — delete graph (auto-rebuilds on next `codebase_index`)
@@ -74,7 +76,7 @@ Supported types: SQL schemas, OpenAPI/Protobuf API specs, Terraform/CloudFormati
 | Slow indexing on macOS/Windows | Docker can't use GPU. Install native Ollama from https://ollama.com/download for Metal/CUDA acceleration. Or use cloud embeddings. |
 | Want cloud embeddings instead | Set `EMBEDDING_PROVIDER=openai` + `OPENAI_API_KEY`, or `EMBEDDING_PROVIDER=google` + `GOOGLE_API_KEY` |
 | Search returns no results | Check `codebase_status` — project may not be indexed. Run `codebase_index`. |
-| Stale results | Check if watcher is active (`codebase_status`). Run `codebase_update` or `codebase_watch { action: "start" }`. |
+| Stale results | Check `codebase_status`. Run `codebase_update`; start the watcher only when status does not say it is disabled. |
 | Indexing was interrupted | Run `codebase_index` again — it resumes from the last checkpoint automatically. |
 | Another process is indexing | `codebase_status` detects cross-process indexing. Wait for it, or use `codebase_stop`. |
 
@@ -94,5 +96,7 @@ Supported types: SQL schemas, OpenAPI/Protobuf API specs, Terraform/CloudFormati
 | `SEARCH_MIN_SCORE` | `0.10` | Default minimum RRF score threshold (0-1) |
 | `MAX_FILE_SIZE_MB` | `5` | Maximum file size for indexing in MB; must be a complete finite number |
 | `EXTRA_EXTENSIONS` | — | Additional file extensions to index (e.g. `.tpl,.blade,.hbs`) |
+| `SOCRATICODE_WATCHER` | `auto` | `auto`, `manual` (explicit start only), or `off` (no watcher) |
+| `SOCRATICODE_AUTO_RESUME` | — | `all` resumes all stored projects; `off` disables startup catch-up and interrupted-index recovery |
 
 For full parameter details on every tool, see [references/tool-reference.md](references/tool-reference.md).

--- a/skills/codebase-management/references/tool-reference.md
+++ b/skills/codebase-management/references/tool-reference.md
@@ -13,7 +13,7 @@ Start indexing a codebase in the background. Returns immediately.
 
 **Key behaviours:**
 - Runs asynchronously — does NOT block. Returns immediately.
-- Auto-starts file watcher upon completion (if not cancelled)
+- Auto-starts file watcher upon completion (if not cancelled and `SOCRATICODE_WATCHER=auto`)
 - Ensures Docker/Qdrant/Ollama infrastructure is running first
 - Concurrency guard: if already indexing, returns current progress instead of starting again
 - Auto-indexes context artifacts defined in `.socraticodecontextartifacts.json`
@@ -36,7 +36,7 @@ Incrementally update an existing index. Only re-indexes changed files.
 **Key behaviours:**
 - Runs synchronously (blocking), unlike `codebase_index`
 - Only processes files changed since last index (via content hash comparison)
-- Auto-starts file watcher if not already active
+- Auto-starts file watcher if not already active and `SOCRATICODE_WATCHER=auto`
 - Usually not needed if the file watcher is running
 
 ---
@@ -95,8 +95,9 @@ Start/stop/status of live file watching.
 - `stop`: Stops same-process watcher (cross-process watchers unaffected)
 - `status`: Lists all watched projects including cross-process watchers
 - Detects if another process already watches the same project
-- Auto-started after successful `codebase_index` or `codebase_update`
-- Debounced with ~500ms delay to batch rapid file changes
+- Auto-started after successful `codebase_index` or `codebase_update` in `auto` mode
+- `manual` suppresses automatic starts but permits `start`; `off` rejects `start` before catch-up or infrastructure work
+- Debounced with 2s delay to batch rapid file changes
 
 ---
 
@@ -233,11 +234,12 @@ List all projects that have been indexed.
 - Stale locks from crashed processes are auto-reclaimed
 
 ### Auto-features
-- File watcher auto-starts after indexing/updates
+- File watcher auto-starts after indexing/updates in `SOCRATICODE_WATCHER=auto`
 - Context artifacts auto-indexed on first `codebase_context_search`
 - Stale artifacts auto-detected and re-indexed
 - Code graph auto-built after indexing
-- Session resume: watcher restarts on first tool use for previously indexed projects
+- Session resume: watcher restarts on first tool use for previously indexed projects in `auto`
+- Snapshot mode: `SOCRATICODE_WATCHER=off` plus `SOCRATICODE_AUTO_RESUME=off` leaves existing code indexes and graphs readable but performs no implicit code-index update, embedding, or graph creation
 
 ### Supported file extensions
 **Built-in:** `.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`, `.py`, `.pyw`, `.pyi`, `.java`, `.kt`, `.kts`, `.scala`, `.c`, `.h`, `.cpp`, `.hpp`, `.cc`, `.hh`, `.cxx`, `.cs`, `.go`, `.rs`, `.rb`, `.php`, `.swift`, `.sh`, `.bash`, `.zsh`, `.html`, `.htm`, `.css`, `.scss`, `.sass`, `.less`, `.styl`, `.vue`, `.svelte`, `.json`, `.yaml`, `.yml`, `.toml`, `.xml`, `.ini`, `.cfg`, `.md`, `.mdx`, `.rst`, `.txt`, `.sql`, `.dart`, `.lua`, `.r`, `.R`, `.dockerfile`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,29 @@ const esmRequire = createRequire(import.meta.url);
 const pkg = esmRequire("../package.json") as { version: string };
 export const SOCRATICODE_VERSION: string = pkg.version;
 
+// ── Indexing lifecycle configuration ───────────────────────────────────
+
+/** File-watcher policy for this MCP process. */
+export type WatcherMode = "auto" | "manual" | "off";
+
+/**
+ * Resolve SOCRATICODE_WATCHER at call time.
+ *
+ * Reading lazily keeps test and embedded-host configuration predictable while
+ * the startup entry point still validates the value before accepting tools.
+ * Unknown values fail loudly: silently restoring automatic writes would break
+ * the user's deliberate snapshot guarantee.
+ */
+export function getWatcherMode(): WatcherMode {
+  const raw = process.env.SOCRATICODE_WATCHER?.trim().toLowerCase() ?? "";
+  if (raw === "" || raw === "auto") return "auto";
+  if (raw === "manual" || raw === "off") return raw;
+  throw new Error(
+    `Invalid SOCRATICODE_WATCHER: "${process.env.SOCRATICODE_WATCHER}". ` +
+    'Must be "auto", "manual", or "off".',
+  );
+}
+
 // ── Embedding configuration ──────────────────────────────────────────────
 // Embedding model and dimensions are now configured via environment variables.
 // See src/services/embedding-config.ts for OLLAMA_MODE, OLLAMA_URL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ import { writeSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { EXTENSION_LANGUAGE_MAP_INVALID, SOCRATICODE_VERSION } from "./constants.js";
+import { EXTENSION_LANGUAGE_MAP_INVALID, getWatcherMode, SOCRATICODE_VERSION } from "./constants.js";
 import { logger, setMcpLogSender } from "./services/logger.js";
 import {
   qdrantClientBreaksOnThisNode,
@@ -55,6 +55,10 @@ import { handleGraphTool } from "./tools/graph-tools.js";
 import { handleIndexTool } from "./tools/index-tools.js";
 import { handleManageTool } from "./tools/manage-tools.js";
 import { handleQueryTool } from "./tools/query-tools.js";
+
+// Validate lifecycle configuration before the server accepts any tools. An
+// invalid manual-mode value must never fall back to automatic index writes.
+getWatcherMode();
 
 const server = new McpServer(
   {
@@ -98,7 +102,7 @@ server.tool(
 
 server.tool(
   "codebase_update",
-  "Incrementally update an existing codebase index. Only re-indexes changed files. Runs synchronously. Usually not needed if file watcher is active.",
+  "Incrementally update an existing codebase index. Only re-indexes changed files. Runs synchronously. Use it to refresh a manual/off snapshot, or whenever an immediate catch-up is needed.",
   {
     projectPath: z
       .string()
@@ -141,7 +145,7 @@ server.tool(
 
 server.tool(
   "codebase_watch",
-  "Start/stop watching a project directory for file changes and automatically update the index. When starting, first runs an incremental update to catch any changes made since the last session, then keeps the index up to date via debounced file system watching.",
+  "Start/stop watching a project directory for file changes and automatically update the index. When starting, first runs an incremental update to catch up, then watches for changes. SOCRATICODE_WATCHER=manual allows explicit starts only; off rejects starts.",
   {
     projectPath: z
       .string()

--- a/src/services/code-graph.ts
+++ b/src/services/code-graph.ts
@@ -143,26 +143,30 @@ export async function getOrBuildGraph(
   projectPath: string,
   extraExtensions?: Set<string>,
 ): Promise<CodeGraph> {
+  const existing = await getExistingGraph(projectPath);
+  if (existing) return existing;
+
   const resolved = path.resolve(projectPath);
-  const cached = graphCache.get(resolved);
-  if (cached) {
-    return cached;
-  }
-
-  // Try loading persisted graph from Qdrant
-  const projectId = projectIdFromPath(resolved);
-  const graphCollName = graphCollectionName(projectId);
-  const persisted = await loadGraphData(graphCollName);
-  if (persisted) {
-    graphCache.set(resolved, persisted);
-    return persisted;
-  }
-
   const graph = await buildCodeGraph(resolved, extraExtensions);
   // Strip symbol fields when serving as a plain CodeGraph
   const plain: CodeGraph = { nodes: graph.nodes, edges: graph.edges };
   graphCache.set(resolved, plain);
   return plain;
+}
+
+/** Get a cached or persisted graph without creating one when it is absent. */
+export async function getExistingGraph(projectPath: string): Promise<CodeGraph | null> {
+  const resolved = path.resolve(projectPath);
+  const cached = graphCache.get(resolved);
+  if (cached) return cached;
+
+  const projectId = projectIdFromPath(resolved);
+  const graphCollName = graphCollectionName(projectId);
+  const persisted = await loadGraphData(graphCollName);
+  if (!persisted) return null;
+
+  graphCache.set(resolved, persisted);
+  return persisted;
 }
 
 /** Options for `rebuildGraph` controlling which layers are rebuilt. */

--- a/src/services/startup.ts
+++ b/src/services/startup.ts
@@ -19,7 +19,7 @@ import { getLockHolderPid, releaseAllLocks } from "./lock.js";
 import { logger } from "./logger.js";
 import { getProjectMetadata, listCodebaseCollections } from "./qdrant.js";
 import { cleanStaleGenerations, coordinateProject, loadSymbolGraphMeta } from "./symbol-graph-store.js";
-import { isWatching, startWatching, stopAllWatchers } from "./watcher.js";
+import { isWatching, startWatchingAutomatically, stopAllWatchers } from "./watcher.js";
 
 /**
  * Auto-resume indexed projects on server startup.
@@ -29,9 +29,11 @@ import { isWatching, startWatching, stopAllWatchers } from "./watcher.js";
  * only the project at process.cwd() is considered.
  *
  *   - SOCRATICODE_AUTO_RESUME_PROJECTS: comma-separated list of project
- *     paths to resume. Takes precedence over SOCRATICODE_AUTO_RESUME.
+ *     paths to resume. Takes precedence over unset/all behavior.
  *   - SOCRATICODE_AUTO_RESUME=all: resume every indexed project that has a
  *     stored path in its Qdrant metadata.
+ *   - SOCRATICODE_AUTO_RESUME=off: skip all startup catch-up and interrupted
+ *     index recovery. This takes precedence over an explicit project list.
  *
  * Multi-project modes resume strictly sequentially: each project's catch-up
  * (incremental update or interrupted-index recovery) completes before the
@@ -53,6 +55,16 @@ import { isWatching, startWatching, stopAllWatchers } from "./watcher.js";
  */
 export async function autoResumeIndexedProjects(projectPath?: string): Promise<void> {
   try {
+    // Read at call time (not module load) so tests and MCP host configs that
+    // set variables after import are honoured. `off` is checked before any
+    // Docker or Qdrant access, and overrides the explicit project list: the
+    // promise is that startup performs no indexing work at all.
+    const resumeMode = process.env.SOCRATICODE_AUTO_RESUME?.trim();
+    if (resumeMode?.toLowerCase() === "off") {
+      logger.info("Auto-resume: disabled by SOCRATICODE_AUTO_RESUME=off");
+      return;
+    }
+
     // In managed mode, check if Docker and Qdrant are already running — don't start them.
     // In external mode, skip Docker checks and let listCodebaseCollections() fail if unreachable.
     if (QDRANT_MODE === "managed") {
@@ -66,10 +78,7 @@ export async function autoResumeIndexedProjects(projectPath?: string): Promise<v
       }
     }
 
-    // Read at call time (not module load) so tests and MCP host configs
-    // that set the variables after import are honoured.
     const explicitList = process.env.SOCRATICODE_AUTO_RESUME_PROJECTS?.trim();
-    const resumeMode = process.env.SOCRATICODE_AUTO_RESUME?.trim();
 
     if (explicitList) {
       await resumeProjectList(explicitList);
@@ -255,7 +264,7 @@ async function resumeProject(
       });
       // Now start the watcher after recovery — only if not cancelled
       if (!result.cancelled && !isWatching(resolvedPath)) {
-        const started = await startWatching(resolvedPath);
+        const started = await startWatchingAutomatically(resolvedPath);
         if (started) {
           logger.info("Auto-resume: started file watcher after recovery", { projectPath: resolvedPath });
         }
@@ -275,7 +284,7 @@ async function resumeProject(
   // is broken for search.
   if (!isWatching(resolvedPath)) {
     try {
-      const started = await startWatching(resolvedPath);
+      const started = await startWatchingAutomatically(resolvedPath);
       if (started) {
         logger.info("Auto-resume: started file watcher", { projectPath: resolvedPath });
       }

--- a/src/services/watcher.ts
+++ b/src/services/watcher.ts
@@ -8,6 +8,7 @@ import watcher from "@parcel/watcher";
 import { collectionName, projectIdFromPath } from "../config.js";
 import {
   EXTENSION_LANGUAGE_MAP,
+  getWatcherMode,
   indexExtensionlessEnabled,
   SPECIAL_FILES,
   SUPPORTED_EXTENSIONS,
@@ -231,6 +232,13 @@ export async function startWatching(
   onProgress?: (message: string) => void,
 ): Promise<boolean> {
   const resolvedPath = path.resolve(projectPath);
+
+  if (getWatcherMode() === "off") {
+    const message = "File watcher disabled by SOCRATICODE_WATCHER=off";
+    onProgress?.(message);
+    logger.info(message, { projectPath: resolvedPath });
+    return false;
+  }
 
   if (subscriptions.has(resolvedPath)) {
     onProgress?.(`Already watching ${resolvedPath}`);
@@ -491,6 +499,19 @@ export async function startWatching(
   }
 }
 
+/**
+ * Start a watcher only when automatic watching is enabled. Manual mode keeps
+ * startWatching available to an explicit codebase_watch start request, while
+ * off mode is also enforced inside startWatching as a final safety boundary.
+ */
+export async function startWatchingAutomatically(
+  projectPath: string,
+  onProgress?: (message: string) => void,
+): Promise<boolean> {
+  if (getWatcherMode() !== "auto") return false;
+  return startWatching(projectPath, onProgress);
+}
+
 /** Stop watching a project directory */
 export async function stopWatching(projectPath: string): Promise<void> {
   const resolvedPath = path.resolve(projectPath);
@@ -560,6 +581,10 @@ export function clearExternalWatchCache(): void {
  */
 export function ensureWatcherStarted(projectPath: string): void {
   const resolvedPath = path.resolve(projectPath);
+
+  // Manual and off modes must not touch Qdrant, acquire the watch lock, or
+  // create a native subscription in response to an unrelated tool call.
+  if (getWatcherMode() !== "auto") return;
 
   // Already watching in this process — nothing to do
   if (subscriptions.has(resolvedPath)) return;

--- a/src/tools/graph-tools.ts
+++ b/src/tools/graph-tools.ts
@@ -2,8 +2,8 @@
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 import path from "node:path";
 import { projectIdFromPath } from "../config.js";
-import { mergeExtraExtensions, SOCRATICODE_VERSION } from "../constants.js";
-import { awaitGraphBuild, describeGraphBuilder, ensureDynamicLanguages, findCircularDependencies, generateMermaidDiagram, getAstGrepLang, getDynamicLanguageStatus, getFileDependencies, getGraphBuildProgress, getGraphStats, getGraphStatus, getLastGraphBuildCompleted, getOrBuildGraph, isGraphBuildInProgress, isImportResolutionLow, rebuildGraph, removeGraph } from "../services/code-graph.js";
+import { getWatcherMode, mergeExtraExtensions, SOCRATICODE_VERSION } from "../constants.js";
+import { awaitGraphBuild, describeGraphBuilder, ensureDynamicLanguages, findCircularDependencies, generateMermaidDiagram, getAstGrepLang, getDynamicLanguageStatus, getExistingGraph, getFileDependencies, getGraphBuildProgress, getGraphStats, getGraphStatus, getLastGraphBuildCompleted, getOrBuildGraph, isGraphBuildInProgress, isImportResolutionLow, rebuildGraph, removeGraph } from "../services/code-graph.js";
 import { detectEntryPoints } from "../services/graph-entrypoints.js";
 import {
   type FlowNode,
@@ -38,6 +38,26 @@ const SYMBOL_GRAPH_TOOLS = new Set([
   "codebase_symbol",
   "codebase_symbols",
 ]);
+
+class ExplicitGraphBuildRequiredError extends Error {}
+
+/**
+ * Default mode keeps the historical lazy-build behaviour. Snapshot modes may
+ * read a cached or persisted graph, but must not create one as a side effect of
+ * a query.
+ */
+async function getGraphForRead(projectPath: string) {
+  const watcherMode = getWatcherMode();
+  if (watcherMode === "auto") return getOrBuildGraph(projectPath);
+
+  const graph = await getExistingGraph(projectPath);
+  if (graph) return graph;
+  throw new ExplicitGraphBuildRequiredError(
+    `No code graph found for: ${projectPath}\n` +
+    `Automatic graph creation is disabled by SOCRATICODE_WATCHER=${watcherMode}. ` +
+    "Run codebase_graph_build to create it explicitly.",
+  );
+}
 
 function hasRelevantGrammarFailure(
   failed: Array<{ name: string }>,
@@ -74,6 +94,7 @@ export async function handleGraphTool(
         result,
       ].join("\n");
     } catch (err) {
+      if (err instanceof ExplicitGraphBuildRequiredError) return err.message;
       if (
         err instanceof SymbolGraphGenerationChangedError
         && SYMBOL_GRAPH_TOOLS.has(name)
@@ -151,7 +172,7 @@ async function dispatchGraphTool(
 
     case "codebase_graph_query": {
       const filePath = args.filePath as string;
-      const graph = await getOrBuildGraph(projectPath);
+      const graph = await getGraphForRead(projectPath);
       const deps = getFileDependencies(graph, filePath);
 
       const lines = [`Dependencies for: ${filePath}\n`];
@@ -179,7 +200,7 @@ async function dispatchGraphTool(
     }
 
     case "codebase_graph_stats": {
-      const graph = await getOrBuildGraph(projectPath);
+      const graph = await getGraphForRead(projectPath);
 
       if (graph.nodes.length === 0) {
         return "No graph data available. Run codebase_graph_build first.";
@@ -222,7 +243,7 @@ async function dispatchGraphTool(
     }
 
     case "codebase_graph_circular": {
-      const graph = await getOrBuildGraph(projectPath);
+      const graph = await getGraphForRead(projectPath);
       const cycles = findCircularDependencies(graph);
 
       if (cycles.length === 0) {
@@ -241,7 +262,7 @@ async function dispatchGraphTool(
     }
 
     case "codebase_graph_visualize": {
-      const graph = await getOrBuildGraph(projectPath);
+      const graph = await getGraphForRead(projectPath);
 
       if (graph.nodes.length === 0) {
         return "No graph data available. Run codebase_graph_build first.";
@@ -526,7 +547,7 @@ async function dispatchGraphTool(
         try {
           // Build a fresh detection using the file graph + per-file payloads from the cache.
           // For efficiency we only list entry points by walking known symbols via the name index.
-          const fileGraph = await getOrBuildGraph(projectPath);
+          const fileGraph = await getGraphForRead(projectPath);
           const nameIndex = await cache.getNameIndex(readerToken);
           const seenFiles = new Set<string>();
           const payloads = [];

--- a/src/tools/index-tools.ts
+++ b/src/tools/index-tools.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 import path from "node:path";
 import { collectionName, projectIdFromPath } from "../config.js";
-import { mergeExtraExtensions, QDRANT_MODE } from "../constants.js";
+import { getWatcherMode, mergeExtraExtensions, QDRANT_MODE } from "../constants.js";
 import { awaitGraphBuild, isGraphBuildInProgress } from "../services/code-graph.js";
 import type { InfraProgressCallback } from "../services/docker.js";
 import { ensureQdrantReady, isDockerAvailable } from "../services/docker.js";
@@ -11,7 +11,7 @@ import { getIndexingProgress, indexProject, isIndexingInProgress, removeProjectI
 import { isProjectLocked, terminateLockHolder } from "../services/lock.js";
 import { logger } from "../services/logger.js";
 import { loadEffectiveIndexProfileForCollection } from "../services/qdrant.js";
-import { getWatchedProjects, isWatching, startWatching, stopWatching } from "../services/watcher.js";
+import { getWatchedProjects, isWatching, startWatching, startWatchingAutomatically, stopWatching } from "../services/watcher.js";
 
 const DOCKER_NOT_AVAILABLE_MESSAGE = [
   "❌ Docker is not available.",
@@ -142,7 +142,7 @@ export async function handleIndexTool(
 
           // Auto-start watcher only if indexing completed (not cancelled)
           if (!result.cancelled && !isWatching(resolved)) {
-            const started = await startWatching(resolved);
+            const started = await startWatchingAutomatically(resolved);
             if (started) {
               logger.info("Auto-started file watcher", { projectPath: resolved });
             }
@@ -194,7 +194,7 @@ export async function handleIndexTool(
 
       // Auto-start watcher after successful update (not cancelled)
       if (!result.cancelled && !isWatching(resolved)) {
-        const started = await startWatching(resolved);
+        const started = await startWatchingAutomatically(resolved);
         if (started) {
           logger.info("Auto-started file watcher after update", { projectPath: resolved });
         }
@@ -344,8 +344,16 @@ export async function handleIndexTool(
 
     case "codebase_watch": {
       const action = args.action as string;
+      const watcherMode = getWatcherMode();
 
       if (action === "start") {
+        if (watcherMode === "off") {
+          return [
+            "File watcher disabled by SOCRATICODE_WATCHER=off.",
+            "Set SOCRATICODE_WATCHER=manual or auto and restart the MCP server before starting it.",
+          ].join("\n");
+        }
+
         await ensureInfrastructure(projectPath);
 
         // Catch any changes made while the watcher was not running before starting it.
@@ -389,14 +397,36 @@ export async function handleIndexTool(
       const resolved = path.resolve(projectPath);
       // Check if the current project is watched by another process (cross-process lock)
       const watchedByOtherProcess = !watched.includes(resolved) && await isProjectLocked(resolved, "watch");
+
+      if (watcherMode === "off") {
+        const lines = ["File watcher: disabled (SOCRATICODE_WATCHER=off)"];
+        if (watched.includes(resolved)) {
+          lines.push(
+            "Warning: this process still has an active watcher. Restart the MCP server to apply the changed environment setting.",
+          );
+        } else if (watchedByOtherProcess) {
+          lines.push(
+            "Warning: another MCP process is still watching this project. Set SOCRATICODE_WATCHER=off for every process that uses this checkout.",
+          );
+        }
+        return lines.join("\n");
+      }
+
       if (watched.length === 0 && !watchedByOtherProcess) {
+        if (watcherMode === "manual") {
+          return [
+            "No projects are currently being watched.",
+            "Automatic watcher startup is disabled by SOCRATICODE_WATCHER=manual; use codebase_watch with action=start to start it explicitly.",
+          ].join("\n");
+        }
         return "No projects are currently being watched.";
       }
       const statusItems = watched.map((p) => `  - ${p}`);
       if (watchedByOtherProcess) {
         statusItems.push(`  - ${resolved} (watched by another process)`);
       }
-      return `Currently watching:\n${statusItems.join("\n")}`;
+      const modeLine = watcherMode === "manual" ? "\nWatcher mode: manual (started explicitly)" : "";
+      return `Currently watching:\n${statusItems.join("\n")}${modeLine}`;
     }
 
     default:

--- a/src/tools/query-tools.ts
+++ b/src/tools/query-tools.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 import path from "node:path";
 import { collectionName, projectIdFromPath, resolveLinkedCollections } from "../config.js";
+import type { WatcherMode } from "../constants.js";
 import { getWatcherMode, SEARCH_DEFAULT_LIMIT, SEARCH_MIN_SCORE, SOCRATICODE_VERSION } from "../constants.js";
 import { getGraphStatus, isGraphBuilderStale } from "../services/code-graph.js";
 import { getArtifactStatusSummary } from "../services/context-artifacts.js";
@@ -53,6 +54,66 @@ function formatProgressLines(progress: IndexingProgress): {
   return { elapsed, pct, progressLine, batchLine, graphLine };
 }
 
+/** Append the current watcher policy and activity state to a tool response. */
+async function appendWatcherState(
+  lines: string[],
+  resolvedPath: string,
+  watcherMode: WatcherMode,
+  context: "search" | "status",
+): Promise<void> {
+  const watchedHere = isWatching(resolvedPath);
+  const watchedAnywhere = watchedHere || await isWatchedByAnyProcess(resolvedPath);
+  const watcherLines: string[] = [];
+
+  if (context === "search") {
+    if (watcherMode === "off") {
+      if (watchedHere) {
+        watcherLines.push("⚠ WARNING: File watching is disabled in this process, but this process still has an active watcher.");
+        watcherLines.push("  Restart the MCP server to apply the changed environment setting.");
+      } else if (watchedAnywhere) {
+        watcherLines.push("⚠ WARNING: File watching is disabled in this process, but another active watcher can still update the shared index.");
+        watcherLines.push("  Set SOCRATICODE_WATCHER=off for every MCP process that uses this checkout.");
+      } else {
+        watcherLines.push("ℹ INDEX SNAPSHOT: File watching is disabled by SOCRATICODE_WATCHER=off.");
+        watcherLines.push("  Results reflect the last explicit codebase_index or codebase_update.");
+      }
+    } else if (watcherMode === "manual") {
+      if (!watchedAnywhere) {
+        watcherLines.push("ℹ INDEX SNAPSHOT: Automatic file watching is disabled by SOCRATICODE_WATCHER=manual.");
+        watcherLines.push("  Run codebase_update to refresh, or start the watcher explicitly with codebase_watch.");
+      } else if (!watchedHere) {
+        watcherLines.push("ℹ NOTE: Another MCP process is watching this project, so the shared index may still update automatically.");
+      }
+    } else if (!watchedAnywhere) {
+      watcherLines.push("⚠ WARNING: File watcher is not yet active for this project. Results may be stale.");
+      watcherLines.push("  The watcher is being started automatically. Run codebase_update to force an immediate catch-up.");
+    }
+  } else if (watcherMode === "off") {
+    watcherLines.push("File watcher: disabled (SOCRATICODE_WATCHER=off)");
+    if (watchedHere) {
+      watcherLines.push("  Warning: this process still has an active watcher. Restart the MCP server to apply the changed environment setting.");
+    } else if (watchedAnywhere) {
+      watcherLines.push("  Warning: another MCP process is watching this project. Set SOCRATICODE_WATCHER=off for every process that uses this checkout.");
+    }
+  } else if (watchedHere) {
+    watcherLines.push(watcherMode === "manual"
+      ? "File watcher: active (started explicitly; SOCRATICODE_WATCHER=manual)"
+      : "File watcher: active (auto-updating on changes)");
+  } else if (watchedAnywhere) {
+    watcherLines.push(watcherMode === "manual"
+      ? "File watcher: active (watched by another process; automatic startup disabled here)"
+      : "File watcher: active (watched by another process)");
+  } else {
+    watcherLines.push(watcherMode === "manual"
+      ? "File watcher: inactive (SOCRATICODE_WATCHER=manual; start explicitly or run codebase_update to refresh)"
+      : "File watcher: inactive");
+  }
+
+  if (watcherLines.length > 0) {
+    lines.push("", ...watcherLines);
+  }
+}
+
 export async function handleQueryTool(
   name: string,
   args: Record<string, unknown>,
@@ -92,10 +153,20 @@ export async function handleQueryTool(
       const filteredCount = allResults.length - results.length;
 
       if (results.length === 0) {
+        const lines: string[] = [];
         if (filteredCount > 0) {
-          return `No results above score threshold ${minScore.toFixed(2)} for "${query}" in project ${resolvedPath}.\n${filteredCount} result${filteredCount === 1 ? " was" : "s were"} below the threshold. Try a broader query or lower the minScore parameter.`;
+          lines.push(
+            `No results above score threshold ${minScore.toFixed(2)} for "${query}" in project ${resolvedPath}.`,
+            `${filteredCount} result${filteredCount === 1 ? " was" : "s were"} below the threshold. Try a broader query or lower the minScore parameter.`,
+          );
+        } else {
+          lines.push(
+            `No results found for "${query}" in project ${resolvedPath}.`,
+            "Make sure the project has been indexed first using codebase_index.",
+          );
         }
-        return `No results found for "${query}" in project ${resolvedPath}.\nMake sure the project has been indexed first using codebase_index.`;
+        await appendWatcherState(lines, resolvedPath, watcherMode, "search");
+        return lines.join("\n");
       }
 
       const lines = [`Search results for "${query}" (${results.length} matches):\n`];
@@ -114,27 +185,7 @@ export async function handleQueryTool(
         }
       }
 
-      const watchedHere = isWatching(resolvedPath);
-      const watchedAnywhere = watchedHere || await isWatchedByAnyProcess(resolvedPath);
-      if (watcherMode === "off") {
-        if (watchedAnywhere) {
-          lines.push("⚠ WARNING: File watching is disabled in this process, but another active watcher can still update the shared index.");
-          lines.push("  Set SOCRATICODE_WATCHER=off for every MCP process that uses this checkout.\n");
-        } else {
-          lines.push("ℹ INDEX SNAPSHOT: File watching is disabled by SOCRATICODE_WATCHER=off.");
-          lines.push("  Results reflect the last explicit codebase_index or codebase_update.\n");
-        }
-      } else if (watcherMode === "manual") {
-        if (!watchedAnywhere) {
-          lines.push("ℹ INDEX SNAPSHOT: Automatic file watching is disabled by SOCRATICODE_WATCHER=manual.");
-          lines.push("  Run codebase_update to refresh, or start the watcher explicitly with codebase_watch.\n");
-        } else if (!watchedHere) {
-          lines.push("ℹ NOTE: Another MCP process is watching this project, so the shared index may still update automatically.\n");
-        }
-      } else if (!watchedAnywhere) {
-        lines.push("\u26a0 WARNING: File watcher is not yet active for this project. Results may be stale.");
-        lines.push("  The watcher is being started automatically. Run codebase_update to force an immediate catch-up.\n");
-      }
+      await appendWatcherState(lines, resolvedPath, watcherMode, "search");
 
       for (const r of results) {
         const projectTag = r.project ? ` [${r.project}]` : "";
@@ -159,7 +210,7 @@ export async function handleQueryTool(
           const progress = getIndexingProgress(resolvedPath);
           if (progress) {
             const { elapsed, progressLine, batchLine, graphLine } = formatProgressLines(progress);
-            return [
+            const lines = [
               `Project: ${resolvedPath}`,
               "",
               `\u26a0 ${progress.type === "full-index" ? "Full index" : "Incremental update"} in progress`,
@@ -171,10 +222,14 @@ export async function handleQueryTool(
               graphLine,
               "",
               "Qdrant is starting up. Keep calling codebase_status to check progress.",
-            ].join("\n");
+            ];
+            await appendWatcherState(lines, resolvedPath, watcherMode, "status");
+            return lines.join("\n");
           }
         }
-        return "Qdrant is not available. Run codebase_index first to set up infrastructure.";
+        const lines = ["Qdrant is not available. Run codebase_index first to set up infrastructure."];
+        await appendWatcherState(lines, resolvedPath, watcherMode, "status");
+        return lines.join("\n");
       }
 
       const info = await getCollectionInfo(collection);
@@ -185,7 +240,7 @@ export async function handleQueryTool(
           const progress = getIndexingProgress(resolvedPath);
           if (progress) {
             const { elapsed, progressLine, batchLine, graphLine } = formatProgressLines(progress);
-            return [
+            const lines = [
               `Project: ${resolvedPath}`,
               "",
               `\u26a0 ${progress.type === "full-index" ? "Full index" : "Incremental update"} in progress`,
@@ -197,10 +252,17 @@ export async function handleQueryTool(
               graphLine,
               "",
               "Index is being created. Keep calling codebase_status to check progress.",
-            ].join("\n");
+            ];
+            await appendWatcherState(lines, resolvedPath, watcherMode, "status");
+            return lines.join("\n");
           }
         }
-        return `No index found for project: ${resolvedPath}\nRun codebase_index to create one.`;
+        const lines = [
+          `No index found for project: ${resolvedPath}`,
+          "Run codebase_index to create one.",
+        ];
+        await appendWatcherState(lines, resolvedPath, watcherMode, "status");
+        return lines.join("\n");
       }
 
       const metadata = await getProjectMetadata(collection);
@@ -291,32 +353,7 @@ export async function handleQueryTool(
         }
       }
 
-      const watchedHere = isWatching(resolvedPath);
-      const watchedAnywhere = watchedHere || await isWatchedByAnyProcess(resolvedPath);
-      if (watcherMode === "off") {
-        statusLines.push("");
-        statusLines.push("File watcher: disabled (SOCRATICODE_WATCHER=off)");
-        if (watchedHere) {
-          statusLines.push("  Warning: this process still has an active watcher. Restart the MCP server to apply the changed environment setting.");
-        } else if (watchedAnywhere) {
-          statusLines.push("  Warning: another MCP process is watching this project. Set SOCRATICODE_WATCHER=off for every process that uses this checkout.");
-        }
-      } else if (watchedHere) {
-        statusLines.push("");
-        statusLines.push(watcherMode === "manual"
-          ? "File watcher: active (started explicitly; SOCRATICODE_WATCHER=manual)"
-          : "File watcher: active (auto-updating on changes)");
-      } else if (watchedAnywhere) {
-        statusLines.push("");
-        statusLines.push(watcherMode === "manual"
-          ? "File watcher: active (watched by another process; automatic startup disabled here)"
-          : "File watcher: active (watched by another process)");
-      } else {
-        statusLines.push("");
-        statusLines.push(watcherMode === "manual"
-          ? "File watcher: inactive (SOCRATICODE_WATCHER=manual; start explicitly or run codebase_update to refresh)"
-          : "File watcher: inactive");
-      }
+      await appendWatcherState(statusLines, resolvedPath, watcherMode, "status");
 
       // Graph status
       try {

--- a/src/tools/query-tools.ts
+++ b/src/tools/query-tools.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 import path from "node:path";
 import { collectionName, projectIdFromPath, resolveLinkedCollections } from "../config.js";
-import { SEARCH_DEFAULT_LIMIT, SEARCH_MIN_SCORE, SOCRATICODE_VERSION } from "../constants.js";
+import { getWatcherMode, SEARCH_DEFAULT_LIMIT, SEARCH_MIN_SCORE, SOCRATICODE_VERSION } from "../constants.js";
 import { getGraphStatus, isGraphBuilderStale } from "../services/code-graph.js";
 import { getArtifactStatusSummary } from "../services/context-artifacts.js";
 import { ensureQdrantReady } from "../services/docker.js";
@@ -61,6 +61,7 @@ export async function handleQueryTool(
   const resolvedPath = path.resolve(projectPath);
   const projectId = projectIdFromPath(resolvedPath);
   const collection = collectionName(projectId);
+  const watcherMode = getWatcherMode();
 
   // Auto-start watcher on any query/status interaction (fire-and-forget)
   ensureWatcherStarted(resolvedPath);
@@ -113,7 +114,24 @@ export async function handleQueryTool(
         }
       }
 
-      if (!(await isWatchedByAnyProcess(resolvedPath))) {
+      const watchedHere = isWatching(resolvedPath);
+      const watchedAnywhere = watchedHere || await isWatchedByAnyProcess(resolvedPath);
+      if (watcherMode === "off") {
+        if (watchedAnywhere) {
+          lines.push("⚠ WARNING: File watching is disabled in this process, but another active watcher can still update the shared index.");
+          lines.push("  Set SOCRATICODE_WATCHER=off for every MCP process that uses this checkout.\n");
+        } else {
+          lines.push("ℹ INDEX SNAPSHOT: File watching is disabled by SOCRATICODE_WATCHER=off.");
+          lines.push("  Results reflect the last explicit codebase_index or codebase_update.\n");
+        }
+      } else if (watcherMode === "manual") {
+        if (!watchedAnywhere) {
+          lines.push("ℹ INDEX SNAPSHOT: Automatic file watching is disabled by SOCRATICODE_WATCHER=manual.");
+          lines.push("  Run codebase_update to refresh, or start the watcher explicitly with codebase_watch.\n");
+        } else if (!watchedHere) {
+          lines.push("ℹ NOTE: Another MCP process is watching this project, so the shared index may still update automatically.\n");
+        }
+      } else if (!watchedAnywhere) {
         lines.push("\u26a0 WARNING: File watcher is not yet active for this project. Results may be stale.");
         lines.push("  The watcher is being started automatically. Run codebase_update to force an immediate catch-up.\n");
       }
@@ -273,15 +291,31 @@ export async function handleQueryTool(
         }
       }
 
-      if (isWatching(resolvedPath)) {
+      const watchedHere = isWatching(resolvedPath);
+      const watchedAnywhere = watchedHere || await isWatchedByAnyProcess(resolvedPath);
+      if (watcherMode === "off") {
         statusLines.push("");
-        statusLines.push("File watcher: active (auto-updating on changes)");
-      } else if (await isWatchedByAnyProcess(resolvedPath)) {
+        statusLines.push("File watcher: disabled (SOCRATICODE_WATCHER=off)");
+        if (watchedHere) {
+          statusLines.push("  Warning: this process still has an active watcher. Restart the MCP server to apply the changed environment setting.");
+        } else if (watchedAnywhere) {
+          statusLines.push("  Warning: another MCP process is watching this project. Set SOCRATICODE_WATCHER=off for every process that uses this checkout.");
+        }
+      } else if (watchedHere) {
         statusLines.push("");
-        statusLines.push("File watcher: active (watched by another process)");
+        statusLines.push(watcherMode === "manual"
+          ? "File watcher: active (started explicitly; SOCRATICODE_WATCHER=manual)"
+          : "File watcher: active (auto-updating on changes)");
+      } else if (watchedAnywhere) {
+        statusLines.push("");
+        statusLines.push(watcherMode === "manual"
+          ? "File watcher: active (watched by another process; automatic startup disabled here)"
+          : "File watcher: active (watched by another process)");
       } else {
         statusLines.push("");
-        statusLines.push("File watcher: inactive");
+        statusLines.push(watcherMode === "manual"
+          ? "File watcher: inactive (SOCRATICODE_WATCHER=manual; start explicitly or run codebase_update to refresh)"
+          : "File watcher: inactive");
       }
 
       // Graph status

--- a/tests/integration/manual-indexing-mode.test.ts
+++ b/tests/integration/manual-indexing-mode.test.ts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+import fs from "node:fs";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { collectionName, projectIdFromPath } from "../../src/config.js";
+import {
+  getGraphStatus,
+  invalidateGraphCache,
+} from "../../src/services/code-graph.js";
+import { loadProjectHashes } from "../../src/services/qdrant.js";
+import { autoResumeIndexedProjects } from "../../src/services/startup.js";
+import {
+  isWatching,
+  stopAllWatchers,
+} from "../../src/services/watcher.js";
+import { handleGraphTool } from "../../src/tools/graph-tools.js";
+import { handleIndexTool } from "../../src/tools/index-tools.js";
+import { handleQueryTool } from "../../src/tools/query-tools.js";
+import {
+  addFileToFixture,
+  createFixtureProject,
+  type FixtureProject,
+  isDockerAvailable,
+} from "../helpers/fixtures.js";
+import { fullIndexOperationState } from "../helpers/index-status.js";
+import {
+  cleanupTestCollections,
+  waitForOllama,
+  waitForQdrant,
+} from "../helpers/setup.js";
+
+const dockerAvailable = isDockerAvailable();
+
+async function waitForIndexingComplete(
+  projectPath: string,
+  timeoutMs = 180_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const status = await handleQueryTool("codebase_status", { projectPath });
+    const operationState = fullIndexOperationState(status);
+    if (operationState === "completed") return;
+    if (operationState === "failed") {
+      throw new Error(`Full indexing failed:\n${status}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`Indexing did not complete within ${timeoutMs}ms`);
+}
+
+async function waitForGraphComplete(
+  projectPath: string,
+  timeoutMs = 90_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const status = await handleGraphTool("codebase_graph_status", { projectPath });
+    if (status.includes("READY")) return;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Graph build did not complete within ${timeoutMs}ms`);
+}
+
+async function waitForIndexedFile(
+  collection: string,
+  relativePath: string,
+  timeoutMs = 90_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if ((await loadProjectHashes(collection))?.has(relativePath)) return;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`${relativePath} was not indexed within ${timeoutMs}ms`);
+}
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+describe.skipIf(!dockerAvailable)(
+  "manual indexing mode",
+  { timeout: 600_000 },
+  () => {
+    let fixture: FixtureProject;
+    let collection: string;
+    const originalWatcherMode = process.env.SOCRATICODE_WATCHER;
+    const originalAutoResume = process.env.SOCRATICODE_AUTO_RESUME;
+    const originalAutoResumeProjects = process.env.SOCRATICODE_AUTO_RESUME_PROJECTS;
+
+    beforeAll(async () => {
+      if (!(await waitForQdrant())) throw new Error("Qdrant did not become ready");
+      if (!(await waitForOllama())) throw new Error("Ollama did not become ready");
+
+      fixture = createFixtureProject("manual-indexing-mode");
+      // macOS reports native watcher events through /private/var while
+      // os.tmpdir() returns /var. Use one canonical path for both sides so
+      // the production out-of-tree guard sees fixture events as in-tree.
+      fixture.root = fs.realpathSync(fixture.root);
+      collection = collectionName(projectIdFromPath(fixture.root));
+      await cleanupTestCollections(fixture.root);
+
+      process.env.SOCRATICODE_WATCHER = "off";
+      process.env.SOCRATICODE_AUTO_RESUME = "off";
+      process.env.SOCRATICODE_AUTO_RESUME_PROJECTS = fixture.root;
+    }, 120_000);
+
+    afterAll(async () => {
+      await stopAllWatchers();
+      if (fixture) {
+        invalidateGraphCache(fixture.root);
+        await cleanupTestCollections(fixture.root);
+        fixture.cleanup();
+      }
+      restoreEnvironment("SOCRATICODE_WATCHER", originalWatcherMode);
+      restoreEnvironment("SOCRATICODE_AUTO_RESUME", originalAutoResume);
+      restoreEnvironment("SOCRATICODE_AUTO_RESUME_PROJECTS", originalAutoResumeProjects);
+    });
+
+    it("keeps the index and graph deliberate while preserving explicit operations", async () => {
+      const indexResult = await handleIndexTool("codebase_index", {
+        projectPath: fixture.root,
+      });
+      expect(indexResult).toContain("Indexing started");
+      await waitForIndexingComplete(fixture.root);
+      expect(isWatching(fixture.root)).toBe(false);
+
+      const unindexedPath = "src/manual-only.ts";
+      addFileToFixture(
+        fixture.root,
+        unindexedPath,
+        "export const manualOnlyCheckpoint = 'not indexed implicitly';\n",
+      );
+
+      const status = await handleQueryTool("codebase_status", {
+        projectPath: fixture.root,
+      });
+      expect(status).toContain("File watcher: disabled (SOCRATICODE_WATCHER=off)");
+
+      const search = await handleQueryTool("codebase_search", {
+        projectPath: fixture.root,
+        query: "authentication user login",
+      });
+      expect(search).toContain("INDEX SNAPSHOT");
+
+      const blockedWatch = await handleIndexTool("codebase_watch", {
+        projectPath: fixture.root,
+        action: "start",
+      });
+      expect(blockedWatch).toContain("File watcher disabled by SOCRATICODE_WATCHER=off");
+
+      // Tool use and the watch debounce window must not make a snapshot write.
+      await new Promise((resolve) => setTimeout(resolve, 3_000));
+      expect((await loadProjectHashes(collection))?.has(unindexedPath)).toBe(false);
+      expect(isWatching(fixture.root)).toBe(false);
+
+      const resumeDisabledPath = "src/resume-disabled.ts";
+      addFileToFixture(
+        fixture.root,
+        resumeDisabledPath,
+        "export const startupResumeIsDisabled = true;\n",
+      );
+      await autoResumeIndexedProjects(fixture.root);
+      await new Promise((resolve) => setTimeout(resolve, 3_000));
+      expect((await loadProjectHashes(collection))?.has(resumeDisabledPath)).toBe(false);
+      expect(isWatching(fixture.root)).toBe(false);
+
+      process.env.SOCRATICODE_WATCHER = "manual";
+      const updateResult = await handleIndexTool("codebase_update", {
+        projectPath: fixture.root,
+      });
+      expect(updateResult).toContain("Added: 2");
+      const hashesAfterUpdate = await loadProjectHashes(collection);
+      expect(hashesAfterUpdate?.has(unindexedPath)).toBe(true);
+      expect(hashesAfterUpdate?.has(resumeDisabledPath)).toBe(true);
+      expect(isWatching(fixture.root)).toBe(false);
+
+      const existingGraph = await handleGraphTool("codebase_graph_stats", {
+        projectPath: fixture.root,
+      });
+      expect(existingGraph).toContain("Code Graph Statistics");
+
+      await handleGraphTool("codebase_graph_remove", {
+        projectPath: fixture.root,
+      });
+      expect(await getGraphStatus(fixture.root)).toBeNull();
+
+      const graphQuery = await handleGraphTool("codebase_graph_stats", {
+        projectPath: fixture.root,
+      });
+      expect(graphQuery).toContain("Automatic graph creation is disabled");
+      expect(graphQuery).toContain("Run codebase_graph_build");
+      expect(await getGraphStatus(fixture.root)).toBeNull();
+
+      const graphBuild = await handleGraphTool("codebase_graph_build", {
+        projectPath: fixture.root,
+      });
+      expect(graphBuild).toContain("Graph build started in the background");
+      await waitForGraphComplete(fixture.root);
+      expect(await getGraphStatus(fixture.root)).not.toBeNull();
+      expect(isWatching(fixture.root)).toBe(false);
+
+      const manualWatch = await handleIndexTool("codebase_watch", {
+        projectPath: fixture.root,
+        action: "start",
+      });
+      expect(manualWatch).toContain("Started watching");
+      expect(isWatching(fixture.root)).toBe(true);
+
+      // Give the native backend time to establish its initial snapshot before
+      // creating the event whose incremental update is under test.
+      await new Promise((resolve) => setTimeout(resolve, 750));
+      const watchedPath = "src/explicit-manual-watch.ts";
+      addFileToFixture(
+        fixture.root,
+        watchedPath,
+        "export const explicitlyWatchedChange = true;\n",
+      );
+      await waitForIndexedFile(collection, watchedPath);
+
+      await handleIndexTool("codebase_watch", {
+        projectPath: fixture.root,
+        action: "stop",
+      });
+      expect(isWatching(fixture.root)).toBe(false);
+    }, 540_000);
+  },
+);

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CHUNK_OVERLAP,
   CHUNK_SIZE,
   detectExtensionlessExtension,
   getLanguageFromExtension,
+  getWatcherMode,
   INDEX_BATCH_SIZE,
   indexExtensionlessEnabled,
   MAX_AVG_LINE_LENGTH,
@@ -34,6 +35,35 @@ import {
 } from "../../src/constants.js";
 
 describe("constants", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("watcher mode", () => {
+    it("defaults to auto when SOCRATICODE_WATCHER is unset or empty", () => {
+      vi.stubEnv("SOCRATICODE_WATCHER", undefined);
+      expect(getWatcherMode()).toBe("auto");
+      vi.stubEnv("SOCRATICODE_WATCHER", "   ");
+      expect(getWatcherMode()).toBe("auto");
+    });
+
+    it("accepts auto, manual, and off case-insensitively", () => {
+      vi.stubEnv("SOCRATICODE_WATCHER", " AUTO ");
+      expect(getWatcherMode()).toBe("auto");
+      vi.stubEnv("SOCRATICODE_WATCHER", " Manual ");
+      expect(getWatcherMode()).toBe("manual");
+      vi.stubEnv("SOCRATICODE_WATCHER", " OFF ");
+      expect(getWatcherMode()).toBe("off");
+    });
+
+    it("rejects unknown values instead of silently enabling automatic writes", () => {
+      vi.stubEnv("SOCRATICODE_WATCHER", "disabled");
+      expect(() => getWatcherMode()).toThrow(
+        'Invalid SOCRATICODE_WATCHER: "disabled". Must be "auto", "manual", or "off".',
+      );
+    });
+  });
+
   describe("Qdrant configuration", () => {
     it("has default port 16333", () => {
       expect(QDRANT_PORT).toBe(16333);

--- a/tests/unit/query-tools.test.ts
+++ b/tests/unit/query-tools.test.ts
@@ -31,7 +31,11 @@ import type { SearchResult } from "../../src/types.js";
 
 const mockSearchChunks = vi.fn(async (_collection: string, _query: string, _limit: number): Promise<SearchResult[]> => []);
 const mockSearchMultipleCollections = vi.fn(async (): Promise<SearchResult[]> => []);
-const mockGetCollectionInfo = vi.fn(async () => ({ pointsCount: 0, status: "green" }));
+const mockGetCollectionInfo = vi.fn(async (): Promise<{
+  pointsCount: number;
+  status: string;
+  denseVectorSize?: number;
+} | null> => ({ pointsCount: 0, status: "green" }));
 const mockGetProjectMetadata = vi.fn(async () => null);
 const mockLoadProjectEffectiveProfile = vi.fn(async (): Promise<EffectiveIndexProfile | null> => null);
 
@@ -105,7 +109,10 @@ vi.mock("../../src/constants.js", async (importOriginal) => {
 
 // ── Imports (after mocks) ────────────────────────────────────────────────
 
+import { ensureQdrantReady } from "../../src/services/docker.js";
 import { handleQueryTool } from "../../src/tools/query-tools.js";
+
+const mockEnsureQdrantReady = vi.mocked(ensureQdrantReady);
 
 // ── Tests ────────────────────────────────────────────────────────────────
 
@@ -147,6 +154,35 @@ describe("manual indexing watcher status", () => {
     expect(output).toContain("last explicit codebase_index or codebase_update");
   });
 
+  it("labels an empty search as a deliberate snapshot when watching is off", async () => {
+    process.env.SOCRATICODE_WATCHER = "off";
+    mockSearchChunks.mockResolvedValueOnce([]);
+
+    const output = await handleQueryTool("codebase_search", {
+      projectPath: TEST_PATH,
+      query: "missing",
+    });
+
+    expect(output).toContain("No results found");
+    expect(output).toContain("INDEX SNAPSHOT");
+    expect(output).toContain("last explicit codebase_index or codebase_update");
+  });
+
+  it("labels below-threshold search results as a manual snapshot", async () => {
+    process.env.SOCRATICODE_WATCHER = "manual";
+    mockSearchChunks.mockResolvedValueOnce([{ ...SEARCH_RESULT, score: 0.01 }]);
+
+    const output = await handleQueryTool("codebase_search", {
+      projectPath: TEST_PATH,
+      query: "weak match",
+      minScore: 0.5,
+    });
+
+    expect(output).toContain("No results above score threshold");
+    expect(output).toContain("INDEX SNAPSHOT");
+    expect(output).toContain("SOCRATICODE_WATCHER=manual");
+  });
+
   it("does not tell agents to auto-start the watcher in manual mode", async () => {
     process.env.SOCRATICODE_WATCHER = "manual";
     mockSearchChunks.mockResolvedValueOnce([SEARCH_RESULT]);
@@ -175,6 +211,21 @@ describe("manual indexing watcher status", () => {
     expect(output).toContain("for every MCP process");
   });
 
+  it("requires a restart when this process still watches after switching to off", async () => {
+    process.env.SOCRATICODE_WATCHER = "off";
+    mockSearchChunks.mockResolvedValueOnce([SEARCH_RESULT]);
+    mockIsWatching.mockReturnValueOnce(true);
+
+    const output = await handleQueryTool("codebase_search", {
+      projectPath: TEST_PATH,
+      query: "value",
+    });
+
+    expect(output).toContain("this process still has an active watcher");
+    expect(output).toContain("Restart the MCP server");
+    expect(output).not.toContain("another active watcher");
+  });
+
   it("reports off as disabled rather than inactive", async () => {
     process.env.SOCRATICODE_WATCHER = "off";
 
@@ -195,6 +246,30 @@ describe("manual indexing watcher status", () => {
 
     expect(output).toContain("File watcher: inactive (SOCRATICODE_WATCHER=manual");
     expect(output).toContain("codebase_update to refresh");
+  });
+
+  it("reports off mode when Qdrant is unavailable", async () => {
+    process.env.SOCRATICODE_WATCHER = "off";
+    mockEnsureQdrantReady.mockRejectedValueOnce(new Error("Qdrant unavailable"));
+
+    const output = await handleQueryTool("codebase_status", {
+      projectPath: TEST_PATH,
+    });
+
+    expect(output).toContain("Qdrant is not available");
+    expect(output).toContain("File watcher: disabled (SOCRATICODE_WATCHER=off)");
+  });
+
+  it("reports manual mode when the project has no index", async () => {
+    process.env.SOCRATICODE_WATCHER = "manual";
+    mockGetCollectionInfo.mockResolvedValueOnce(null);
+
+    const output = await handleQueryTool("codebase_status", {
+      projectPath: TEST_PATH,
+    });
+
+    expect(output).toContain("No index found for project");
+    expect(output).toContain("File watcher: inactive (SOCRATICODE_WATCHER=manual");
   });
 });
 

--- a/tests/unit/query-tools.test.ts
+++ b/tests/unit/query-tools.test.ts
@@ -4,7 +4,7 @@
 /** Unit tests for query-tool routing and result formatting. */
 
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 
@@ -80,10 +80,14 @@ vi.mock("../../src/services/context-artifacts.js", () => ({
 
 // ── watcher.js mock ──────────────────────────────────────────────────────
 
+const mockEnsureWatcherStarted = vi.fn();
+const mockIsWatching = vi.fn(() => false);
+const mockIsWatchedByAnyProcess = vi.fn(async () => false);
+
 vi.mock("../../src/services/watcher.js", () => ({
-  ensureWatcherStarted: vi.fn(),
-  isWatching: vi.fn(() => false),
-  isWatchedByAnyProcess: vi.fn(async () => false),
+  ensureWatcherStarted: (...args: unknown[]) => mockEnsureWatcherStarted(...args),
+  isWatching: (...args: unknown[]) => mockIsWatching(...args),
+  isWatchedByAnyProcess: (...args: unknown[]) => mockIsWatchedByAnyProcess(...args),
 }));
 
 // ── lock.js mock ─────────────────────────────────────────────────────────
@@ -106,6 +110,93 @@ import { handleQueryTool } from "../../src/tools/query-tools.js";
 // ── Tests ────────────────────────────────────────────────────────────────
 
 const TEST_PATH = "/tmp/test-project";
+const SEARCH_RESULT: SearchResult = {
+  filePath: "/tmp/test-project/src/index.ts",
+  relativePath: "src/index.ts",
+  content: "export const value = 1;",
+  startLine: 1,
+  endLine: 1,
+  language: "typescript",
+  score: 0.5,
+};
+
+afterEach(() => {
+  delete process.env.SOCRATICODE_WATCHER;
+  mockIsWatching.mockReturnValue(false);
+  mockIsWatchedByAnyProcess.mockResolvedValue(false);
+});
+
+describe("manual indexing watcher status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCollectionInfo.mockResolvedValue({ pointsCount: 3, status: "green" });
+    mockGetProjectMetadata.mockResolvedValue(null);
+    mockLoadProjectEffectiveProfile.mockResolvedValue(null);
+  });
+
+  it("labels search results as a deliberate snapshot when watching is off", async () => {
+    process.env.SOCRATICODE_WATCHER = "off";
+    mockSearchChunks.mockResolvedValueOnce([SEARCH_RESULT]);
+
+    const output = await handleQueryTool("codebase_search", {
+      projectPath: TEST_PATH,
+      query: "value",
+    });
+
+    expect(output).toContain("INDEX SNAPSHOT");
+    expect(output).toContain("last explicit codebase_index or codebase_update");
+  });
+
+  it("does not tell agents to auto-start the watcher in manual mode", async () => {
+    process.env.SOCRATICODE_WATCHER = "manual";
+    mockSearchChunks.mockResolvedValueOnce([SEARCH_RESULT]);
+
+    const output = await handleQueryTool("codebase_search", {
+      projectPath: TEST_PATH,
+      query: "value",
+    });
+
+    expect(output).toContain("SOCRATICODE_WATCHER=manual");
+    expect(output).toContain("Run codebase_update to refresh");
+    expect(output).not.toContain("being started automatically");
+  });
+
+  it("warns when another process can still update an off-mode shared index", async () => {
+    process.env.SOCRATICODE_WATCHER = "off";
+    mockSearchChunks.mockResolvedValueOnce([SEARCH_RESULT]);
+    mockIsWatchedByAnyProcess.mockResolvedValueOnce(true);
+
+    const output = await handleQueryTool("codebase_search", {
+      projectPath: TEST_PATH,
+      query: "value",
+    });
+
+    expect(output).toContain("another active watcher");
+    expect(output).toContain("for every MCP process");
+  });
+
+  it("reports off as disabled rather than inactive", async () => {
+    process.env.SOCRATICODE_WATCHER = "off";
+
+    const output = await handleQueryTool("codebase_status", {
+      projectPath: TEST_PATH,
+    });
+
+    expect(output).toContain("File watcher: disabled (SOCRATICODE_WATCHER=off)");
+    expect(output).not.toContain("File watcher: inactive");
+  });
+
+  it("reports manual mode with the explicit actions that can refresh it", async () => {
+    process.env.SOCRATICODE_WATCHER = "manual";
+
+    const output = await handleQueryTool("codebase_status", {
+      projectPath: TEST_PATH,
+    });
+
+    expect(output).toContain("File watcher: inactive (SOCRATICODE_WATCHER=manual");
+    expect(output).toContain("codebase_update to refresh");
+  });
+});
 
 // ── includeLinked tests ──────────────────────────────────────────────────
 

--- a/tests/unit/remove-tools.test.ts
+++ b/tests/unit/remove-tools.test.ts
@@ -10,7 +10,7 @@
  * All external services are mocked — no Docker required.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 
@@ -48,6 +48,8 @@ vi.mock("../../src/services/indexer.js", () => ({
 const mockIsGraphBuildInProgress = vi.fn((_path: string) => false);
 const mockAwaitGraphBuild = vi.fn(async (_path: string) => {});
 const mockRemoveGraph = vi.fn(async (_path: string) => {});
+const mockGetExistingGraph = vi.fn(async () => null);
+const mockGetOrBuildGraph = vi.fn(async () => ({ nodes: [], edges: [] }));
 
 vi.mock("../../src/services/code-graph.js", () => ({
   isGraphBuildInProgress: (...args: unknown[]) => mockIsGraphBuildInProgress(...(args as [string])),
@@ -61,7 +63,8 @@ vi.mock("../../src/services/code-graph.js", () => ({
   getGraphStats: vi.fn(),
   getGraphStatus: vi.fn(async () => null),
   getLastGraphBuildCompleted: vi.fn(() => null),
-  getOrBuildGraph: vi.fn(async () => ({ nodes: [], edges: [] })),
+  getExistingGraph: (...args: unknown[]) => mockGetExistingGraph(...args),
+  getOrBuildGraph: (...args: unknown[]) => mockGetOrBuildGraph(...args),
   rebuildGraph: vi.fn(async () => ({ nodes: [], edges: [] })),
 }));
 
@@ -69,19 +72,24 @@ vi.mock("../../src/services/code-graph.js", () => ({
 
 const mockIsWatching = vi.fn((_path: string) => false);
 const mockStopWatching = vi.fn(async (_path: string) => {});
+const mockStartWatching = vi.fn(async () => true);
+const mockStartWatchingAutomatically = vi.fn(async () => true);
 
 vi.mock("../../src/services/watcher.js", () => ({
   isWatching: (...args: unknown[]) => mockIsWatching(...(args as [string])),
   stopWatching: (...args: unknown[]) => mockStopWatching(...(args as [string])),
-  startWatching: vi.fn(async () => true),
+  startWatching: (...args: unknown[]) => mockStartWatching(...args),
+  startWatchingAutomatically: (...args: unknown[]) => mockStartWatchingAutomatically(...args),
   getWatchedProjects: vi.fn(() => []),
   ensureWatcherStarted: vi.fn(),
 }));
 
 // ── docker.js mock ──────────────────────────────────────────────────────
 
+const mockEnsureQdrantReady = vi.fn(async () => ({ pulled: false, started: false }));
+
 vi.mock("../../src/services/docker.js", () => ({
-  ensureQdrantReady: vi.fn(async () => ({ pulled: false, started: false })),
+  ensureQdrantReady: (...args: unknown[]) => mockEnsureQdrantReady(...args),
   isDockerAvailable: vi.fn(async () => true),
 }));
 
@@ -94,6 +102,15 @@ vi.mock("../../src/services/embedding-config.js", () => ({
 vi.mock("../../src/services/embedding-provider.js", () => ({
   getEmbeddingProvider: vi.fn(async () => ({
     ensureReady: async () => ({ imagePulled: false, containerStarted: false, modelPulled: false }),
+  })),
+}));
+
+vi.mock("../../src/services/index-profile.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ensureEffectiveEmbeddingReady: vi.fn(async () => ({
+    imagePulled: false,
+    containerStarted: false,
+    modelPulled: false,
   })),
 }));
 
@@ -124,6 +141,9 @@ vi.mock("../../src/services/context-artifacts.js", () => ({
 vi.mock("../../src/services/qdrant.js", () => ({
   getCollectionInfo: vi.fn(async () => null),
   loadContextMetadata: vi.fn(async () => null),
+  loadEffectiveIndexProfileForCollection: vi.fn(async () => ({
+    embedding: { provider: "ollama", model: "test", dimensions: 3 },
+  })),
 }));
 
 // ── ollama.js mock ──────────────────────────────────────────────────────
@@ -136,6 +156,7 @@ vi.mock("../../src/services/ollama.js", () => ({
 
 vi.mock("../../src/config.js", () => ({
   projectIdFromPath: vi.fn(() => "test-project-id"),
+  collectionName: vi.fn(() => "codebase_test-project-id"),
   contextCollectionName: vi.fn(() => "context_test"),
 }));
 
@@ -155,6 +176,76 @@ import { handleIndexTool } from "../../src/tools/index-tools.js";
 // ── Tests ────────────────────────────────────────────────────────────────
 
 const TEST_PATH = "/tmp/test-project";
+
+describe("manual indexing mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.SOCRATICODE_WATCHER;
+  });
+
+  afterEach(() => {
+    delete process.env.SOCRATICODE_WATCHER;
+  });
+
+  it("rejects codebase_watch start in off mode before infrastructure or catch-up work", async () => {
+    process.env.SOCRATICODE_WATCHER = "off";
+
+    const result = await handleIndexTool("codebase_watch", {
+      projectPath: TEST_PATH,
+      action: "start",
+    });
+
+    expect(result).toContain("File watcher disabled by SOCRATICODE_WATCHER=off");
+    expect(mockEnsureQdrantReady).not.toHaveBeenCalled();
+    expect(mockUpdateProjectIndex).not.toHaveBeenCalled();
+    expect(mockStartWatching).not.toHaveBeenCalled();
+  });
+
+  it("does not lazily build a missing graph in manual mode", async () => {
+    process.env.SOCRATICODE_WATCHER = "manual";
+    mockGetExistingGraph.mockResolvedValueOnce(null);
+
+    const result = await handleGraphTool("codebase_graph_stats", {
+      projectPath: TEST_PATH,
+    });
+
+    expect(result).toContain("Automatic graph creation is disabled");
+    expect(result).toContain("codebase_graph_build");
+    expect(mockGetExistingGraph).toHaveBeenCalledWith(TEST_PATH);
+    expect(mockGetOrBuildGraph).not.toHaveBeenCalled();
+  });
+
+  it("preserves lazy graph creation in the default mode", async () => {
+    await handleGraphTool("codebase_graph_stats", {
+      projectPath: TEST_PATH,
+    });
+
+    expect(mockGetOrBuildGraph).toHaveBeenCalledWith(TEST_PATH);
+    expect(mockGetExistingGraph).not.toHaveBeenCalled();
+  });
+
+  it("preserves post-update automatic watcher startup in the default mode", async () => {
+    const result = await handleIndexTool("codebase_update", {
+      projectPath: TEST_PATH,
+    });
+
+    expect(result).toContain("Updated project index");
+    expect(mockStartWatchingAutomatically).toHaveBeenCalledWith(TEST_PATH);
+    expect(mockStartWatching).not.toHaveBeenCalled();
+  });
+
+  it("preserves post-index automatic watcher startup in the default mode", async () => {
+    const result = await handleIndexTool("codebase_index", {
+      projectPath: TEST_PATH,
+    });
+
+    expect(result).toContain("Indexing started in the background");
+    await vi.waitFor(() => {
+      expect(mockStartWatchingAutomatically).toHaveBeenCalledWith(TEST_PATH);
+    });
+    expect(mockStartWatching).not.toHaveBeenCalled();
+  });
+});
 
 describe("codebase_remove — stops all in-flight operations before deleting", () => {
   beforeEach(() => {

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -33,7 +33,7 @@ vi.mock("../../src/services/lock.js", () => ({
 
 vi.mock("../../src/services/watcher.js", () => ({
   isWatching: vi.fn().mockReturnValue(false),
-  startWatching: vi.fn().mockResolvedValue(true),
+  startWatchingAutomatically: vi.fn().mockResolvedValue(true),
   stopAllWatchers: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -62,7 +62,7 @@ import { getLockHolderPid, releaseAllLocks } from "../../src/services/lock.js";
 import { logger } from "../../src/services/logger.js";
 import { getProjectMetadata, listCodebaseCollections } from "../../src/services/qdrant.js";
 import { autoResumeIndexedProjects, awaitActiveIndexing, gracefulShutdown } from "../../src/services/startup.js";
-import { isWatching, startWatching, stopAllWatchers } from "../../src/services/watcher.js";
+import { isWatching, startWatchingAutomatically, stopAllWatchers } from "../../src/services/watcher.js";
 
 // Typed mock helpers
 const mockIsDockerAvailable = vi.mocked(isDockerAvailable);
@@ -76,7 +76,7 @@ const mockGetIndexingInProgress = vi.mocked(getIndexingInProgressProjects);
 const mockRequestCancellation = vi.mocked(requestCancellation);
 const mockGetLockHolderPid = vi.mocked(getLockHolderPid);
 const mockIsWatching = vi.mocked(isWatching);
-const mockStartWatching = vi.mocked(startWatching);
+const mockStartWatchingAutomatically = vi.mocked(startWatchingAutomatically);
 const mockStopAllWatchers = vi.mocked(stopAllWatchers);
 const mockReleaseAllLocks = vi.mocked(releaseAllLocks);
 
@@ -98,6 +98,24 @@ beforeEach(() => {
 // ── autoResumeIndexedProjects ────────────────────────────────────────────
 
 describe("autoResumeIndexedProjects", () => {
+  it("SOCRATICODE_AUTO_RESUME=off exits before infrastructure access and overrides a project list", async () => {
+    process.env.SOCRATICODE_AUTO_RESUME = " OFF ";
+    process.env.SOCRATICODE_AUTO_RESUME_PROJECTS = TEST_PROJECT;
+
+    await autoResumeIndexedProjects(TEST_PROJECT);
+
+    expect(mockIsDockerAvailable).not.toHaveBeenCalled();
+    expect(mockIsQdrantRunning).not.toHaveBeenCalled();
+    expect(mockListCollections).not.toHaveBeenCalled();
+    expect(mockGetPersistedStatus).not.toHaveBeenCalled();
+    expect(mockIndexProject).not.toHaveBeenCalled();
+    expect(mockUpdateProjectIndex).not.toHaveBeenCalled();
+    expect(mockStartWatchingAutomatically).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      "Auto-resume: disabled by SOCRATICODE_AUTO_RESUME=off",
+    );
+  });
+
   it("skips when Docker is not available (managed mode)", async () => {
     mockIsDockerAvailable.mockResolvedValue(false);
 
@@ -208,7 +226,7 @@ describe("autoResumeIndexedProjects", () => {
     await autoResumeIndexedProjects(TEST_PROJECT);
 
     await vi.waitFor(() => {
-      expect(mockStartWatching).toHaveBeenCalledWith(TEST_PROJECT);
+      expect(mockStartWatchingAutomatically).toHaveBeenCalledWith(TEST_PROJECT);
     });
   });
 
@@ -224,7 +242,7 @@ describe("autoResumeIndexedProjects", () => {
 
     // Give the .then() time to fire
     await new Promise((r) => setTimeout(r, 50));
-    expect(mockStartWatching).not.toHaveBeenCalled();
+    expect(mockStartWatchingAutomatically).not.toHaveBeenCalled();
   });
 
   it("starts watcher and runs incremental update for completed index", async () => {
@@ -237,7 +255,7 @@ describe("autoResumeIndexedProjects", () => {
 
     await autoResumeIndexedProjects(TEST_PROJECT);
 
-    expect(mockStartWatching).toHaveBeenCalledWith(TEST_PROJECT);
+    expect(mockStartWatchingAutomatically).toHaveBeenCalledWith(TEST_PROJECT);
     expect(mockUpdateProjectIndex).toHaveBeenCalledWith(TEST_PROJECT);
 
     await vi.waitFor(() => {
@@ -276,7 +294,7 @@ describe("autoResumeIndexedProjects", () => {
 
     await autoResumeIndexedProjects(TEST_PROJECT);
 
-    expect(mockStartWatching).not.toHaveBeenCalled();
+    expect(mockStartWatchingAutomatically).not.toHaveBeenCalled();
   });
 
   it("handles updateProjectIndex failure gracefully for completed index", async () => {
@@ -357,7 +375,7 @@ describe("autoResumeIndexedProjects (multi-project modes)", () => {
     mockListCollections.mockResolvedValue([collA, collB]);
     mockGetPersistedStatus.mockResolvedValue("completed");
     mockIsWatching.mockReturnValue(false);
-    mockStartWatching.mockResolvedValue(true);
+    mockStartWatchingAutomatically.mockResolvedValue(true);
     mockUpdateProjectIndex.mockResolvedValue(noChanges);
   });
 
@@ -393,14 +411,14 @@ describe("autoResumeIndexedProjects (multi-project modes)", () => {
     // The whole point of sequential resume: B has not been touched while A's
     // update is still in flight.
     expect(mockUpdateProjectIndex).not.toHaveBeenCalledWith(dirB);
-    expect(mockStartWatching).not.toHaveBeenCalledWith(dirB);
+    expect(mockStartWatchingAutomatically).not.toHaveBeenCalledWith(dirB);
 
     resolveA(noChanges);
     await run;
 
     expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirB);
-    expect(mockStartWatching).toHaveBeenCalledWith(dirA);
-    expect(mockStartWatching).toHaveBeenCalledWith(dirB);
+    expect(mockStartWatchingAutomatically).toHaveBeenCalledWith(dirA);
+    expect(mockStartWatchingAutomatically).toHaveBeenCalledWith(dirB);
   });
 
   it("skips list entries whose directory does not exist, with a warning, and resumes the rest", async () => {
@@ -556,7 +574,7 @@ describe("autoResumeIndexedProjects (multi-project modes)", () => {
 
   it("still runs the incremental catch-up when watcher startup throws", async () => {
     process.env.SOCRATICODE_AUTO_RESUME_PROJECTS = dirA;
-    mockStartWatching.mockRejectedValue(new Error("inotify limit reached"));
+    mockStartWatchingAutomatically.mockRejectedValue(new Error("inotify limit reached"));
 
     await autoResumeIndexedProjects();
 
@@ -580,7 +598,7 @@ describe("autoResumeIndexedProjects (multi-project modes)", () => {
       expect.objectContaining({ value: "yes" }),
     );
     // Default behavior still runs for the provided (cwd) project.
-    expect(mockStartWatching).toHaveBeenCalledWith(dirA);
+    expect(mockStartWatchingAutomatically).toHaveBeenCalledWith(dirA);
     expect(mockUpdateProjectIndex).toHaveBeenCalledWith(dirA);
   });
 });

--- a/tests/unit/watcher.test.ts
+++ b/tests/unit/watcher.test.ts
@@ -89,6 +89,7 @@ import {
   isWatchedByAnyProcess,
   isWatching,
   startWatching,
+  startWatchingAutomatically,
   stopAllWatchers,
   stopWatching,
 } from "../../src/services/watcher.js";
@@ -103,6 +104,7 @@ const RESOLVED_PROJECT = path.resolve(TEST_PROJECT);
 describe("watcher (unit)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.SOCRATICODE_WATCHER;
     mockSubscribeCallback = null;
     mockAcquireProjectLock.mockResolvedValue(true);
     mockIsProjectLocked.mockResolvedValue(false);
@@ -116,11 +118,33 @@ describe("watcher (unit)", () => {
     // Clean up any active watchers between tests
     await stopAllWatchers();
     clearExternalWatchCache();
+    delete process.env.SOCRATICODE_WATCHER;
   });
 
   // ── startWatching / stopWatching / isWatching / getWatchedProjects ───
 
   describe("startWatching", () => {
+    it("refuses to start before acquiring a lock when watcher mode is off", async () => {
+      process.env.SOCRATICODE_WATCHER = "off";
+      const progress: string[] = [];
+
+      const result = await startWatching(TEST_PROJECT, (msg) => progress.push(msg));
+
+      expect(result).toBe(false);
+      expect(progress).toContain("File watcher disabled by SOCRATICODE_WATCHER=off");
+      expect(mockAcquireProjectLock).not.toHaveBeenCalled();
+      const watcher = await import("@parcel/watcher");
+      expect(watcher.default.subscribe).not.toHaveBeenCalled();
+    });
+
+    it("still permits an explicit start in manual mode", async () => {
+      process.env.SOCRATICODE_WATCHER = "manual";
+
+      await expect(startWatching(TEST_PROJECT)).resolves.toBe(true);
+
+      expect(isWatching(TEST_PROJECT)).toBe(true);
+    });
+
     it("starts watching and reports via onProgress", async () => {
       const progress: string[] = [];
       const result = await startWatching(TEST_PROJECT, (msg) => progress.push(msg));
@@ -1030,7 +1054,33 @@ describe("watcher (unit)", () => {
 
   // ── ensureWatcherStarted ───────────────────────────────────────────────
 
+  describe("startWatchingAutomatically", () => {
+    it("preserves automatic startup when the mode is unset", async () => {
+      await expect(startWatchingAutomatically(TEST_PROJECT)).resolves.toBe(true);
+      expect(isWatching(TEST_PROJECT)).toBe(true);
+    });
+
+    it.each(["manual", "off"])("does no watcher work in %s mode", async (mode) => {
+      process.env.SOCRATICODE_WATCHER = mode;
+
+      await expect(startWatchingAutomatically(TEST_PROJECT)).resolves.toBe(false);
+
+      expect(mockAcquireProjectLock).not.toHaveBeenCalled();
+      const watcher = await import("@parcel/watcher");
+      expect(watcher.default.subscribe).not.toHaveBeenCalled();
+    });
+  });
+
   describe("ensureWatcherStarted", () => {
+    it.each(["manual", "off"])("returns before storage access in %s mode", (mode) => {
+      process.env.SOCRATICODE_WATCHER = mode;
+
+      ensureWatcherStarted(TEST_PROJECT);
+
+      expect(mockGetCollectionInfo).not.toHaveBeenCalled();
+      expect(mockAcquireProjectLock).not.toHaveBeenCalled();
+    });
+
     it("does nothing if already watching", async () => {
       await startWatching(TEST_PROJECT);
       mockGetCollectionInfo.mockClear();


### PR DESCRIPTION
Closes #148

## Summary

- add `SOCRATICODE_WATCHER=auto|manual|off`, preserving automatic behavior by default, allowing explicit watcher starts in `manual`, and rejecting every watcher start in `off`
- add `SOCRATICODE_AUTO_RESUME=off`, checked before startup infrastructure or persisted-index access
- keep existing indexes and graphs readable in snapshot modes while preventing graph queries from creating a missing graph implicitly
- make search and status output describe deliberate snapshots and cross-process watcher conflicts clearly
- document the configuration in the README, developer guide, and shipped skills

## Backward compatibility

- unset configuration preserves the existing automatic watcher and startup-resume behavior
- existing indexes and graphs remain usable without a re-index
- no storage schema, index profile, dependency, or tool-argument change
- explicit `codebase_index`, `codebase_update`, and `codebase_graph_build` behavior remains available

## Validation

- `npm run lint`
- `npm run build`
- `npm run test:unit` (1,853 tests)
- affected TypeScript and unit tests under Node 18.17.0 (265 tests)
- integration and E2E suites against real Qdrant and Ollama services (177 tests; Docker-managed lifecycle test excluded)
- real MCP stdio initialization and tool-list smoke test in `off`/`off` mode
- invalid watcher-mode startup failure smoke test
- local CodeRabbit review of the committed diff: zero findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added watcher modes: `auto`, `manual`, and `off`.
  - Manual mode supports explicit updates while preventing automatic watcher startup.
  - Off mode disables watcher startup entirely.
  - Added snapshot mode to prevent automatic resume, indexing, embedding, and graph creation.
  - Graph tools now require an explicit graph build when no graph exists in manual or snapshot modes.

- **Bug Fixes**
  - Invalid watcher settings are rejected during startup.
  - Status and search results now accurately describe watcher activity and snapshot state.

- **Documentation**
  - Updated setup, troubleshooting, FAQ, and tool guidance for watcher and snapshot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->