### PR TITLE
ci: update actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     name: Lint & Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -30,8 +30,8 @@ jobs:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -42,8 +42,8 @@ jobs:
     name: Node 18.17 Consumer Install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 18.17.0
           cache: npm
@@ -76,8 +76,8 @@ jobs:
     name: Rust graph vs cargo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -23,9 +23,9 @@ jobs:
       run:
         working-directory: extension
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -50,7 +50,7 @@ jobs:
         run: npm run package
 
       - name: Upload .vsix artefact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: socraticode-vsix
           path: extension/*.vsix

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -19,9 +19,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -57,7 +57,7 @@ jobs:
 
       - name: Upload .vsix to GitHub release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: extension/*.vsix
           fail_on_unmatched_files: false


### PR DESCRIPTION
## Summary

- update checkout and setup-node actions to their Node 24-based major versions
- update artifact upload and GitHub release actions to their Node 24-based major versions
- preserve the Node 18.17 consumer-install check and Node 18/20/22 test matrix

## Validation

- workflow YAML parses successfully
- existing action inputs remain supported by the updated majors
- root lint, build, and full test suite pass
- extension lint, typecheck, tests, compile, and VSIX packaging pass
- local CodeRabbit review passes with zero findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated automated build, testing, artifact, and extension release workflows to use newer action versions.
  - Kept existing workflow steps and configuration unchanged.
  - No user-facing features or behavior were changed; these updates apply only to project automation and release processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->