### PR TITLE
fix(qdrant): support Node 26 without dropping Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 26]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -41,6 +41,11 @@ jobs:
   node-floor-consumer-install:
     name: Node 18.17 Consumer Install
     runs-on: ubuntu-latest
+    services:
+      qdrant:
+        image: qdrant/qdrant:v1.17.0
+        ports:
+          - 6333:6333
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -53,6 +58,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          qdrant_ready=false
+          for attempt in {1..30}; do
+            if curl -fsS http://127.0.0.1:6333/healthz >/dev/null; then
+              qdrant_ready=true
+              break
+            fi
+            sleep 1
+          done
+          test "$qdrant_ready" = true
+          repo_dir="$PWD"
           consumer_dir="$(mktemp -d)"
           npm pack --pack-destination "$consumer_dir"
           package_file="$(find "$consumer_dir" -maxdepth 1 -type f -name 'socraticode-*.tgz' -print -quit)"
@@ -61,6 +76,51 @@ jobs:
           npm init --yes
           npm install --engine-strict "$package_file"
           test -f node_modules/socraticode/dist/index.js
+          SOCRATICODE_AUTO_RESUME=off node node_modules/socraticode/dist/index.js < /dev/null
+          QDRANT_MODE=external QDRANT_URL=http://127.0.0.1:6333 \
+            node "$repo_dir/scripts/verify-packaged-qdrant.mjs" "$consumer_dir/node_modules/socraticode"
+
+  node-26-consumer-qdrant:
+    name: Node 26 Packaged Qdrant Smoke
+    runs-on: ubuntu-latest
+    services:
+      qdrant:
+        image: qdrant/qdrant:v1.17.0
+        ports:
+          - 6333:6333
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 26
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Verify the unmodified package against Qdrant on Node 26
+        shell: bash
+        run: |
+          set -euo pipefail
+          qdrant_ready=false
+          for attempt in {1..30}; do
+            if curl -fsS http://127.0.0.1:6333/healthz >/dev/null; then
+              qdrant_ready=true
+              break
+            fi
+            sleep 1
+          done
+          test "$qdrant_ready" = true
+          repo_dir="$PWD"
+          consumer_dir="$(mktemp -d)"
+          npm pack --pack-destination "$consumer_dir"
+          package_file="$(find "$consumer_dir" -maxdepth 1 -type f -name 'socraticode-*.tgz' -print -quit)"
+          test -n "$package_file"
+          cd "$consumer_dir"
+          npm init --yes
+          npm install --engine-strict "$package_file"
+          test -f node_modules/socraticode/dist/index.js
+          SOCRATICODE_AUTO_RESUME=off node node_modules/socraticode/dist/index.js < /dev/null
+          QDRANT_MODE=external QDRANT_HOST=127.0.0.1 QDRANT_PORT=6333 \
+            node "$repo_dir/scripts/verify-packaged-qdrant.mjs" "$consumer_dir/node_modules/socraticode"
 
   # The one test that asks the compiler instead of asserting what we believe.
   # It lives under tests/integration/ because it runs a real `cargo check`, and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           set -euo pipefail
           qdrant_ready=false
           for attempt in {1..30}; do
-            if curl -fsS http://127.0.0.1:6333/healthz >/dev/null; then
+            if curl --connect-timeout 1 --max-time 2 -fsS http://127.0.0.1:6333/healthz >/dev/null; then
               qdrant_ready=true
               break
             fi
@@ -102,7 +102,7 @@ jobs:
           set -euo pipefail
           qdrant_ready=false
           for attempt in {1..30}; do
-            if curl -fsS http://127.0.0.1:6333/healthz >/dev/null; then
+            if curl --connect-timeout 1 --max-time 2 -fsS http://127.0.0.1:6333/healthz >/dev/null; then
               qdrant_ready=true
               break
             fi

--- a/scripts/verify-packaged-qdrant.mjs
+++ b/scripts/verify-packaged-qdrant.mjs
@@ -4,6 +4,8 @@
 
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import http from "node:http";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -11,8 +13,80 @@ const packageRoot = process.argv[2];
 assert(packageRoot, "Usage: verify-packaged-qdrant.mjs <installed-socraticode-directory>");
 
 const packageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
+const packageRequire = createRequire(path.join(packageRoot, "package.json"));
 const serviceUrl = (name) =>
   pathToFileURL(path.join(packageRoot, "dist", "services", `${name}.js`)).href;
+
+/** Wait for a predicate without leaving an unbounded integration check. */
+async function waitUntil(predicate, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return predicate();
+}
+
+/**
+ * Prove that the Node 26 transport bridge preserves Qdrant's request timeout
+ * through response-body reads and releases the stalled server connection.
+ */
+async function verifyTimeoutCancellation(compatibility) {
+  const { QdrantClient, QdrantClientTimeoutError } = packageRequire(
+    "@qdrant/js-client-rest",
+  );
+  const sockets = new Set();
+  let requestReceived = false;
+  const server = http.createServer((_request, response) => {
+    requestReceived = true;
+    response.writeHead(200, {
+      "content-type": "application/json",
+      "content-length": "1000000",
+    });
+    response.write('{"result":');
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    assert(address && typeof address !== "string", "The timeout probe did not bind a port");
+    const url = `http://127.0.0.1:${address.port}`;
+    compatibility.ensureQdrantClientCompatibility(url);
+
+    const client = new QdrantClient({ url, timeout: 100, checkCompatibility: false });
+    const startedAt = Date.now();
+    let failure;
+    try {
+      await client.getCollections();
+    } catch (error) {
+      failure = error;
+    }
+    const elapsedMs = Date.now() - startedAt;
+
+    assert(requestReceived, "The timeout probe did not reach the stalled response handler");
+    assert(
+      failure instanceof QdrantClientTimeoutError,
+      `Expected QdrantClientTimeoutError, received ${failure?.constructor?.name ?? "no error"}`,
+    );
+    assert(elapsedMs < 2_000, `The timed-out request settled after ${elapsedMs}ms`);
+    assert(
+      await waitUntil(() => sockets.size === 0, 8_000),
+      "The timed-out Qdrant request left its server connection open",
+    );
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
 
 const compatibility = await import(serviceUrl("qdrant-client-compat"));
 const qdrantClientVersion = compatibility.readInstalledQdrantClientVersion();
@@ -26,12 +100,18 @@ const { listCodebaseCollections } = await import(serviceUrl("qdrant"));
 const collections = await listCodebaseCollections();
 assert(Array.isArray(collections), "The packaged Qdrant request did not return a collection list");
 
+const nodeMajor = Number.parseInt(process.versions.node.split(".")[0], 10);
+if (nodeMajor >= 26) {
+  await verifyTimeoutCancellation(compatibility);
+}
+
 process.stdout.write(
   `${JSON.stringify({
     node: process.versions.node,
     socraticode: packageJson.version,
     qdrantClient: qdrantClientVersion,
     qdrantRequest: "passed",
+    timeoutCancellation: nodeMajor >= 26 ? "passed" : "not-applicable",
   })}\n`,
 );
 process.exit(0);

--- a/scripts/verify-packaged-qdrant.mjs
+++ b/scripts/verify-packaged-qdrant.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const packageRoot = process.argv[2];
+assert(packageRoot, "Usage: verify-packaged-qdrant.mjs <installed-socraticode-directory>");
+
+const packageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
+const serviceUrl = (name) =>
+  pathToFileURL(path.join(packageRoot, "dist", "services", `${name}.js`)).href;
+
+const compatibility = await import(serviceUrl("qdrant-client-compat"));
+const qdrantClientVersion = compatibility.readInstalledQdrantClientVersion();
+assert.match(
+  qdrantClientVersion ?? "",
+  /^1\.18\./,
+  "The consumer smoke test must exercise the declared Qdrant 1.18 dependency without substitution",
+);
+
+const { listCodebaseCollections } = await import(serviceUrl("qdrant"));
+const collections = await listCodebaseCollections();
+assert(Array.isArray(collections), "The packaged Qdrant request did not return a collection list");
+
+process.stdout.write(
+  `${JSON.stringify({
+    node: process.versions.node,
+    socraticode: packageJson.version,
+    qdrantClient: qdrantClientVersion,
+    qdrantRequest: "passed",
+  })}\n`,
+);
+process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,53 +2,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 
-// Pre-flight: refuse to start on the PAIR known to break — Node 26+ with
-// @qdrant/js-client-rest older than 1.19. Those clients bundle undici 6, whose Agent
-// (handed to Node's built-in fetch as init.dispatcher) fails Node 26's undici-8 handler
-// validation, so every qdrant call dies with `UND_ERR_INVALID_ARG: invalid onError
-// method`. Upstream fixed this in client 1.19 by moving to undici 7
-// (https://github.com/qdrant/qdrant-js/issues/134), verified working on Node 26 against a
-// live Qdrant, so Node 26+ with client >= 1.19 starts normally; a fresh install resolves
-// a >= 1.19 client on Node 26 and never sees this refusal. The refusal remains for stale
-// installs (an old lockfile pinning a pre-1.19 client) and for an undeterminable client
-// version, where booting would trade this message for the opaque undici error later.
-//
-// This runtime guard is deliberately the ONLY gate. Do NOT add an upper bound to
-// `engines.node` in package.json. An upper bound is actively harmful here: a bare
-// `npx socraticode` install resolves a version range, and npm engine-filters that range,
-// so a `<26.0.0` bound makes Node 26 silently resolve to the newest version *below* the
-// bound (which predates this guard) and boot into the broken client instead of refusing.
-//
-// (Imports below are evaluated before this check per ESM semantics, but qdrant-js's
-// module-init is side-effect-light: only an actual request triggers the undici path, so
-// exiting here is enough to spare users the opaque error later.)
-const nodeMajor = Number.parseInt(process.versions.node.split(".")[0], 10);
-const installedClient = readInstalledQdrantClientVersion();
-if (qdrantClientBreaksOnThisNode(nodeMajor, installedClient)) {
-  // fs.writeSync(2, …) is the canonical Node idiom for "print fatal error then die":
-  // blocking (no truncation when stderr is piped — every MCP host pipes stderr) and
-  // synchronous (so process.exit(1) runs before any further top-level code).
-  const msg =
-    `socraticode: Node ${process.versions.node} needs @qdrant/js-client-rest 1.19 or newer ` +
-    `(installed: ${installedClient ?? "undeterminable"}).\n` +
-    "  Clients before 1.19 bundle an undici incompatible with Node 26+.\n" +
-    "  Reinstall socraticode (or update its lockfile) to pick up a current client,\n" +
-    "  or use Node 22.x (via nvm: `nvm install 22 && nvm use 22`).\n" +
-    "  See https://github.com/qdrant/qdrant-js/issues/134.\n";
-  writeSync(2, msg);
-  process.exit(1);
-}
-
-import { writeSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { EXTENSION_LANGUAGE_MAP_INVALID, getWatcherMode, SOCRATICODE_VERSION } from "./constants.js";
 import { logger, setMcpLogSender } from "./services/logger.js";
-import {
-  qdrantClientBreaksOnThisNode,
-  readInstalledQdrantClientVersion,
-} from "./services/qdrant-client-compat.js";
 import { autoResumeIndexedProjects, gracefulShutdown } from "./services/startup.js";
 import { handleContextTool } from "./tools/context-tools.js";
 import { handleGraphTool } from "./tools/graph-tools.js";

--- a/src/services/qdrant-client-compat.ts
+++ b/src/services/qdrant-client-compat.ts
@@ -3,6 +3,7 @@
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
+import { fetch as undiciFetch } from "undici";
 
 /**
  * Support facts this module encodes (each verified by running the client
@@ -13,13 +14,17 @@ import path from "node:path";
  *     renamed the legacy `onError` handler hook, so the v6 Agent fails
  *     validation and every request dies with
  *     `UND_ERR_INVALID_ARG: invalid onError method`.
- *   - 1.19+ bundles undici 7 and works on Node 26+
+ *   - Pairing the client's Agent with fetch from the same undici line avoids
+ *     that cross-version handoff. SocratiCode already depends on undici 6 for
+ *     its Ollama transport, so the same pairing keeps client 1.18 working on
+ *     Node 26 without dropping Node 18 support.
+ *   - 1.19+ bundles undici 7 and works on Node 26 without this bridge
  *     (https://github.com/qdrant/qdrant-js/issues/134, fixed in 1.19).
  *
- * So "does this process break?" is a property of the PAIR (node major,
- * installed client version), not of the Node version alone. The startup
- * guard in index.ts uses these helpers to refuse only the pair that
- * actually breaks.
+ * The bridge below is deliberately narrow: only Qdrant-origin requests that
+ * carry a per-request dispatcher are routed through undici's fetch, and only
+ * for the affected Node/client pair. Every other request keeps using the
+ * process's original fetch implementation.
  */
 
 const QDRANT_CLIENT_PACKAGE = "@qdrant/js-client-rest";
@@ -69,19 +74,84 @@ export function readInstalledQdrantClientVersion(): string | null {
  * dies with an opaque undici error, which is exactly what the guard exists
  * to prevent. On Node < 26 the client version is irrelevant.
  */
-export function qdrantClientBreaksOnThisNode(
+export type QdrantFetchMode = "native" | "paired-undici" | "unknown";
+
+/** Select the fetch transport required by a Node/Qdrant-client pair. */
+export function qdrantFetchMode(
   nodeMajor: number,
   clientVersion: string | null,
-): boolean {
-  if (!Number.isFinite(nodeMajor) || nodeMajor < 26) return false;
-  if (clientVersion === null) return true;
+): QdrantFetchMode {
+  if (!Number.isFinite(nodeMajor) || nodeMajor < 26) return "native";
+  if (clientVersion === null) return "unknown";
   // Full semver shape required (prerelease/build tags allowed): a partial
   // match like `1.19.not-a-version` is NOT a version the registry could
-  // have served, so it fails closed with every other unparseable string
-  // rather than being half-read as a 1.19.
+  // have served, so transport selection fails closed rather than guessing.
   const match = clientVersion.match(/^(\d+)\.(\d+)\.\d+(?:[-+].*)?$/);
-  if (!match) return true;
+  if (!match) return "unknown";
   const major = Number.parseInt(match[1], 10);
   const minor = Number.parseInt(match[2], 10);
-  return major < 1 || (major === 1 && minor < 19);
+  return major < 1 || (major === 1 && minor < 19) ? "paired-undici" : "native";
+}
+
+type FetchFunction = typeof globalThis.fetch;
+type DispatcherRequestInit = RequestInit & { dispatcher?: unknown };
+
+function requestOrigin(input: Parameters<FetchFunction>[0]): string | null {
+  try {
+    if (typeof input === "string") return new URL(input).origin;
+    if (input instanceof URL) return input.origin;
+    return new URL(input.url).origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a fetch wrapper that pairs Qdrant's undici dispatcher with undici's
+ * own fetch. Errors propagate unchanged; there is no retry or fallback path.
+ */
+export function createQdrantFetchBridge(
+  nativeFetch: FetchFunction,
+  pairedFetch: FetchFunction,
+  qdrantOrigins: ReadonlySet<string>,
+): FetchFunction {
+  return (input, init) => {
+    const origin = requestOrigin(input);
+    const dispatcher = (init as DispatcherRequestInit | undefined)?.dispatcher;
+    if (origin !== null && qdrantOrigins.has(origin) && dispatcher !== undefined) {
+      return pairedFetch(input, init);
+    }
+    return nativeFetch(input, init);
+  };
+}
+
+const bridgedQdrantOrigins = new Set<string>();
+let bridgeInstalled = false;
+
+/**
+ * Install the Node 26/Qdrant 1.18 transport bridge once for the configured
+ * Qdrant origin. Repeated calls only register an additional origin.
+ */
+export function ensureQdrantClientCompatibility(qdrantBaseUrl: string): void {
+  const nodeMajor = Number.parseInt(process.versions.node.split(".")[0], 10);
+  const clientVersion = readInstalledQdrantClientVersion();
+  const mode = qdrantFetchMode(nodeMajor, clientVersion);
+  if (mode === "native") return;
+  if (mode === "unknown") {
+    throw new Error(
+      `socraticode: cannot determine the installed @qdrant/js-client-rest version on Node ${process.versions.node}; ` +
+        "cannot select a safe Qdrant transport.",
+    );
+  }
+
+  bridgedQdrantOrigins.add(new URL(qdrantBaseUrl).origin);
+  if (bridgeInstalled) return;
+
+  const nativeFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = createQdrantFetchBridge(
+    nativeFetch,
+    undiciFetch as unknown as FetchFunction,
+    bridgedQdrantOrigins,
+  );
+  bridgeInstalled = true;
 }

--- a/src/services/qdrant-client-compat.ts
+++ b/src/services/qdrant-client-compat.ts
@@ -86,11 +86,12 @@ export function qdrantFetchMode(
   // Full semver shape required (prerelease/build tags allowed): a partial
   // match like `1.19.not-a-version` is NOT a version the registry could
   // have served, so transport selection fails closed rather than guessing.
-  const identifier = "(?:0|[1-9]\\d*|[A-Za-z-][0-9A-Za-z-]*)";
+  const numericIdentifier = "(?:0|[1-9]\\d*)";
+  const prereleaseIdentifier = `(?:${numericIdentifier}|\\d*[A-Za-z-][0-9A-Za-z-]*)`;
   const match = clientVersion.match(
     new RegExp(
-      `^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)` +
-        `(?:-${identifier}(?:\\.${identifier})*)?` +
+      `^(${numericIdentifier})\\.(${numericIdentifier})\\.${numericIdentifier}` +
+        `(?:-${prereleaseIdentifier}(?:\\.${prereleaseIdentifier})*)?` +
         "(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
     ),
   );

--- a/src/services/qdrant-client-compat.ts
+++ b/src/services/qdrant-client-compat.ts
@@ -86,7 +86,14 @@ export function qdrantFetchMode(
   // Full semver shape required (prerelease/build tags allowed): a partial
   // match like `1.19.not-a-version` is NOT a version the registry could
   // have served, so transport selection fails closed rather than guessing.
-  const match = clientVersion.match(/^(\d+)\.(\d+)\.\d+(?:[-+].*)?$/);
+  const identifier = "(?:0|[1-9]\\d*|[A-Za-z-][0-9A-Za-z-]*)";
+  const match = clientVersion.match(
+    new RegExp(
+      `^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)` +
+        `(?:-${identifier}(?:\\.${identifier})*)?` +
+        "(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+    ),
+  );
   if (!match) return "unknown";
   const major = Number.parseInt(match[1], 10);
   const minor = Number.parseInt(match[2], 10);

--- a/src/services/qdrant-client-compat.ts
+++ b/src/services/qdrant-client-compat.ts
@@ -116,10 +116,12 @@ export function createQdrantFetchBridge(
   qdrantOrigins: ReadonlySet<string>,
 ): FetchFunction {
   return (input, init) => {
-    const origin = requestOrigin(input);
     const dispatcher = (init as DispatcherRequestInit | undefined)?.dispatcher;
-    if (origin !== null && qdrantOrigins.has(origin) && dispatcher !== undefined) {
-      return pairedFetch(input, init);
+    if (dispatcher !== undefined) {
+      const origin = requestOrigin(input);
+      if (origin !== null && qdrantOrigins.has(origin)) {
+        return pairedFetch(input, init);
+      }
     }
     return nativeFetch(input, init);
   };

--- a/src/services/qdrant.ts
+++ b/src/services/qdrant.ts
@@ -16,6 +16,7 @@ import {
   withEffectiveEmbedding,
 } from "./index-profile.js";
 import { logger } from "./logger.js";
+import { ensureQdrantClientCompatibility } from "./qdrant-client-compat.js";
 
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 500;
@@ -102,6 +103,9 @@ let client: QdrantClient | null = null;
 
 export function getClient(): QdrantClient {
   if (!client) {
+    const qdrantBaseUrl =
+      QDRANT_URL ?? `${QDRANT_API_KEY ? "https" : "http"}://${QDRANT_HOST}:${QDRANT_PORT}`;
+    ensureQdrantClientCompatibility(qdrantBaseUrl);
     client = new QdrantClient(
       QDRANT_URL
         ? {

--- a/tests/unit/qdrant-client-compat.test.ts
+++ b/tests/unit/qdrant-client-compat.test.ts
@@ -67,10 +67,17 @@ describe("qdrant-client-compat", () => {
       // legitimately serves.
       expect(qdrantFetchMode(26, "1.19.0-rc.1")).toBe("native");
       expect(qdrantFetchMode(26, "1.18.2+build.5")).toBe("paired-undici");
+      expect(qdrantFetchMode(26, "1.18.0-1a")).toBe("paired-undici");
     });
 
     it("fails closed for malformed prerelease and build metadata", () => {
-      for (const version of ["1.19.0-", "1.19.0+", "1.19.0-alpha..1", "1.19.0+meta."]) {
+      for (const version of [
+        "1.19.0-",
+        "1.19.0+",
+        "1.19.0-01",
+        "1.19.0-alpha..1",
+        "1.19.0+meta.",
+      ]) {
         expect(qdrantFetchMode(26, version), version).toBe("unknown");
       }
     });

--- a/tests/unit/qdrant-client-compat.test.ts
+++ b/tests/unit/qdrant-client-compat.test.ts
@@ -69,6 +69,12 @@ describe("qdrant-client-compat", () => {
       expect(qdrantFetchMode(26, "1.18.2+build.5")).toBe("paired-undici");
     });
 
+    it("fails closed for malformed prerelease and build metadata", () => {
+      for (const version of ["1.19.0-", "1.19.0+", "1.19.0-alpha..1", "1.19.0+meta."]) {
+        expect(qdrantFetchMode(26, version), version).toBe("unknown");
+      }
+    });
+
     it("keeps native fetch for a non-finite Node major", () => {
       expect(qdrantFetchMode(Number.NaN, "1.18.0")).toBe("native");
     });

--- a/tests/unit/qdrant-client-compat.test.ts
+++ b/tests/unit/qdrant-client-compat.test.ts
@@ -2,19 +2,18 @@
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
-  qdrantClientBreaksOnThisNode,
+  createQdrantFetchBridge,
+  qdrantFetchMode,
   readInstalledQdrantClientVersion,
 } from "../../src/services/qdrant-client-compat.js";
 
 /**
- * The startup guard refuses only the PAIR that breaks: Node 26+ with
- * @qdrant/js-client-rest < 1.19 (undici 6 vs Node 26's fetch). These tests
- * pin the pair logic and the version reader; getting either wrong turns the
- * guard back into what it replaced — a blanket Node 26 refusal that turns
- * away working installs, or a silent boot into a client whose first request
- * dies with an opaque undici error.
+ * Node 26 must pair Qdrant client 1.18's dispatcher with fetch from the same
+ * undici line, while every unaffected runtime and request keeps the native
+ * transport. The packaged-runtime CI job proves this decision against a real
+ * Qdrant from a clean consumer installation.
  */
 describe("qdrant-client-compat", () => {
   describe("readInstalledQdrantClientVersion", () => {
@@ -33,51 +32,101 @@ describe("qdrant-client-compat", () => {
     });
   });
 
-  describe("qdrantClientBreaksOnThisNode", () => {
-    it("never breaks below Node 26, whatever the client", () => {
+  describe("qdrantFetchMode", () => {
+    it("keeps native fetch below Node 26, whatever the client", () => {
       for (const version of ["1.18.0", "1.19.0", null]) {
         for (const major of [18, 20, 22, 24, 25]) {
-          expect(qdrantClientBreaksOnThisNode(major, version), `${major}/${version}`).toBe(false);
+          expect(qdrantFetchMode(major, version), `${major}/${version}`).toBe("native");
         }
       }
     });
 
-    it("breaks on Node 26+ with a pre-1.19 client", () => {
-      expect(qdrantClientBreaksOnThisNode(26, "1.18.0")).toBe(true);
-      expect(qdrantClientBreaksOnThisNode(26, "1.17.0")).toBe(true);
-      expect(qdrantClientBreaksOnThisNode(27, "1.18.5")).toBe(true);
+    it("pairs fetch on Node 26+ with a pre-1.19 client", () => {
+      expect(qdrantFetchMode(26, "1.18.0")).toBe("paired-undici");
+      expect(qdrantFetchMode(26, "1.17.0")).toBe("paired-undici");
+      expect(qdrantFetchMode(27, "1.18.5")).toBe("paired-undici");
     });
 
-    it("does not break on Node 26+ with 1.19 or newer", () => {
-      // The whole point of the versioned guard: a working install must not
-      // be turned away.
-      expect(qdrantClientBreaksOnThisNode(26, "1.19.0")).toBe(false);
-      expect(qdrantClientBreaksOnThisNode(26, "1.20.3")).toBe(false);
-      expect(qdrantClientBreaksOnThisNode(27, "2.0.0")).toBe(false);
+    it("keeps native fetch on Node 26+ with 1.19 or newer", () => {
+      expect(qdrantFetchMode(26, "1.19.0")).toBe("native");
+      expect(qdrantFetchMode(26, "1.20.3")).toBe("native");
+      expect(qdrantFetchMode(27, "2.0.0")).toBe("native");
     });
 
-    it("fails closed on Node 26+ when the version is unknown or unparseable", () => {
-      // Booting anyway would trade the guard's clear message for the opaque
-      // UND_ERR_INVALID_ARG at the first qdrant call.
-      expect(qdrantClientBreaksOnThisNode(26, null)).toBe(true);
-      expect(qdrantClientBreaksOnThisNode(26, "not-a-version")).toBe(true);
+    it("fails closed when the Node 26+ client version is unknown or unparseable", () => {
+      expect(qdrantFetchMode(26, null)).toBe("unknown");
+      expect(qdrantFetchMode(26, "not-a-version")).toBe("unknown");
       // A half-valid string must not be half-read as its leading 1.19,
       // whether the garbage starts at the patch or trails after it.
-      expect(qdrantClientBreaksOnThisNode(26, "1.19.not-a-version")).toBe(true);
-      expect(qdrantClientBreaksOnThisNode(26, "1.19.0garbage")).toBe(true);
+      expect(qdrantFetchMode(26, "1.19.not-a-version")).toBe("unknown");
+      expect(qdrantFetchMode(26, "1.19.0garbage")).toBe("unknown");
     });
 
     it("reads prerelease and build-metadata versions normally", () => {
       // The strict shape must not reject the tagged versions the registry
       // legitimately serves.
-      expect(qdrantClientBreaksOnThisNode(26, "1.19.0-rc.1")).toBe(false);
-      expect(qdrantClientBreaksOnThisNode(26, "1.18.2+build.5")).toBe(true);
+      expect(qdrantFetchMode(26, "1.19.0-rc.1")).toBe("native");
+      expect(qdrantFetchMode(26, "1.18.2+build.5")).toBe("paired-undici");
     });
 
-    it("treats a non-finite node major as not breaking", () => {
-      // An unparseable process.versions.node must not brick startup on
-      // Node versions the guard was never about.
-      expect(qdrantClientBreaksOnThisNode(Number.NaN, "1.18.0")).toBe(false);
+    it("keeps native fetch for a non-finite Node major", () => {
+      expect(qdrantFetchMode(Number.NaN, "1.18.0")).toBe("native");
+    });
+  });
+
+  describe("createQdrantFetchBridge", () => {
+    const response = new Response(JSON.stringify({ result: true }));
+    const dispatcher = {};
+
+    it("uses paired fetch only for a Qdrant request carrying a dispatcher", async () => {
+      const nativeFetch = vi.fn(async () => response);
+      const pairedFetch = vi.fn(async () => response);
+      const bridge = createQdrantFetchBridge(
+        nativeFetch,
+        pairedFetch,
+        new Set(["http://qdrant.test:6333"]),
+      );
+      const init = { dispatcher } as RequestInit;
+
+      await bridge("http://qdrant.test:6333/collections", init);
+
+      expect(pairedFetch).toHaveBeenCalledWith("http://qdrant.test:6333/collections", init);
+      expect(nativeFetch).not.toHaveBeenCalled();
+    });
+
+    it("keeps native fetch for unrelated origins and dispatcher-free requests", async () => {
+      const nativeFetch = vi.fn(async () => response);
+      const pairedFetch = vi.fn(async () => response);
+      const bridge = createQdrantFetchBridge(
+        nativeFetch,
+        pairedFetch,
+        new Set(["http://qdrant.test:6333"]),
+      );
+      const init = { dispatcher } as RequestInit;
+
+      await bridge("https://example.com/collections", init);
+      await bridge("http://qdrant.test:6333/healthz");
+
+      expect(nativeFetch).toHaveBeenCalledTimes(2);
+      expect(pairedFetch).not.toHaveBeenCalled();
+    });
+
+    it("propagates the paired transport error without falling back", async () => {
+      const failure = new Error("transport failed");
+      const nativeFetch = vi.fn(async () => response);
+      const pairedFetch = vi.fn(async () => {
+        throw failure;
+      });
+      const bridge = createQdrantFetchBridge(
+        nativeFetch,
+        pairedFetch,
+        new Set(["http://qdrant.test:6333"]),
+      );
+
+      await expect(
+        bridge("http://qdrant.test:6333/collections", { dispatcher } as RequestInit),
+      ).rejects.toBe(failure);
+      expect(nativeFetch).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- keep `@qdrant/js-client-rest` 1.18 so Node 18.17 remains supported
- on Node 26+, pair Qdrant's per-request dispatcher with fetch from the same undici line
- leave unrelated fetch traffic and unaffected runtime/client pairs on native fetch
- add clean packaged-consumer Qdrant smoke coverage for Node 18.17 and Node 26
- add Node 26 to the unit-test matrix

## Compatibility

Qdrant client 1.19 requires Node 22 or newer, so upgrading it cannot fix Node 26 without dropping existing Node 18 support. The bridge applies only to Node 26 or newer with a Qdrant client older than 1.19. It does not change index data or metadata and requires no reindex.

The consumer smoke tests install the generated tarball with engine checks and assert that its installed Qdrant client is 1.18 before performing a real Qdrant request. This prevents a substituted dependency from hiding a failure in the package that users actually install.

Fixes #154


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Qdrant connectivity across supported Node.js and client-version combinations.
  * Qdrant requests now select the appropriate transport when compatibility adjustments are needed.
  * Improved handling of invalid, unknown, and prerelease Qdrant client versions.
  * Startup no longer exits solely because a Qdrant client version is incompatible or unrecognized.

* **Tests**
  * Added Node.js 26 compatibility coverage.
  * Expanded packaged-installation, CLI, readiness, timeout, and Qdrant integration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->