### PR TITLE
fix(indexer): do not mark a file indexed when its upsert was partially skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,35 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+
+      # The partial-upsert regression needs a real Qdrant, so it lives under
+      # tests/integration/ and the unit matrix never reaches it. Run it here,
+      # against this job's service container.
+      #
+      # REQUIRE_QDRANT=1 makes an unreachable backend fail the job rather than
+      # letting describe.skipIf report a skipped success — the same reasoning as
+      # the rust job's `rustc --version` step below. QDRANT_URL drives the
+      # client; QDRANT_HOST/PORT are what the test helpers read, so both are set.
+      - name: Partial-upsert regression against Qdrant
+        shell: bash
+        run: |
+          set -euo pipefail
+          qdrant_ready=false
+          for attempt in {1..30}; do
+            if curl --connect-timeout 1 --max-time 2 -fsS http://127.0.0.1:6333/healthz >/dev/null; then
+              qdrant_ready=true
+              break
+            fi
+            sleep 1
+          done
+          test "$qdrant_ready" = true
+          REQUIRE_QDRANT=1 \
+          QDRANT_MODE=external \
+          QDRANT_URL=http://127.0.0.1:6333 \
+          QDRANT_HOST=127.0.0.1 \
+          QDRANT_PORT=6333 \
+            npx vitest run tests/integration/partial-upsert-skip.test.ts
+
       - name: Verify the unmodified package against Qdrant on Node 26
         shell: bash
         run: |

--- a/src/services/context-artifacts.ts
+++ b/src/services/context-artifacts.ts
@@ -571,14 +571,10 @@ export async function indexArtifact(
     } as Record<string, unknown>,
   }));
 
-  const { pointsSkipped } = await upsertPreEmbeddedChunks(collection, points);
-
-  if (pointsSkipped > 0 && pointsSkipped === points.length) {
-    throw new Error(
-      `Qdrant upsert: all ${points.length} points for artifact "${artifact.name}" ` +
-      `were skipped (collection=${collection}). The collection may have been deleted externally.`
-    );
-  }
+  // Throws if any point failed after the per-point fallback. An artifact whose
+  // chunks only partially landed must not be recorded with a contentHash, or it
+  // will be treated as up-to-date and never re-indexed.
+  await upsertPreEmbeddedChunks(collection, points);
 
   logger.info("Indexed context artifact", {
     name: artifact.name,

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -942,11 +942,6 @@ export async function indexProject(
 
   let globalChunksProcessed = 0;
   let totalChunksCreated = 0;
-  // Files left unstored by a partial upsert, accumulated across every batch.
-  // Needed because `hashes` is preloaded from existing metadata: a re-indexed
-  // file that fails to store keeps its OLD hash, so it still occupies an entry
-  // and `hashes.size` alone would count it as indexed.
-  const strandedPaths = new Set<string>();
 
   for (let batchIdx = 0; batchIdx < chunkedFiles.length; batchIdx += INDEX_BATCH_SIZE) {
     // ── Cancellation check: stop gracefully between batches ──
@@ -1027,7 +1022,9 @@ export async function indexProject(
       },
     }));
 
-    const { pointsSkipped, skippedPaths } = await upsertPreEmbeddedChunks(collection, batchPoints).catch((err) => {
+    // Throws if any point failed after the per-point fallback, so hashes below
+    // are only advanced for a batch that landed in full.
+    await upsertPreEmbeddedChunks(collection, batchPoints).catch((err) => {
       // Enrich the error with batch context for debugging
       const fileList = fileBatch.map((f) => f.relativePath).join(", ");
       const msg = err instanceof Error ? err.message : String(err);
@@ -1038,40 +1035,11 @@ export async function indexProject(
       );
     });
 
-    if (pointsSkipped > 0 && pointsSkipped === batchPoints.length) {
-      // Every single point in the batch was skipped — the collection likely disappeared
-      throw new Error(
-        `Qdrant upsert: all ${batchPoints.length} points in batch ${batchNum}/${totalBatches} ` +
-        `were skipped (collection=${collection}). The collection may have been deleted externally.`
-      );
-    }
-
-    // Update hashes for this batch's files.
-    //
-    // A file whose points were only PARTIALLY upserted must keep its old hash.
-    // Re-indexed files have their previous chunks deleted before this loop, so
-    // recording the new hash here would leave the file at zero chunks while
-    // claiming it is current — and every later incremental would skip it,
-    // making the loss permanent and invisible.
-    const skipped = skippedPaths ?? new Set<string>();
-    let chunksLost = 0;
+    // Update hashes for this batch's files
     for (const file of fileBatch) {
-      if (skipped.has(file.relativePath)) {
-        chunksLost += file.chunks.length;
-        strandedPaths.add(file.relativePath);
-        continue;
-      }
       hashes.set(file.relativePath, file.contentHash);
-      strandedPaths.delete(file.relativePath);
     }
-    if (chunksLost > 0) {
-      logger.warn("Files left unindexed after partial upsert; hashes withheld so the next run retries them", {
-        collection,
-        batch: `${batchNum}/${totalBatches}`,
-        files: [...skipped],
-      });
-    }
-    totalChunksCreated += batchChunkData.length - chunksLost;
+    totalChunksCreated += batchChunkData.length;
 
     // Checkpoint: persist hashes after each batch so progress survives crashes
     progress.phase = `checkpointing (batch ${batchNum}/${totalBatches})`;
@@ -1088,17 +1056,9 @@ export async function indexProject(
     onProgress?.(`Batch ${batchNum}/${totalBatches} checkpointed (${totalChunksCreated} chunks so far)`);
   }
 
-  // filesTotal counts everything the walk found; filesIndexed counts only what
-  // actually landed. They diverge when a partial upsert left files unindexed —
-  // reporting files.length as indexed would claim a clean run that did not
-  // happen, and hide the very files the withheld hashes exist to retry.
-  //
-  // hashes.size is not sufficient on its own: it is preloaded from existing
-  // metadata, so a re-indexed file whose upsert was skipped keeps its previous
-  // hash and still occupies an entry. Those have to come back off the count.
-  const filesTotal = files.length;
-  const strandedWithStaleHash = [...strandedPaths].filter((p) => hashes.has(p)).length;
-  const filesIndexed = hashes.size - strandedWithStaleHash;
+  // Reaching here means every batch landed in full — a partial upsert throws —
+  // so the walked count is also the indexed count.
+  const filesIndexed = files.length;
   const chunksCreated = totalChunksCreated;
 
   // Final metadata save
@@ -1106,8 +1066,8 @@ export async function indexProject(
   await saveProjectMetadata(
     collection,
     resolvedPath,
-    filesTotal,
     filesIndexed,
+    hashes.size,
     hashes,
     "completed",
     effectiveProfile,
@@ -1144,12 +1104,7 @@ export async function indexProject(
     onProgress?.(`Context artifact indexing failed (non-fatal): ${artifactMsg}`);
   }
 
-  onProgress?.(
-    filesIndexed === filesTotal
-      ? `Indexing complete: ${filesIndexed} files, ${chunksCreated} chunks`
-      : `Indexing complete: ${filesIndexed}/${filesTotal} files, ${chunksCreated} chunks ` +
-        `(${filesTotal - filesIndexed} left for retry after partial upsert failures)`,
-  );
+  onProgress?.(`Indexing complete: ${filesIndexed} files, ${chunksCreated} chunks`);
   lastCompleted.set(resolvedPath, {
     type: "full-index",
     completedAt: Date.now(),
@@ -1439,40 +1394,17 @@ export async function updateProjectIndex(
         },
       }));
 
-      const { pointsSkipped, skippedPaths } = await upsertPreEmbeddedChunks(collection, batchPoints);
+      // Throws if any point failed after the per-point fallback, so hashes below
+      // are only advanced for a batch that landed in full.
+      await upsertPreEmbeddedChunks(collection, batchPoints);
 
-      if (pointsSkipped > 0 && pointsSkipped === batchPoints.length) {
-        throw new Error(
-          `Qdrant upsert: all ${batchPoints.length} points in batch ${batchNum}/${totalBatches} ` +
-          `were skipped (collection=${collection}). The collection may have been deleted externally.`
-        );
-      }
-
-      // Update hashes and counts for this batch's files.
-      //
-      // See the note in indexProject: a file whose points were only partially
-      // upserted keeps its old hash. Its previous chunks were already deleted,
-      // so recording the new hash would strand it at zero chunks and suppress
-      // every future re-index of it.
-      const skipped = skippedPaths ?? new Set<string>();
-      let chunksLost = 0;
+      // Update hashes and counts for this batch's files
       for (const file of fileBatch) {
-        if (skipped.has(file.relativePath)) {
-          chunksLost += file.chunks.length;
-          continue;
-        }
         hashes.set(file.relativePath, file.contentHash);
         if (file.isNew) added++;
         else updated++;
       }
-      if (chunksLost > 0) {
-        logger.warn("Files left unindexed after partial upsert; hashes withheld so the next run retries them", {
-          collection,
-          batch: `${batchNum}/${totalBatches}`,
-          files: [...skipped],
-        });
-      }
-      chunksCreated += batchChunkData.length - chunksLost;
+      chunksCreated += batchChunkData.length;
 
       // Checkpoint: persist hashes after each batch
       progress.phase = `checkpointing (batch ${batchNum}/${totalBatches})`;

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -1056,9 +1056,15 @@ export async function indexProject(
     onProgress?.(`Batch ${batchNum}/${totalBatches} checkpointed (${totalChunksCreated} chunks so far)`);
   }
 
-  // Reaching here means every batch landed in full — a partial upsert throws —
-  // so the walked count is also the indexed count.
-  const filesIndexed = files.length;
+  // filesTotal is everything the walk found; filesIndexed is what the index
+  // actually represents. They differ whenever a file was skipped before
+  // chunking — oversized, or unreadable — so the walked count would overstate
+  // the result. hashes.size is authoritative: oversized paths are excluded from
+  // currentFileSet above and pruned from hashes, and unreadable files never get
+  // an entry. Reaching here means every batch landed in full, since a partial
+  // upsert throws, so no stale entry can inflate it either.
+  const filesTotal = files.length;
+  const filesIndexed = hashes.size;
   const chunksCreated = totalChunksCreated;
 
   // Final metadata save
@@ -1066,8 +1072,8 @@ export async function indexProject(
   await saveProjectMetadata(
     collection,
     resolvedPath,
+    filesTotal,
     filesIndexed,
-    hashes.size,
     hashes,
     "completed",
     effectiveProfile,

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -1081,7 +1081,12 @@ export async function indexProject(
     onProgress?.(`Batch ${batchNum}/${totalBatches} checkpointed (${totalChunksCreated} chunks so far)`);
   }
 
-  const filesIndexed = files.length;
+  // filesTotal counts everything the walk found; filesIndexed counts only what
+  // actually landed. They diverge when a partial upsert left files unindexed —
+  // reporting files.length as indexed would claim a clean run that did not
+  // happen, and hide the very files the withheld hashes exist to retry.
+  const filesTotal = files.length;
+  const filesIndexed = hashes.size;
   const chunksCreated = totalChunksCreated;
 
   // Final metadata save
@@ -1089,8 +1094,8 @@ export async function indexProject(
   await saveProjectMetadata(
     collection,
     resolvedPath,
+    filesTotal,
     filesIndexed,
-    hashes.size,
     hashes,
     "completed",
     effectiveProfile,
@@ -1127,7 +1132,12 @@ export async function indexProject(
     onProgress?.(`Context artifact indexing failed (non-fatal): ${artifactMsg}`);
   }
 
-  onProgress?.(`Indexing complete: ${filesIndexed} files, ${chunksCreated} chunks`);
+  onProgress?.(
+    filesIndexed === filesTotal
+      ? `Indexing complete: ${filesIndexed} files, ${chunksCreated} chunks`
+      : `Indexing complete: ${filesIndexed}/${filesTotal} files, ${chunksCreated} chunks ` +
+        `(${filesTotal - filesIndexed} left for retry after partial upsert failures)`,
+  );
   lastCompleted.set(resolvedPath, {
     type: "full-index",
     completedAt: Date.now(),

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -1022,7 +1022,7 @@ export async function indexProject(
       },
     }));
 
-    const { pointsSkipped } = await upsertPreEmbeddedChunks(collection, batchPoints).catch((err) => {
+    const { pointsSkipped, skippedPaths } = await upsertPreEmbeddedChunks(collection, batchPoints).catch((err) => {
       // Enrich the error with batch context for debugging
       const fileList = fileBatch.map((f) => f.relativePath).join(", ");
       const msg = err instanceof Error ? err.message : String(err);
@@ -1041,11 +1041,30 @@ export async function indexProject(
       );
     }
 
-    // Update hashes for this batch's files
+    // Update hashes for this batch's files.
+    //
+    // A file whose points were only PARTIALLY upserted must keep its old hash.
+    // Re-indexed files have their previous chunks deleted before this loop, so
+    // recording the new hash here would leave the file at zero chunks while
+    // claiming it is current — and every later incremental would skip it,
+    // making the loss permanent and invisible.
+    const skipped = skippedPaths ?? new Set<string>();
+    let chunksLost = 0;
     for (const file of fileBatch) {
+      if (skipped.has(file.relativePath)) {
+        chunksLost += file.chunks.length;
+        continue;
+      }
       hashes.set(file.relativePath, file.contentHash);
     }
-    totalChunksCreated += batchChunkData.length;
+    if (chunksLost > 0) {
+      logger.warn("Files left unindexed after partial upsert; hashes withheld so the next run retries them", {
+        collection,
+        batch: `${batchNum}/${totalBatches}`,
+        files: [...skipped],
+      });
+    }
+    totalChunksCreated += batchChunkData.length - chunksLost;
 
     // Checkpoint: persist hashes after each batch so progress survives crashes
     progress.phase = `checkpointing (batch ${batchNum}/${totalBatches})`;
@@ -1398,7 +1417,7 @@ export async function updateProjectIndex(
         },
       }));
 
-      const { pointsSkipped } = await upsertPreEmbeddedChunks(collection, batchPoints);
+      const { pointsSkipped, skippedPaths } = await upsertPreEmbeddedChunks(collection, batchPoints);
 
       if (pointsSkipped > 0 && pointsSkipped === batchPoints.length) {
         throw new Error(
@@ -1407,13 +1426,31 @@ export async function updateProjectIndex(
         );
       }
 
-      // Update hashes and counts for this batch's files
+      // Update hashes and counts for this batch's files.
+      //
+      // See the note in indexProject: a file whose points were only partially
+      // upserted keeps its old hash. Its previous chunks were already deleted,
+      // so recording the new hash would strand it at zero chunks and suppress
+      // every future re-index of it.
+      const skipped = skippedPaths ?? new Set<string>();
+      let chunksLost = 0;
       for (const file of fileBatch) {
+        if (skipped.has(file.relativePath)) {
+          chunksLost += file.chunks.length;
+          continue;
+        }
         hashes.set(file.relativePath, file.contentHash);
         if (file.isNew) added++;
         else updated++;
       }
-      chunksCreated += batchChunkData.length;
+      if (chunksLost > 0) {
+        logger.warn("Files left unindexed after partial upsert; hashes withheld so the next run retries them", {
+          collection,
+          batch: `${batchNum}/${totalBatches}`,
+          files: [...skipped],
+        });
+      }
+      chunksCreated += batchChunkData.length - chunksLost;
 
       // Checkpoint: persist hashes after each batch
       progress.phase = `checkpointing (batch ${batchNum}/${totalBatches})`;

--- a/src/services/indexer.ts
+++ b/src/services/indexer.ts
@@ -942,6 +942,11 @@ export async function indexProject(
 
   let globalChunksProcessed = 0;
   let totalChunksCreated = 0;
+  // Files left unstored by a partial upsert, accumulated across every batch.
+  // Needed because `hashes` is preloaded from existing metadata: a re-indexed
+  // file that fails to store keeps its OLD hash, so it still occupies an entry
+  // and `hashes.size` alone would count it as indexed.
+  const strandedPaths = new Set<string>();
 
   for (let batchIdx = 0; batchIdx < chunkedFiles.length; batchIdx += INDEX_BATCH_SIZE) {
     // ── Cancellation check: stop gracefully between batches ──
@@ -1053,9 +1058,11 @@ export async function indexProject(
     for (const file of fileBatch) {
       if (skipped.has(file.relativePath)) {
         chunksLost += file.chunks.length;
+        strandedPaths.add(file.relativePath);
         continue;
       }
       hashes.set(file.relativePath, file.contentHash);
+      strandedPaths.delete(file.relativePath);
     }
     if (chunksLost > 0) {
       logger.warn("Files left unindexed after partial upsert; hashes withheld so the next run retries them", {
@@ -1085,8 +1092,13 @@ export async function indexProject(
   // actually landed. They diverge when a partial upsert left files unindexed —
   // reporting files.length as indexed would claim a clean run that did not
   // happen, and hide the very files the withheld hashes exist to retry.
+  //
+  // hashes.size is not sufficient on its own: it is preloaded from existing
+  // metadata, so a re-indexed file whose upsert was skipped keeps its previous
+  // hash and still occupies an entry. Those have to come back off the count.
   const filesTotal = files.length;
-  const filesIndexed = hashes.size;
+  const strandedWithStaleHash = [...strandedPaths].filter((p) => hashes.has(p)).length;
+  const filesIndexed = hashes.size - strandedWithStaleHash;
   const chunksCreated = totalChunksCreated;
 
   // Final metadata save

--- a/src/services/qdrant.ts
+++ b/src/services/qdrant.ts
@@ -356,13 +356,15 @@ const MAX_BM25_TEXT_CHARS = 32_000; // ~32KB
 /** Upsert pre-embedded points into a collection (no embedding generation).
  * bm25Text is forwarded to Qdrant's server-side BM25 inference (truncated if too long).
  *
- * Returns the number of points skipped due to upsert errors, and the
- * `relativePath` of every file those points belonged to.
+ * A failing batch is retried point by point to isolate the bad point(s). If any
+ * point still fails, this throws: a partial write must fail the whole indexing
+ * operation.
  *
- * Callers MUST NOT record a file as indexed when its path is in `skippedPaths`.
- * A re-indexed file has its previous chunks deleted before this call, so
- * marking it current after a partial skip strands it at zero chunks with a
- * content hash that suppresses every future re-index. */
+ * Callers must not treat a partial write as success. A re-indexed file has its
+ * previous chunks deleted before this call, so recording it as indexed after a
+ * partial failure strands it at zero chunks with a content hash that suppresses
+ * every future re-index. Throwing leaves stored hashes and earlier checkpoints
+ * untouched, so the next index or update retries the file naturally. */
 export async function upsertPreEmbeddedChunks(
   collectionName: string,
   points: Array<{
@@ -371,8 +373,8 @@ export async function upsertPreEmbeddedChunks(
     bm25Text: string;
     payload: Record<string, unknown>;
   }>,
-): Promise<{ pointsSkipped: number; skippedPaths: Set<string> }> {
-  if (points.length === 0) return { pointsSkipped: 0, skippedPaths: new Set<string>() };
+): Promise<void> {
+  if (points.length === 0) return;
 
   const qdrant = getClient();
   const namedPoints = points.map((p) => ({
@@ -433,7 +435,17 @@ export async function upsertPreEmbeddedChunks(
     }
   }
 
-  return { pointsSkipped: totalSkipped, skippedPaths };
+  if (totalSkipped > 0) {
+    const affected = [...skippedPaths].sort();
+    const shown = affected.slice(0, 10).join(", ");
+    const more = affected.length > 10 ? `, and ${affected.length - 10} more` : "";
+    throw new Error(
+      `Qdrant upsert incomplete for collection=${collectionName}: ` +
+      `${totalSkipped}/${points.length} point(s) failed after per-point retry. ` +
+      `Affected files: ${shown}${more}. ` +
+      `Nothing has been recorded as indexed; re-run the index once Qdrant is healthy.`,
+    );
+  }
 }
 
 /** Delete all chunks for a specific file (matched by relativePath) */

--- a/src/services/qdrant.ts
+++ b/src/services/qdrant.ts
@@ -355,7 +355,14 @@ const MAX_BM25_TEXT_CHARS = 32_000; // ~32KB
 
 /** Upsert pre-embedded points into a collection (no embedding generation).
  * bm25Text is forwarded to Qdrant's server-side BM25 inference (truncated if too long).
- * Returns the number of points that were skipped due to upsert errors. */
+ *
+ * Returns the number of points skipped due to upsert errors, and the
+ * `relativePath` of every file those points belonged to.
+ *
+ * Callers MUST NOT record a file as indexed when its path is in `skippedPaths`.
+ * A re-indexed file has its previous chunks deleted before this call, so
+ * marking it current after a partial skip strands it at zero chunks with a
+ * content hash that suppresses every future re-index. */
 export async function upsertPreEmbeddedChunks(
   collectionName: string,
   points: Array<{
@@ -364,8 +371,8 @@ export async function upsertPreEmbeddedChunks(
     bm25Text: string;
     payload: Record<string, unknown>;
   }>,
-): Promise<{ pointsSkipped: number }> {
-  if (points.length === 0) return { pointsSkipped: 0 };
+): Promise<{ pointsSkipped: number; skippedPaths: Set<string> }> {
+  if (points.length === 0) return { pointsSkipped: 0, skippedPaths: new Set<string>() };
 
   const qdrant = getClient();
   const namedPoints = points.map((p) => ({
@@ -383,6 +390,7 @@ export async function upsertPreEmbeddedChunks(
   }));
 
   let totalSkipped = 0;
+  const skippedPaths = new Set<string>();
 
   // Upsert in batches of 100, with per-point fallback on failure
   for (let i = 0; i < namedPoints.length; i += 100) {
@@ -406,6 +414,11 @@ export async function upsertPreEmbeddedChunks(
         } catch (pointErr) {
           skipped++;
           const filePath = point.payload?.relativePath ?? point.payload?.filePath ?? point.id;
+          // Record the owning file so the caller can leave its hash untouched
+          // and re-index it on the next pass.
+          if (typeof point.payload?.relativePath === "string") {
+            skippedPaths.add(point.payload.relativePath);
+          }
           logger.warn(`Skipping point that failed upsert`, {
             pointId: point.id,
             filePath: String(filePath),
@@ -420,7 +433,7 @@ export async function upsertPreEmbeddedChunks(
     }
   }
 
-  return { pointsSkipped: totalSkipped };
+  return { pointsSkipped: totalSkipped, skippedPaths };
 }
 
 /** Delete all chunks for a specific file (matched by relativePath) */

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -7,14 +7,26 @@
  * and infrastructure readiness cache resets.
  */
 
-import { QdrantClient } from "@qdrant/js-client-rest";
-import { QDRANT_HOST, QDRANT_PORT } from "../../src/constants.js";
+import type { QdrantClient } from "@qdrant/js-client-rest";
+import { getClient } from "../../src/services/qdrant.js";
 
 /**
- * Create a Qdrant client for test cleanup operations.
+ * Qdrant client for test setup and cleanup.
+ *
+ * Reuses the service's own `getClient()` rather than constructing
+ * `@qdrant/js-client-rest` here. Building one locally duplicated the URL,
+ * API-key and `checkCompatibility` configuration, and — the reason this
+ * changed — skipped `ensureQdrantClientCompatibility()`, the transport bridge
+ * the pinned 1.18 client needs on Node 26. Without it every request fails with
+ * `UND_ERR_INVALID_ARG: invalid onError method`, and `waitForQdrant()` retries
+ * that real client error until it reports a perfectly healthy Qdrant as
+ * unreachable.
+ *
+ * `checkCompatibility: false` is not a substitute: it silences the version
+ * probe without installing the bridge, so the requests still fail.
  */
 export function createTestQdrantClient(): QdrantClient {
-  return new QdrantClient({ host: QDRANT_HOST, port: QDRANT_PORT });
+  return getClient();
 }
 
 /**

--- a/tests/integration/partial-upsert-skip.test.ts
+++ b/tests/integration/partial-upsert-skip.test.ts
@@ -26,7 +26,6 @@ import { collectionName, projectIdFromPath } from "../../src/config.js";
 import { ensureQdrantReady } from "../../src/services/docker.js";
 import { requestedIndexProfile } from "../../src/services/index-profile.js";
 import {
-  deleteCollection,
   ensureCollection,
   getCollectionInfo,
   loadProjectHashes,
@@ -34,6 +33,7 @@ import {
   upsertPreEmbeddedChunks,
 } from "../../src/services/qdrant.js";
 import { isDockerAvailable } from "../helpers/fixtures.js";
+import { deleteTestCollection, waitForQdrant } from "../helpers/setup.js";
 
 /**
  * Locally this skips without Docker. In CI it must not: a test that skips
@@ -72,23 +72,21 @@ describe.skipIf(!shouldRun)("partial Qdrant upsert fails the whole operation", (
       await ensureQdrantReady();
     }
 
-    // Reach Qdrant through the service's own client rather than the raw one in
-    // tests/helpers: getClient() applies ensureQdrantClientCompatibility(),
-    // which is what makes the client usable on Node 26. A bare QdrantClient
-    // fails there with "Failed to obtain server version", which would look like
-    // an unreachable server even while Qdrant is healthy.
-    try {
-      await deleteCollection(TEST_COLLECTION).catch(() => undefined);
-      await ensureCollection(TEST_COLLECTION);
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
+    // Uses the shared helpers deliberately: they now route through the
+    // service's getClient(), so running here is what proves that path works on
+    // Node 26. Reaching around them would leave the helper fix uncovered.
+    const ready = await waitForQdrant(60_000);
+    if (!ready) {
       throw new Error(
         requireQdrant
-          ? "REQUIRE_QDRANT=1 but Qdrant is not usable. This regression must fail rather than " +
-            `skip: point QDRANT_MODE/QDRANT_URL at a running instance. Underlying error: ${detail}`
-          : `Qdrant did not become ready: ${detail}`,
+          ? "REQUIRE_QDRANT=1 but Qdrant is not reachable. This regression must fail rather " +
+            "than skip: point QDRANT_MODE/QDRANT_URL at a running instance."
+          : "Qdrant did not become ready",
       );
     }
+
+    await deleteTestCollection(TEST_COLLECTION);
+    await ensureCollection(TEST_COLLECTION);
 
     const info = await getCollectionInfo(TEST_COLLECTION);
     if (!info?.denseVectorSize) {
@@ -98,7 +96,7 @@ describe.skipIf(!shouldRun)("partial Qdrant upsert fails the whole operation", (
   }, 180_000);
 
   afterAll(async () => {
-    await deleteCollection(TEST_COLLECTION).catch(() => undefined);
+    await deleteTestCollection(TEST_COLLECTION);
   });
 
   it("stores the valid point, then throws naming the invalid one", async () => {

--- a/tests/integration/partial-upsert-skip.test.ts
+++ b/tests/integration/partial-upsert-skip.test.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+/**
+ * Regression for partial Qdrant writes, against a real Qdrant.
+ *
+ * A batch containing one valid and one genuinely invalid point must:
+ *   1. fail the batch upsert,
+ *   2. store the valid point via the per-point fallback,
+ *   3. surface the remaining failure rather than reporting success,
+ *   4. leave the affected file's stored hash unadvanced, so
+ *   5. a later healthy run re-indexes it.
+ *
+ * (4) and (5) are the point of the exercise. Before this, a partially-skipped
+ * file was recorded as current, which stranded it at zero chunks permanently:
+ * no later incremental looked at it again, and a full re-index hash-matched and
+ * skipped it too.
+ *
+ * The invalid point is rejected by Qdrant itself — a dense vector of the wrong
+ * width — rather than by a stub, so the batch/per-point fallback is exercised
+ * exactly as it runs in production.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { collectionName, projectIdFromPath } from "../../src/config.js";
+import { ensureQdrantReady } from "../../src/services/docker.js";
+import { requestedIndexProfile } from "../../src/services/index-profile.js";
+import {
+  ensureCollection,
+  getCollectionInfo,
+  loadProjectHashes,
+  saveProjectMetadata,
+  upsertPreEmbeddedChunks,
+} from "../../src/services/qdrant.js";
+import { isDockerAvailable } from "../helpers/fixtures.js";
+import { deleteTestCollection, waitForQdrant } from "../helpers/setup.js";
+
+const dockerAvailable = isDockerAvailable();
+const TEST_PROJECT = "/tmp/socraticode-partial-upsert-integration";
+const TEST_COLLECTION = collectionName(projectIdFromPath(TEST_PROJECT));
+
+const KEPT_ID = "11111111-1111-4111-8111-111111111111";
+const LOST_ID = "22222222-2222-4222-8222-222222222222";
+const KEPT_PATH = "src/kept.ts";
+const LOST_PATH = "src/lost.ts";
+
+/** Width the collection was actually created with, read back from Qdrant. */
+let denseSize = 0;
+
+function pointOfWidth(id: string, relativePath: string, width: number) {
+  return {
+    id,
+    vector: Array.from({ length: width }, () => 0.1),
+    bm25Text: `contents of ${relativePath}`,
+    payload: { relativePath, content: "chunk", contentHash: `hash-${relativePath}` },
+  };
+}
+
+describe.skipIf(!dockerAvailable)("partial Qdrant upsert fails the whole operation", () => {
+  beforeAll(async () => {
+    await ensureQdrantReady();
+    await waitForQdrant();
+    await deleteTestCollection(TEST_COLLECTION);
+    await ensureCollection(TEST_COLLECTION);
+
+    const info = await getCollectionInfo(TEST_COLLECTION);
+    if (!info?.denseVectorSize) {
+      throw new Error("test setup: could not read the collection's dense vector width");
+    }
+    denseSize = info.denseVectorSize;
+  }, 180_000);
+
+  afterAll(async () => {
+    await deleteTestCollection(TEST_COLLECTION);
+  });
+
+  it("stores the valid point, then throws naming the invalid one", async () => {
+    const err = await upsertPreEmbeddedChunks(TEST_COLLECTION, [
+      pointOfWidth(KEPT_ID, KEPT_PATH, denseSize),
+      // Wrong width — Qdrant rejects this in the batch and again on its own.
+      pointOfWidth(LOST_ID, LOST_PATH, denseSize + 3),
+    ]).catch((e: unknown) => e as Error);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain(LOST_PATH);
+    expect(err.message).toContain("1/2");
+
+    // Failing the operation must not throw away the point that did land.
+    const info = await getCollectionInfo(TEST_COLLECTION);
+    expect(info?.pointsCount).toBe(1);
+  }, 120_000);
+
+  it("leaves the stored hash unadvanced so a later healthy run retries the file", async () => {
+    const priorHash = "hash-from-previous-index";
+    await saveProjectMetadata(
+      TEST_COLLECTION,
+      TEST_PROJECT,
+      1,
+      1,
+      new Map([[LOST_PATH, priorHash]]),
+      "completed",
+      requestedIndexProfile("code"),
+    );
+
+    // A caller that honours the throw never reaches its hash update.
+    await upsertPreEmbeddedChunks(TEST_COLLECTION, [
+      pointOfWidth(KEPT_ID, KEPT_PATH, denseSize),
+      pointOfWidth(LOST_ID, LOST_PATH, denseSize + 3),
+    ]).catch(() => undefined);
+
+    const hashes = await loadProjectHashes(TEST_COLLECTION);
+    expect(hashes?.get(LOST_PATH)).toBe(priorHash);
+
+    // With the stale hash intact the file still looks changed, so the next run
+    // re-indexes it — and now that the point is well-formed, it lands.
+    await expect(
+      upsertPreEmbeddedChunks(TEST_COLLECTION, [
+        pointOfWidth(LOST_ID, LOST_PATH, denseSize),
+      ]),
+    ).resolves.toBeUndefined();
+
+    const info = await getCollectionInfo(TEST_COLLECTION);
+    expect(info?.pointsCount).toBe(2);
+  }, 120_000);
+});

--- a/tests/integration/partial-upsert-skip.test.ts
+++ b/tests/integration/partial-upsert-skip.test.ts
@@ -26,6 +26,7 @@ import { collectionName, projectIdFromPath } from "../../src/config.js";
 import { ensureQdrantReady } from "../../src/services/docker.js";
 import { requestedIndexProfile } from "../../src/services/index-profile.js";
 import {
+  deleteCollection,
   ensureCollection,
   getCollectionInfo,
   loadProjectHashes,
@@ -33,7 +34,6 @@ import {
   upsertPreEmbeddedChunks,
 } from "../../src/services/qdrant.js";
 import { isDockerAvailable } from "../helpers/fixtures.js";
-import { deleteTestCollection, waitForQdrant } from "../helpers/setup.js";
 
 /**
  * Locally this skips without Docker. In CI it must not: a test that skips
@@ -71,18 +71,24 @@ describe.skipIf(!shouldRun)("partial Qdrant upsert fails the whole operation", (
     if (!requireQdrant) {
       await ensureQdrantReady();
     }
-    const ready = await waitForQdrant(60_000);
-    if (!ready) {
+
+    // Reach Qdrant through the service's own client rather than the raw one in
+    // tests/helpers: getClient() applies ensureQdrantClientCompatibility(),
+    // which is what makes the client usable on Node 26. A bare QdrantClient
+    // fails there with "Failed to obtain server version", which would look like
+    // an unreachable server even while Qdrant is healthy.
+    try {
+      await deleteCollection(TEST_COLLECTION).catch(() => undefined);
+      await ensureCollection(TEST_COLLECTION);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
       throw new Error(
         requireQdrant
-          ? "REQUIRE_QDRANT=1 but Qdrant is not reachable. This regression must fail rather " +
-            "than skip: set QDRANT_MODE/QDRANT_HOST/QDRANT_PORT to a running instance."
-          : "Qdrant did not become ready",
+          ? "REQUIRE_QDRANT=1 but Qdrant is not usable. This regression must fail rather than " +
+            `skip: point QDRANT_MODE/QDRANT_URL at a running instance. Underlying error: ${detail}`
+          : `Qdrant did not become ready: ${detail}`,
       );
     }
-
-    await deleteTestCollection(TEST_COLLECTION);
-    await ensureCollection(TEST_COLLECTION);
 
     const info = await getCollectionInfo(TEST_COLLECTION);
     if (!info?.denseVectorSize) {
@@ -92,7 +98,7 @@ describe.skipIf(!shouldRun)("partial Qdrant upsert fails the whole operation", (
   }, 180_000);
 
   afterAll(async () => {
-    await deleteTestCollection(TEST_COLLECTION);
+    await deleteCollection(TEST_COLLECTION).catch(() => undefined);
   });
 
   it("stores the valid point, then throws naming the invalid one", async () => {

--- a/tests/integration/partial-upsert-skip.test.ts
+++ b/tests/integration/partial-upsert-skip.test.ts
@@ -35,7 +35,17 @@ import {
 import { isDockerAvailable } from "../helpers/fixtures.js";
 import { deleteTestCollection, waitForQdrant } from "../helpers/setup.js";
 
+/**
+ * Locally this skips without Docker. In CI it must not: a test that skips
+ * itself is a silent no-op, and a silent no-op is indistinguishable from a
+ * passing boundary check. REQUIRE_QDRANT=1 therefore turns an unreachable
+ * backend into a failure — the same reason the Rust graph job asserts
+ * `rustc --version` before running its skip-capable test.
+ */
+const requireQdrant = process.env.REQUIRE_QDRANT === "1";
 const dockerAvailable = isDockerAvailable();
+const shouldRun = requireQdrant || dockerAvailable;
+
 const TEST_PROJECT = "/tmp/socraticode-partial-upsert-integration";
 const TEST_COLLECTION = collectionName(projectIdFromPath(TEST_PROJECT));
 
@@ -56,10 +66,21 @@ function pointOfWidth(id: string, relativePath: string, width: number) {
   };
 }
 
-describe.skipIf(!dockerAvailable)("partial Qdrant upsert fails the whole operation", () => {
+describe.skipIf(!shouldRun)("partial Qdrant upsert fails the whole operation", () => {
   beforeAll(async () => {
-    await ensureQdrantReady();
-    await waitForQdrant();
+    if (!requireQdrant) {
+      await ensureQdrantReady();
+    }
+    const ready = await waitForQdrant(60_000);
+    if (!ready) {
+      throw new Error(
+        requireQdrant
+          ? "REQUIRE_QDRANT=1 but Qdrant is not reachable. This regression must fail rather " +
+            "than skip: set QDRANT_MODE/QDRANT_HOST/QDRANT_PORT to a running instance."
+          : "Qdrant did not become ready",
+      );
+    }
+
     await deleteTestCollection(TEST_COLLECTION);
     await ensureCollection(TEST_COLLECTION);
 

--- a/tests/unit/indexer-partial-upsert.test.ts
+++ b/tests/unit/indexer-partial-upsert.test.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+/**
+ * Caller-level behaviour around partial Qdrant writes and completion reporting.
+ *
+ * Only the Qdrant client and the metadata store are stubbed — `indexProject`
+ * and `upsertPreEmbeddedChunks` both run as shipped, so the batch -> per-point
+ * fallback and the caller's reaction to it are exercised together.
+ */
+
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EffectiveIndexProfile } from "../../src/services/index-profile.js";
+
+/** Points whose payload.relativePath is in here are rejected by the stub client. */
+const failUpsertFor = new Set<string>();
+
+let storedHashes: Map<string, string> | null = null;
+let storedProfile: EffectiveIndexProfile | null = null;
+let collectionInfo: { pointsCount: number; status: string } | null = null;
+let tempRoot = "";
+
+const savedMetadata: Array<{
+  filesTotal: number;
+  filesIndexed: number;
+  hashes: Map<string, string>;
+  status: string;
+}> = [];
+
+vi.mock("../../src/services/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@qdrant/js-client-rest", () => ({
+  QdrantClient: class {
+    async upsert(_collection: string, body: { points: Array<{ payload?: Record<string, unknown> }> }) {
+      if (body.points.some((p) => failUpsertFor.has(String(p.payload?.relativePath)))) {
+        throw new Error("Bad Request: invalid point");
+      }
+    }
+  },
+}));
+
+vi.mock("../../src/services/qdrant-client-compat.js", () => ({
+  ensureQdrantClientCompatibility: vi.fn(),
+}));
+
+vi.mock("../../src/services/embedding-provider.js", () => ({
+  getEmbeddingProvider: vi.fn(async () => ({
+    ensureReady: vi.fn(async () => ({ modelPulled: false, containerStarted: false, imagePulled: false })),
+  })),
+}));
+
+vi.mock("../../src/services/embeddings.js", () => ({
+  prepareDocumentText: vi.fn((content: string) => content),
+  generateEmbeddings: vi.fn(async (texts: string[]) => texts.map(() => [0.1, 0.1, 0.1])),
+}));
+
+// Keep the real upsertPreEmbeddedChunks; stub only the metadata/collection I/O.
+vi.mock("../../src/services/qdrant.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/services/qdrant.js")>();
+  return {
+    ...actual,
+    deleteCollection: vi.fn(async () => undefined),
+    deleteFileChunks: vi.fn(async () => undefined),
+    deleteProjectMetadata: vi.fn(async () => undefined),
+    ensureCollection: vi.fn(async () => undefined),
+    getCollectionInfo: vi.fn(async () => collectionInfo),
+    getProjectMetadata: vi.fn(async () => null),
+    loadProjectEffectiveProfile: vi.fn(async () => storedProfile),
+    loadProjectHashes: vi.fn(async () => (storedHashes === null ? null : new Map(storedHashes))),
+    saveProjectMetadata: vi.fn(async (
+      _collection: string,
+      _projectPath: string,
+      filesTotal: number,
+      filesIndexed: number,
+      hashes: Map<string, string>,
+      status: string,
+      profile: EffectiveIndexProfile,
+    ) => {
+      storedHashes = new Map(hashes);
+      storedProfile = profile;
+      savedMetadata.push({ filesTotal, filesIndexed, hashes: new Map(hashes), status });
+    }),
+  };
+});
+
+vi.mock("../../src/services/code-graph.js", () => ({
+  ensureDynamicLanguages: vi.fn(),
+  getAstGrepLang: vi.fn(() => null),
+  rebuildGraph: vi.fn(async () => ({ nodes: [], edges: [] })),
+  removeGraph: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../src/services/elixir-templates.js", () => ({
+  analyzeElixirTemplate: vi.fn(() => null),
+  ensureElixirTemplateParsers: vi.fn(async () => undefined),
+  isElixirTemplateExtension: vi.fn(() => false),
+}));
+
+vi.mock("../../src/services/lock.js", () => ({
+  acquireProjectLock: vi.fn(async () => true),
+  releaseProjectLock: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../src/services/symbol-graph-incremental.js", () => ({
+  updateChangedFilesSymbolGraph: vi.fn(async () => ({ updated: 0, removed: 0 })),
+}));
+
+vi.mock("../../src/services/symbol-graph-store.js", () => ({
+  loadSymbolGraphMeta: vi.fn(async () => null),
+}));
+
+const originalEnv = { ...process.env };
+
+async function loadIndexer(overrides: Record<string, string> = {}) {
+  vi.resetModules();
+  process.env = {
+    ...originalEnv,
+    EMBEDDING_PROVIDER: "openai",
+    EMBEDDING_MODEL: "test-model",
+    EMBEDDING_DIMENSIONS: "3",
+    EMBEDDING_CONTEXT_LENGTH: "512",
+    EMBEDDING_DOCUMENT_INCLUDE_PATH: "false",
+    MAX_CHUNK_CHARS: "2000",
+    MAX_FILE_SIZE_MB: "5",
+    ...overrides,
+  };
+  return import("../../src/services/indexer.js");
+}
+
+beforeEach(async () => {
+  storedHashes = null;
+  storedProfile = null;
+  collectionInfo = null;
+  savedMetadata.length = 0;
+  failUpsertFor.clear();
+  tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "socraticode-indexer-partial-"));
+});
+
+afterEach(async () => {
+  process.env = { ...originalEnv };
+  await fsp.rm(tempRoot, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe("completion reporting counts only files the index represents", () => {
+  it("reports filesTotal 2 and filesIndexed 1 when one file is skipped as oversized", async () => {
+    // 1 kB ceiling: small.ts is indexed, big.ts is skipped before chunking.
+    const indexer = await loadIndexer({ MAX_FILE_SIZE_MB: "0.001" });
+    const project = await fsp.mkdtemp(path.join(tempRoot, "project-"));
+    await fsp.writeFile(path.join(project, "small.ts"), "export const small = 1;\n");
+    await fsp.writeFile(path.join(project, "big.ts"), `// ${"x".repeat(4000)}\n`);
+
+    const result = await indexer.indexProject(project);
+
+    const meta = savedMetadata.at(-1);
+    expect(meta?.filesTotal).toBe(2);
+    expect(meta?.filesIndexed).toBe(1);
+    // The returned and reported count must match what the index holds, not the
+    // number of paths the walk turned up.
+    expect(result.filesIndexed).toBe(1);
+  });
+});
+
+describe("a partial Qdrant failure reaches the caller and is retried later", () => {
+  it("propagates the failure, saves no completion, and re-indexes the file on the next healthy run", async () => {
+    const indexer = await loadIndexer();
+    const project = await fsp.mkdtemp(path.join(tempRoot, "project-"));
+    const lostContent = "export const lost = 2;\n";
+    await fsp.writeFile(path.join(project, "kept.ts"), "export const kept = 1;\n");
+    await fsp.writeFile(path.join(project, "lost.ts"), lostContent);
+
+    failUpsertFor.add("lost.ts");
+
+    // 1. the partial Qdrant failure is propagated
+    await expect(indexer.indexProject(project)).rejects.toThrow(/point\(s\) failed|upsert failed/i);
+
+    // 2. no successful completion was saved, and the hash was never advanced
+    expect(savedMetadata.some((m) => m.status === "completed")).toBe(false);
+    expect(storedHashes?.has("lost.ts") ?? false).toBe(false);
+
+    // 3. a subsequent healthy run selects the file and stores it
+    failUpsertFor.clear();
+    const result = await indexer.indexProject(project);
+
+    expect(storedHashes?.get("lost.ts")).toBe(indexer.hashContent(lostContent));
+    expect(result.filesIndexed).toBe(2);
+    expect(savedMetadata.at(-1)?.status).toBe("completed");
+  });
+});

--- a/tests/unit/partial-upsert-skip.test.ts
+++ b/tests/unit/partial-upsert-skip.test.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EffectiveIndexProfile } from "../../src/services/index-profile.js";
+
+let collectionInfo: { pointsCount: number; status: string } | null = null;
+let storedHashes: Map<string, string> | null = null;
+let storedProfile: EffectiveIndexProfile | null = null;
+let tempRoot = "";
+
+/** Points whose payload.relativePath is in here fail to upsert. */
+const failUpsertFor = new Set<string>();
+
+const savedMetadata: Array<{ hashes: Map<string, string>; status: string }> = [];
+const deletedFiles: string[] = [];
+
+vi.mock("../../src/services/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../src/services/embedding-provider.js", () => ({
+  getEmbeddingProvider: vi.fn(async () => ({
+    ensureReady: vi.fn(async () => ({
+      modelPulled: false,
+      containerStarted: false,
+      imagePulled: false,
+    })),
+  })),
+}));
+
+vi.mock("../../src/services/embeddings.js", () => ({
+  prepareDocumentText: vi.fn((content: string) => content),
+  generateEmbeddings: vi.fn(async (texts: string[]) => texts.map(() => [0.1, 0.1, 0.1])),
+}));
+
+vi.mock("../../src/services/qdrant.js", () => ({
+  deleteCollection: vi.fn(async () => undefined),
+  deleteFileChunks: vi.fn(async (_collection: string, relativePath: string) => {
+    deletedFiles.push(relativePath);
+  }),
+  deleteProjectMetadata: vi.fn(async () => undefined),
+  ensureCollection: vi.fn(async () => undefined),
+  getCollectionInfo: vi.fn(async () => collectionInfo),
+  getProjectMetadata: vi.fn(async () => null),
+  loadProjectEffectiveProfile: vi.fn(async () => storedProfile),
+  loadProjectHashes: vi.fn(async () => (storedHashes === null ? null : new Map(storedHashes))),
+  saveProjectMetadata: vi.fn(async (
+    _collection: string,
+    _projectPath: string,
+    _filesTotal: number,
+    _filesIndexed: number,
+    hashes: Map<string, string>,
+    status: string,
+  ) => {
+    storedHashes = new Map(hashes);
+    savedMetadata.push({ hashes: new Map(hashes), status });
+  }),
+  // Mirrors the real per-point fallback: points that fail are skipped, and the
+  // owning file's relativePath is reported back to the caller.
+  upsertPreEmbeddedChunks: vi.fn(async (
+    _collection: string,
+    points: Array<{ payload: Record<string, unknown> }>,
+  ) => {
+    const skippedPaths = new Set<string>();
+    let pointsSkipped = 0;
+    for (const p of points) {
+      const rel = p.payload?.relativePath;
+      if (typeof rel === "string" && failUpsertFor.has(rel)) {
+        pointsSkipped++;
+        skippedPaths.add(rel);
+      }
+    }
+    return { pointsSkipped, skippedPaths };
+  }),
+}));
+
+vi.mock("../../src/services/code-graph.js", () => ({
+  ensureDynamicLanguages: vi.fn(),
+  getAstGrepLang: vi.fn(() => null),
+  rebuildGraph: vi.fn(async () => ({ nodes: [], edges: [] })),
+  removeGraph: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../src/services/elixir-templates.js", () => ({
+  analyzeElixirTemplate: vi.fn(() => null),
+  ensureElixirTemplateParsers: vi.fn(async () => undefined),
+  isElixirTemplateExtension: vi.fn(() => false),
+}));
+
+vi.mock("../../src/services/lock.js", () => ({
+  acquireProjectLock: vi.fn(async () => true),
+  releaseProjectLock: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../src/services/symbol-graph-incremental.js", () => ({
+  updateChangedFilesSymbolGraph: vi.fn(async () => ({ updated: 0, removed: 0 })),
+}));
+
+vi.mock("../../src/services/symbol-graph-store.js", () => ({
+  loadSymbolGraphMeta: vi.fn(async () => null),
+}));
+
+const originalEnv = { ...process.env };
+
+async function loadIndexer() {
+  vi.resetModules();
+  process.env = {
+    ...originalEnv,
+    EMBEDDING_PROVIDER: "openai",
+    EMBEDDING_MODEL: "test-model",
+    EMBEDDING_DIMENSIONS: "3",
+    EMBEDDING_CONTEXT_LENGTH: "512",
+    EMBEDDING_DOCUMENT_INCLUDE_PATH: "false",
+    MAX_CHUNK_CHARS: "2000",
+    MAX_FILE_SIZE_MB: "1",
+  };
+  return import("../../src/services/indexer.js");
+}
+
+beforeEach(async () => {
+  collectionInfo = null;
+  storedHashes = null;
+  storedProfile = null;
+  savedMetadata.length = 0;
+  deletedFiles.length = 0;
+  failUpsertFor.clear();
+  tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "socraticode-partial-upsert-"));
+});
+
+afterEach(async () => {
+  process.env = { ...originalEnv };
+  await fsp.rm(tempRoot, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe("partial upsert skips must not mark a file as indexed", () => {
+  it("withholds the hash of a file whose points were skipped during a full index", async () => {
+    const indexer = await loadIndexer();
+    const project = await fsp.mkdtemp(path.join(tempRoot, "project-"));
+    await fsp.writeFile(path.join(project, "kept.ts"), "export const kept = 1;\n");
+    await fsp.writeFile(path.join(project, "lost.ts"), "export const lost = 2;\n");
+
+    failUpsertFor.add("lost.ts");
+
+    await indexer.indexProject(project);
+
+    const hashes = savedMetadata.at(-1)?.hashes ?? new Map();
+    expect(hashes.has("kept.ts")).toBe(true);
+    // The file whose points were skipped has no chunks in the collection, so
+    // recording its hash would suppress every future attempt to index it.
+    expect(hashes.has("lost.ts")).toBe(false);
+  });
+
+  it("re-indexes a previously skipped file on the next incremental run", async () => {
+    const indexer = await loadIndexer();
+    const project = await fsp.mkdtemp(path.join(tempRoot, "project-"));
+    const lostContent = "export const lost = 2;\n";
+    await fsp.writeFile(path.join(project, "kept.ts"), "export const kept = 1;\n");
+    await fsp.writeFile(path.join(project, "lost.ts"), lostContent);
+
+    // First pass: lost.ts fails to upsert.
+    failUpsertFor.add("lost.ts");
+    await indexer.indexProject(project);
+    expect(storedHashes?.has("lost.ts")).toBe(false);
+
+    // Second pass with Qdrant healthy: the file must be picked up again even
+    // though nothing about it changed on disk.
+    failUpsertFor.clear();
+    collectionInfo = { pointsCount: 1, status: "green" };
+    const result = await indexer.updateProjectIndex(project);
+
+    expect(result.chunksCreated).toBeGreaterThan(0);
+    expect(storedHashes?.get("lost.ts")).toBe(indexer.hashContent(lostContent));
+  });
+
+  it("does not count skipped chunks as created", async () => {
+    const indexer = await loadIndexer();
+    const project = await fsp.mkdtemp(path.join(tempRoot, "project-"));
+    await fsp.writeFile(path.join(project, "kept.ts"), "export const kept = 1;\n");
+    await fsp.writeFile(path.join(project, "lost.ts"), "export const lost = 2;\n");
+
+    failUpsertFor.add("lost.ts");
+
+    const result = await indexer.indexProject(project);
+
+    // Two files chunked, one never landed in Qdrant.
+    expect(result.chunksCreated).toBe(1);
+  });
+});

--- a/tests/unit/partial-upsert-skip.test.ts
+++ b/tests/unit/partial-upsert-skip.test.ts
@@ -1,234 +1,113 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 
-import fsp from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
+/**
+ * A point that still fails after the per-point fallback must fail the whole
+ * upsert. Anything less lets a caller record a file as indexed whose chunks were
+ * deleted and never replaced, stranding it at zero chunks behind a content hash
+ * that suppresses every future re-index.
+ *
+ * These exercise the real `upsertPreEmbeddedChunks`, stubbing only the Qdrant
+ * client beneath it, so the batch -> per-point fallback runs as shipped.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { EffectiveIndexProfile } from "../../src/services/index-profile.js";
 
-let collectionInfo: { pointsCount: number; status: string } | null = null;
-let storedHashes: Map<string, string> | null = null;
-let storedProfile: EffectiveIndexProfile | null = null;
-let tempRoot = "";
+/** Points carrying this path are rejected by the stub client. */
+const POISON_PATH = "src/lost.ts";
 
-/** Points whose payload.relativePath is in here fail to upsert. */
-const failUpsertFor = new Set<string>();
-
-const savedMetadata: Array<{ hashes: Map<string, string>; status: string }> = [];
-const deletedFiles: string[] = [];
+const upsertCalls: Array<{ collection: string; ids: string[] }> = [];
 
 vi.mock("../../src/services/logger.js", () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-vi.mock("../../src/services/embedding-provider.js", () => ({
-  getEmbeddingProvider: vi.fn(async () => ({
-    ensureReady: vi.fn(async () => ({
-      modelPulled: false,
-      containerStarted: false,
-      imagePulled: false,
-    })),
-  })),
+vi.mock("../../src/services/qdrant-client-compat.js", () => ({
+  ensureQdrantClientCompatibility: vi.fn(),
 }));
 
-vi.mock("../../src/services/embeddings.js", () => ({
-  prepareDocumentText: vi.fn((content: string) => content),
-  generateEmbeddings: vi.fn(async (texts: string[]) => texts.map(() => [0.1, 0.1, 0.1])),
-}));
-
-vi.mock("../../src/services/qdrant.js", () => ({
-  deleteCollection: vi.fn(async () => undefined),
-  deleteFileChunks: vi.fn(async (_collection: string, relativePath: string) => {
-    deletedFiles.push(relativePath);
-  }),
-  deleteProjectMetadata: vi.fn(async () => undefined),
-  ensureCollection: vi.fn(async () => undefined),
-  getCollectionInfo: vi.fn(async () => collectionInfo),
-  getProjectMetadata: vi.fn(async () => null),
-  loadProjectEffectiveProfile: vi.fn(async () => storedProfile),
-  loadProjectHashes: vi.fn(async () => (storedHashes === null ? null : new Map(storedHashes))),
-  saveProjectMetadata: vi.fn(async (
-    _collection: string,
-    _projectPath: string,
-    _filesTotal: number,
-    _filesIndexed: number,
-    hashes: Map<string, string>,
-    status: string,
-  ) => {
-    storedHashes = new Map(hashes);
-    savedMetadata.push({ hashes: new Map(hashes), status });
-  }),
-  // Mirrors the real per-point fallback: points that fail are skipped, and the
-  // owning file's relativePath is reported back to the caller.
-  upsertPreEmbeddedChunks: vi.fn(async (
-    _collection: string,
-    points: Array<{ payload: Record<string, unknown> }>,
-  ) => {
-    const skippedPaths = new Set<string>();
-    let pointsSkipped = 0;
-    for (const p of points) {
-      const rel = p.payload?.relativePath;
-      if (typeof rel === "string" && failUpsertFor.has(rel)) {
-        pointsSkipped++;
-        skippedPaths.add(rel);
+vi.mock("@qdrant/js-client-rest", () => ({
+  QdrantClient: class {
+    async upsert(collection: string, body: { points: Array<{ id: string; payload?: Record<string, unknown> }> }) {
+      const ids = body.points.map((p) => p.id);
+      const poisoned = body.points.some((p) => p.payload?.relativePath === POISON_PATH);
+      if (poisoned) {
+        // Fails whether sent in a batch or on its own, so the per-point
+        // fallback isolates it rather than curing it.
+        throw new Error("Bad Request: invalid point");
       }
+      upsertCalls.push({ collection, ids });
     }
-    return { pointsSkipped, skippedPaths };
-  }),
+  },
 }));
 
-vi.mock("../../src/services/code-graph.js", () => ({
-  ensureDynamicLanguages: vi.fn(),
-  getAstGrepLang: vi.fn(() => null),
-  rebuildGraph: vi.fn(async () => ({ nodes: [], edges: [] })),
-  removeGraph: vi.fn(async () => undefined),
-}));
-
-vi.mock("../../src/services/elixir-templates.js", () => ({
-  analyzeElixirTemplate: vi.fn(() => null),
-  ensureElixirTemplateParsers: vi.fn(async () => undefined),
-  isElixirTemplateExtension: vi.fn(() => false),
-}));
-
-vi.mock("../../src/services/lock.js", () => ({
-  acquireProjectLock: vi.fn(async () => true),
-  releaseProjectLock: vi.fn(async () => undefined),
-}));
-
-vi.mock("../../src/services/symbol-graph-incremental.js", () => ({
-  updateChangedFilesSymbolGraph: vi.fn(async () => ({ updated: 0, removed: 0 })),
-}));
-
-vi.mock("../../src/services/symbol-graph-store.js", () => ({
-  loadSymbolGraphMeta: vi.fn(async () => null),
-}));
-
-const originalEnv = { ...process.env };
-
-async function loadIndexer() {
-  vi.resetModules();
-  process.env = {
-    ...originalEnv,
-    EMBEDDING_PROVIDER: "openai",
-    EMBEDDING_MODEL: "test-model",
-    EMBEDDING_DIMENSIONS: "3",
-    EMBEDDING_CONTEXT_LENGTH: "512",
-    EMBEDDING_DOCUMENT_INCLUDE_PATH: "false",
-    MAX_CHUNK_CHARS: "2000",
-    MAX_FILE_SIZE_MB: "1",
+function point(id: string, relativePath: string) {
+  return {
+    id,
+    vector: [0.1, 0.2, 0.3],
+    bm25Text: `text for ${relativePath}`,
+    payload: { relativePath, content: "x" },
   };
-  return import("../../src/services/indexer.js");
 }
 
-beforeEach(async () => {
-  collectionInfo = null;
-  storedHashes = null;
-  storedProfile = null;
-  savedMetadata.length = 0;
-  deletedFiles.length = 0;
-  failUpsertFor.clear();
-  tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "socraticode-partial-upsert-"));
+beforeEach(() => {
+  upsertCalls.length = 0;
+  vi.resetModules();
 });
 
-afterEach(async () => {
-  process.env = { ...originalEnv };
-  await fsp.rm(tempRoot, { recursive: true, force: true });
+afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("partial upsert skips must not mark a file as indexed", () => {
-  it("withholds the hash of a file whose points were skipped during a full index", async () => {
-    const indexer = await loadIndexer();
-    const project = await fsp.mkdtemp(path.join(tempRoot, "project-"));
-    await fsp.writeFile(path.join(project, "kept.ts"), "export const kept = 1;\n");
-    await fsp.writeFile(path.join(project, "lost.ts"), "export const lost = 2;\n");
+describe("upsertPreEmbeddedChunks partial failure handling", () => {
+  it("throws when a point still fails after the per-point fallback", async () => {
+    const { upsertPreEmbeddedChunks } = await import("../../src/services/qdrant.js");
 
-    failUpsertFor.add("lost.ts");
-
-    await indexer.indexProject(project);
-
-    const hashes = savedMetadata.at(-1)?.hashes ?? new Map();
-    expect(hashes.has("kept.ts")).toBe(true);
-    // The file whose points were skipped has no chunks in the collection, so
-    // recording its hash would suppress every future attempt to index it.
-    expect(hashes.has("lost.ts")).toBe(false);
+    await expect(
+      upsertPreEmbeddedChunks("codebase_test", [
+        point("00000000-0000-4000-8000-000000000001", "src/kept.ts"),
+        point("00000000-0000-4000-8000-000000000002", POISON_PATH),
+      ]),
+    ).rejects.toThrow(/1\/2 point\(s\) failed/);
   });
 
-  it("re-indexes a previously skipped file on the next incremental run", async () => {
-    const indexer = await loadIndexer();
-    const project = await fsp.mkdtemp(path.join(tempRoot, "project-"));
-    const lostContent = "export const lost = 2;\n";
-    await fsp.writeFile(path.join(project, "kept.ts"), "export const kept = 1;\n");
-    await fsp.writeFile(path.join(project, "lost.ts"), lostContent);
+  it("names the affected file and the collection in the error", async () => {
+    const { upsertPreEmbeddedChunks } = await import("../../src/services/qdrant.js");
 
-    // First pass: lost.ts fails to upsert.
-    failUpsertFor.add("lost.ts");
-    await indexer.indexProject(project);
-    expect(storedHashes?.has("lost.ts")).toBe(false);
+    const err = await upsertPreEmbeddedChunks("codebase_test", [
+      point("00000000-0000-4000-8000-000000000001", "src/kept.ts"),
+      point("00000000-0000-4000-8000-000000000002", POISON_PATH),
+    ]).catch((e: unknown) => e as Error);
 
-    // Second pass with Qdrant healthy: the file must be picked up again even
-    // though nothing about it changed on disk.
-    failUpsertFor.clear();
-    collectionInfo = { pointsCount: 1, status: "green" };
-    const result = await indexer.updateProjectIndex(project);
-
-    expect(result.chunksCreated).toBeGreaterThan(0);
-    expect(storedHashes?.get("lost.ts")).toBe(indexer.hashContent(lostContent));
+    expect(err.message).toContain(POISON_PATH);
+    expect(err.message).toContain("codebase_test");
   });
 
-  it("does not count skipped chunks as created", async () => {
-    const indexer = await loadIndexer();
-    const project = await fsp.mkdtemp(path.join(tempRoot, "project-"));
-    await fsp.writeFile(path.join(project, "kept.ts"), "export const kept = 1;\n");
-    await fsp.writeFile(path.join(project, "lost.ts"), "export const lost = 2;\n");
+  it("still stores the healthy points of a mixed batch before failing", async () => {
+    const { upsertPreEmbeddedChunks } = await import("../../src/services/qdrant.js");
 
-    failUpsertFor.add("lost.ts");
+    await upsertPreEmbeddedChunks("codebase_test", [
+      point("00000000-0000-4000-8000-000000000001", "src/kept.ts"),
+      point("00000000-0000-4000-8000-000000000002", POISON_PATH),
+    ]).catch(() => undefined);
 
-    const result = await indexer.indexProject(project);
-
-    // Two files chunked, one never landed in Qdrant.
-    expect(result.chunksCreated).toBe(1);
+    // The batch call fails, then the fallback writes the good point on its own.
+    // Losing it would be a second, quieter data-loss bug.
+    const stored = upsertCalls.flatMap((c) => c.ids);
+    expect(stored).toContain("00000000-0000-4000-8000-000000000001");
+    expect(stored).not.toContain("00000000-0000-4000-8000-000000000002");
   });
 
-  it("does not report a skipped file as indexed", async () => {
-    const indexer = await loadIndexer();
-    const project = await fsp.mkdtemp(path.join(tempRoot, "project-"));
-    await fsp.writeFile(path.join(project, "kept.ts"), "export const kept = 1;\n");
-    await fsp.writeFile(path.join(project, "lost.ts"), "export const lost = 2;\n");
+  it("resolves without error when every point lands", async () => {
+    const { upsertPreEmbeddedChunks } = await import("../../src/services/qdrant.js");
 
-    failUpsertFor.add("lost.ts");
+    await expect(
+      upsertPreEmbeddedChunks("codebase_test", [
+        point("00000000-0000-4000-8000-000000000001", "src/kept.ts"),
+        point("00000000-0000-4000-8000-000000000003", "src/also-kept.ts"),
+      ]),
+    ).resolves.toBeUndefined();
 
-    const result = await indexer.indexProject(project);
-
-    // Two files were walked, one never landed. Reporting 2 would claim a clean
-    // run and hide the file whose hash was withheld precisely so it is retried.
-    expect(result.filesIndexed).toBe(1);
-  });
-
-  it("does not report a skipped file as indexed when it already had a stored hash", async () => {
-    const indexer = await loadIndexer();
-    const project = await fsp.mkdtemp(path.join(tempRoot, "project-"));
-    const keptContent = "export const kept = 1;\n";
-    await fsp.writeFile(path.join(project, "kept.ts"), keptContent);
-    await fsp.writeFile(path.join(project, "lost.ts"), "export const lost = 2;\n");
-
-    // Both files are already indexed and both have since been edited, so both
-    // are re-chunked into the same batch — which is what makes the skip below
-    // partial rather than total. lost.ts keeps a STALE hash after the withhold,
-    // so hashes.size alone would still count it and report a clean 2/2.
-    collectionInfo = { pointsCount: 2, status: "green" };
-    storedHashes = new Map([
-      ["kept.ts", indexer.hashContent("export const kept = 0;\n")],
-      ["lost.ts", indexer.hashContent("export const lost = 1;\n")],
-    ]);
-
-    failUpsertFor.add("lost.ts");
-
-    const result = await indexer.indexProject(project);
-
-    expect(result.filesIndexed).toBe(1);
-    // The stale hash must remain, so the next run retries the file.
-    expect(storedHashes?.get("lost.ts")).toBe(indexer.hashContent("export const lost = 1;\n"));
+    expect(upsertCalls).toHaveLength(1);
   });
 });

--- a/tests/unit/partial-upsert-skip.test.ts
+++ b/tests/unit/partial-upsert-skip.test.ts
@@ -190,4 +190,19 @@ describe("partial upsert skips must not mark a file as indexed", () => {
     // Two files chunked, one never landed in Qdrant.
     expect(result.chunksCreated).toBe(1);
   });
+
+  it("does not report a skipped file as indexed", async () => {
+    const indexer = await loadIndexer();
+    const project = await fsp.mkdtemp(path.join(tempRoot, "project-"));
+    await fsp.writeFile(path.join(project, "kept.ts"), "export const kept = 1;\n");
+    await fsp.writeFile(path.join(project, "lost.ts"), "export const lost = 2;\n");
+
+    failUpsertFor.add("lost.ts");
+
+    const result = await indexer.indexProject(project);
+
+    // Two files were walked, one never landed. Reporting 2 would claim a clean
+    // run and hide the file whose hash was withheld precisely so it is retried.
+    expect(result.filesIndexed).toBe(1);
+  });
 });

--- a/tests/unit/partial-upsert-skip.test.ts
+++ b/tests/unit/partial-upsert-skip.test.ts
@@ -205,4 +205,30 @@ describe("partial upsert skips must not mark a file as indexed", () => {
     // run and hide the file whose hash was withheld precisely so it is retried.
     expect(result.filesIndexed).toBe(1);
   });
+
+  it("does not report a skipped file as indexed when it already had a stored hash", async () => {
+    const indexer = await loadIndexer();
+    const project = await fsp.mkdtemp(path.join(tempRoot, "project-"));
+    const keptContent = "export const kept = 1;\n";
+    await fsp.writeFile(path.join(project, "kept.ts"), keptContent);
+    await fsp.writeFile(path.join(project, "lost.ts"), "export const lost = 2;\n");
+
+    // Both files are already indexed and both have since been edited, so both
+    // are re-chunked into the same batch — which is what makes the skip below
+    // partial rather than total. lost.ts keeps a STALE hash after the withhold,
+    // so hashes.size alone would still count it and report a clean 2/2.
+    collectionInfo = { pointsCount: 2, status: "green" };
+    storedHashes = new Map([
+      ["kept.ts", indexer.hashContent("export const kept = 0;\n")],
+      ["lost.ts", indexer.hashContent("export const lost = 1;\n")],
+    ]);
+
+    failUpsertFor.add("lost.ts");
+
+    const result = await indexer.indexProject(project);
+
+    expect(result.filesIndexed).toBe(1);
+    // The stale hash must remain, so the next run retries the file.
+    expect(storedHashes?.get("lost.ts")).toBe(indexer.hashContent("export const lost = 1;\n"));
+  });
 });


### PR DESCRIPTION
## Summary

A partially-skipped Qdrant upsert is recorded as a full success, which strands the
affected files at zero chunks and permanently suppresses any attempt to re-index
them.

`upsertPreEmbeddedChunks` falls back to per-point upserts when a batch fails, and
silently skips points that still fail, returning only a count. Both indexer call
sites treat that as an error only when *every* point in the batch was skipped:

```ts
if (pointsSkipped > 0 && pointsSkipped === batchPoints.length) throw ...
```

A partial skip falls through, and the code then unconditionally marks every file
in the batch as current:

```ts
for (const file of fileBatch) hashes.set(file.relativePath, file.contentHash);
```

Re-indexed files have their previous chunks deleted before this point
(`indexer.ts`, "cleaning stale chunks"). So a file whose points were partially
skipped ends up with **zero chunks in the collection and a content hash claiming
it is up to date**. Every later incremental skips it on the hash match, and a
full re-index hash-matches and skips it too — the loss is permanent, silent, and
the run reports success throughout.

## Changes

- `upsertPreEmbeddedChunks` now returns `skippedPaths: Set<string>` alongside
  `pointsSkipped`, identifying which files lost points.
- Both indexer call sites (`indexProject`, `updateProjectIndex`) withhold the
  hash for any file in `skippedPaths`, so the next run re-indexes it instead of
  skipping it forever. This makes the failure self-healing rather than terminal.
- A warning is logged naming the affected files.
- `chunksCreated` / `totalChunksCreated` no longer count chunks that never landed.

`context-artifacts.ts` has the same all-or-nothing guard, but artifacts have no
per-file hash to withhold, so the fix there is a different shape and is left out
of this PR deliberately.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test coverage improvement

## Testing

New file `tests/unit/partial-upsert-skip.test.ts`, three cases:

1. a file whose points are skipped during a full index does not get its hash recorded
2. that file is re-indexed on the next incremental run, with nothing changed on disk
3. skipped chunks are not counted as created

All three **fail against unmodified `main` and pass with this change** — verified
by reverting `src/services/{indexer,qdrant}.ts` and re-running.

- [x] Unit tests pass (`npm run test:unit`) — see note below
- [ ] Integration tests pass (`npm run test:integration`) — not run (requires Docker)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] New tests added for new/changed functionality

~~**Note on the suite:** 33 tests across 5 files already fail on a clean checkout
of `main`.~~ **Struck — this was wrong.** Those 33 failures (`config`,
`constants`, `context-artifacts`, `docker`, `symbol-graph-multipart-shards`)
occur only in my local environment; CI is green on Node 18/20/22/26. They are
not pre-existing breakage in the project.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate
- [ ] I have updated documentation (README.md / DEVELOPER.md) if needed — not applicable
- [ ] I have addressed all CodeRabbit review comments (or marked as resolved with explanation)
- [x] I have read the Contributing Guide
- [x] I agree to the Contributor License Agreement

## How this surfaced

An index of ~3,200 files went from **14,191 chunks to 11,870 in a single
`codebase_update`** with nothing changed on disk. Files verified present in
`HEAD`, on disk, tracked and unignored had zero chunks afterwards, and retrieval
recall@5 over a fixed query set dropped from 75% to 65%.

Ruled out during diagnosis: the file walk returning short (both the healthy and
the degraded run recorded `filesTotal: 3207`), the repository changing (`git
reflog` clean), ignore rules, and read failures (`catch { return null }` leaves
the path in `files`, so those chunks survive by design).

I could not capture the `Skipping point that failed upsert` warning from that
specific run, because logs only reach a file when `SOCRATICODE_LOG_FILE` is set.
So I am **not claiming this defect caused that particular incident** — the tests
above demonstrate the flaw on its own terms, independent of it.

Two related observations from the same investigation, mentioned in case they are
worth separate issues:

- A full re-index cannot repair an already-degraded collection: it hash-matches
  the surviving chunks and skips (34s for 11,870 chunks). Anyone hitting this and
  reaching for a full reindex will believe they fixed it and will not have.
- Deleting the collection alone is not enough either — the `socraticode_metadata`
  record survives, and `codebase_index` then fails with `codebase_status still
  reports no index after running codebase_index` until that metadata point is
  removed by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Partial indexing failures now surface as errors while successfully processed chunks are retained.
  * Affected files remain eligible for retry during subsequent indexing runs.
  * Artifact metadata is not marked current when any chunk upload fails.
  * Indexing totals now distinguish all files encountered from files successfully indexed, excluding skipped files.

* **Tests**
  * Added coverage for partial upload failures, fallback behavior, error reporting, metadata handling, and retry processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
