### PR TITLE
fix(qdrant): scroll project metadata by page, and read only the field used

### DIFF
--- a/src/services/qdrant.ts
+++ b/src/services/qdrant.ts
@@ -279,19 +279,34 @@ export async function listCodebaseCollections(): Promise<string[]> {
   // Listing is read-only: an absent metadata collection means there are no metadata-only entries yet.
   if (collections.collections.some((collection) => collection.name === METADATA_COLLECTION)) {
     try {
-      const metaPoints = await qdrant.scroll(METADATA_COLLECTION, {
-        limit: 100,
-        with_payload: true,
-      });
-      for (const point of metaPoints.points) {
-        const collName = point.payload?.collectionName as string | undefined;
-        if (
-          (collName?.startsWith(`${p}codegraph_`) || collName?.startsWith(`${p}context_`)) &&
-          !result.includes(collName)
-        ) {
-          result.push(collName);
+      // Only `collectionName` is read below, but a metadata point also carries
+      // the project's entire path-to-hash map, so `with_payload: true` fetched
+      // every hash map on the instance to look at one string per point.
+      // Measured against a 29-project instance: 13.7 MB transferred for 3 KB of
+      // payload actually used. This runs on every auto-resume and every listing.
+      //
+      // The single `limit: 100` request also silently dropped everything past
+      // the hundredth point, and this list is what the manage tools report, so
+      // page it the way `listIndexedFilePaths` does.
+      let offset: string | number | Record<string, unknown> | undefined | null;
+      do {
+        const metaPoints = await qdrant.scroll(METADATA_COLLECTION, {
+          limit: 100,
+          with_payload: { include: ["collectionName"] },
+          with_vector: false,
+          ...(offset === undefined || offset === null ? {} : { offset }),
+        });
+        for (const point of metaPoints.points) {
+          const collName = point.payload?.collectionName as string | undefined;
+          if (
+            (collName?.startsWith(`${p}codegraph_`) || collName?.startsWith(`${p}context_`)) &&
+            !result.includes(collName)
+          ) {
+            result.push(collName);
+          }
         }
-      }
+        offset = metaPoints.next_page_offset;
+      } while (offset !== undefined && offset !== null);
     } catch (err) {
       logger.info("listCodebaseCollections: metadata scroll failed", {
         error: err instanceof Error ? err.message : String(err),

--- a/src/services/qdrant.ts
+++ b/src/services/qdrant.ts
@@ -256,6 +256,51 @@ export async function deleteCollection(name: string): Promise<void> {
   }
 }
 
+/**
+ * Scroll one payload field across an entire collection.
+ *
+ * Enumeration has to be complete, because callers use it to decide what exists.
+ * So this follows the cursor rather than taking the first page, retries a
+ * transient failure instead of returning a short answer, and stops if the
+ * cursor ever fails to advance — an unbounded cursor loop cannot be caught,
+ * since an infinite loop never throws.
+ *
+ * Only `field` is fetched. A point can carry a large payload — a project's
+ * entire path-to-hash map, in the metadata collection — so an unprojected read
+ * scales with the stored data rather than with the number of points.
+ */
+async function scrollPayloadField(
+  collName: string,
+  field: string,
+  label: string,
+  pageSize: number,
+  visit: (value: unknown) => void,
+): Promise<void> {
+  const qdrant = getClient();
+  let offset: string | number | Record<string, unknown> | undefined | null;
+
+  do {
+    const page = await withRetry(
+      () =>
+        qdrant.scroll(collName, {
+          limit: pageSize,
+          with_payload: { include: [field] },
+          with_vector: false,
+          ...(offset === undefined || offset === null ? {} : { offset }),
+        }),
+      label,
+    );
+    for (const point of page.points) visit(point.payload?.[field]);
+
+    const next = page.next_page_offset;
+    if (next !== undefined && next !== null && JSON.stringify(next) === JSON.stringify(offset)) {
+      logger.warn(`${label}: cursor did not advance, stopping`, { collName });
+      break;
+    }
+    offset = next;
+  } while (offset !== undefined && offset !== null);
+}
+
 /** List all codebase, codegraph, and context artifact entries.
  * Codebase and context entries are actual collections; codegraph entries come from metadata.
  *
@@ -279,36 +324,37 @@ export async function listCodebaseCollections(): Promise<string[]> {
   // Listing is read-only: an absent metadata collection means there are no metadata-only entries yet.
   if (collections.collections.some((collection) => collection.name === METADATA_COLLECTION)) {
     try {
-      // Only `collectionName` is read below, but a metadata point also carries
-      // the project's entire path-to-hash map, so `with_payload: true` fetched
-      // every hash map on the instance to look at one string per point.
-      // Measured against a 29-project instance: 13.7 MB transferred for 3 KB of
-      // payload actually used. This runs on every auto-resume and every listing.
-      //
-      // The single `limit: 100` request also silently dropped everything past
-      // the hundredth point, and this list is what the manage tools report, so
-      // page it the way `listIndexedFilePaths` does.
-      let offset: string | number | Record<string, unknown> | undefined | null;
-      do {
-        const metaPoints = await qdrant.scroll(METADATA_COLLECTION, {
-          limit: 100,
-          with_payload: { include: ["collectionName"] },
-          with_vector: false,
-          ...(offset === undefined || offset === null ? {} : { offset }),
-        });
-        for (const point of metaPoints.points) {
-          const collName = point.payload?.collectionName as string | undefined;
+      // This list must be complete: the manage tools present it as the set of
+      // indexed projects, and startup reads it to decide what to resume. The
+      // previous single unpaginated request silently dropped everything past
+      // the hundredth point, and fetched every project's whole hash map to
+      // read one string per point.
+      const seen = new Set(result);
+      await scrollPayloadField(
+        METADATA_COLLECTION,
+        "collectionName",
+        "listCodebaseCollections(metadata)",
+        1000,
+        (value) => {
+          // Narrow rather than cast: optional chaining guards null and
+          // undefined, so a non-string here would have reached `.startsWith`
+          // and thrown, taking out a read-only listing over one bad point.
+          if (typeof value !== "string") return;
           if (
-            (collName?.startsWith(`${p}codegraph_`) || collName?.startsWith(`${p}context_`)) &&
-            !result.includes(collName)
+            (value.startsWith(`${p}codegraph_`) || value.startsWith(`${p}context_`)) &&
+            !seen.has(value)
           ) {
-            result.push(collName);
+            seen.add(value);
+            result.push(value);
           }
-        }
-        offset = metaPoints.next_page_offset;
-      } while (offset !== undefined && offset !== null);
+        },
+      );
     } catch (err) {
-      logger.info("listCodebaseCollections: metadata scroll failed", {
+      // Non-fatal: this is a read-only listing and the collections found above
+      // stand. Warned rather than logged at info because paging made a partial
+      // result more reachable, not less — a failure can now land on page three
+      // of five and return a list that looks complete.
+      logger.warn("listCodebaseCollections: metadata scroll failed, list may be incomplete", {
         error: err instanceof Error ? err.message : String(err),
       });
     }
@@ -854,28 +900,16 @@ export async function listIndexedFilePaths(
   collName: string,
   pageSize = 1000,
 ): Promise<Set<string>> {
-  const qdrant = getClient();
   const paths = new Set<string>();
-  let offset: string | number | Record<string, unknown> | undefined | null;
-
-  do {
-    const page = await withRetry(
-      () =>
-        qdrant.scroll(collName, {
-          limit: pageSize,
-          with_payload: { include: ["relativePath"] },
-          with_vector: false,
-          ...(offset === undefined || offset === null ? {} : { offset }),
-        }),
-      `listIndexedFilePaths(${collName})`,
-    );
-    for (const point of page.points) {
-      const rel = point.payload?.relativePath;
-      if (typeof rel === "string") paths.add(rel);
-    }
-    offset = page.next_page_offset;
-  } while (offset !== undefined && offset !== null);
-
+  await scrollPayloadField(
+    collName,
+    "relativePath",
+    `listIndexedFilePaths(${collName})`,
+    pageSize,
+    (value) => {
+      if (typeof value === "string") paths.add(value);
+    },
+  );
   return paths;
 }
 

--- a/tests/unit/list-collections-metadata-scroll.test.ts
+++ b/tests/unit/list-collections-metadata-scroll.test.ts
@@ -27,6 +27,11 @@ interface ScrollOptions {
 let scrollCalls: ScrollOptions[] = [];
 /** Metadata points the fake backend holds, paged out `limit` at a time. */
 let metadataPoints: Array<{ id: number; payload: Record<string, unknown> }> = [];
+/** Scroll attempts (1-based) that should throw, to exercise retry and failure. */
+let failAttempts = new Set<number>();
+/** When true the backend keeps handing back the cursor it was given. */
+let stallCursor = false;
+let attempt = 0;
 
 vi.mock("../../src/services/logger.js", () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -35,6 +40,20 @@ vi.mock("../../src/services/logger.js", () => ({
 vi.mock("../../src/services/qdrant-client-compat.js", () => ({
   ensureQdrantClientCompatibility: vi.fn(),
 }));
+
+/**
+ * Qdrant's `next_page_offset` is an opaque point id, not an index. The fake
+ * mints string cursors so nothing under test can quietly depend on arithmetic
+ * that only works for numbers.
+ */
+function cursorFor(index: number): string {
+  return `point-${index}`;
+}
+
+function indexFromCursor(offset: unknown): number {
+  if (typeof offset !== "string") return 0;
+  return Number.parseInt(offset.slice("point-".length), 10);
+}
 
 vi.mock("@qdrant/js-client-rest", () => ({
   QdrantClient: class {
@@ -45,10 +64,19 @@ vi.mock("@qdrant/js-client-rest", () => ({
     }
     async scroll(_name: string, opts: ScrollOptions) {
       scrollCalls.push(opts);
+      attempt++;
+      if (failAttempts.has(attempt)) {
+        throw new Error(`scroll attempt ${attempt} failed`);
+      }
       const limit = opts.limit ?? 100;
-      const start = typeof opts.offset === "number" ? opts.offset : 0;
+      const start = indexFromCursor(opts.offset);
       const page = metadataPoints.slice(start, start + limit);
-      const next = start + limit < metadataPoints.length ? start + limit : null;
+      const end = start + limit;
+      const next = stallCursor
+        ? (opts.offset ?? cursorFor(0))
+        : end < metadataPoints.length
+          ? cursorFor(end)
+          : null;
       // Mirror Qdrant's contract: honour the payload projection, so a test that
       // reads a field the caller did not ask for sees it absent.
       const include =
@@ -56,12 +84,12 @@ vi.mock("@qdrant/js-client-rest", () => ({
           ? ((opts.with_payload as { include?: string[] }).include ?? null)
           : null;
       return {
-        points: page.map((p) => ({
-          id: p.id,
+        points: page.map((pt) => ({
+          id: pt.id,
           payload:
             include === null
-              ? p.payload
-              : Object.fromEntries(include.map((k) => [k, p.payload[k]])),
+              ? pt.payload
+              : Object.fromEntries(include.map((k) => [k, pt.payload[k]])),
         })),
         next_page_offset: next,
       };
@@ -75,6 +103,9 @@ beforeEach(() => {
   vi.resetModules();
   scrollCalls = [];
   metadataPoints = [];
+  failAttempts = new Set();
+  stallCursor = false;
+  attempt = 0;
   process.env = {
     ...originalEnv,
     QDRANT_MODE: "external",
@@ -98,7 +129,7 @@ function metadataPoint(id: number, collectionName: string) {
       // The field that makes the full-payload read expensive: one entry per
       // file in the project.
       fileHashes: Object.fromEntries(
-        Array.from({ length: 50 }, (_, i) => [`src/file${i}.ts`, `hash-${id}-${i}`]),
+        Array.from({ length: 3 }, (_, i) => [`src/file${i}.ts`, `hash-${id}-${i}`]),
       ),
     },
   };
@@ -106,9 +137,9 @@ function metadataPoint(id: number, collectionName: string) {
 
 describe("listCodebaseCollections metadata scroll", () => {
   it("returns entries beyond the first page", async () => {
-    // 250 points against a page size of 100: entries 100..249 are only
-    // reachable by following the cursor.
-    metadataPoints = Array.from({ length: 250 }, (_, i) =>
+    // 2500 points against a page size of 1000: everything past the first
+    // thousand is only reachable by following the cursor.
+    metadataPoints = Array.from({ length: 2500 }, (_, i) =>
       metadataPoint(i, i % 2 === 0 ? `codegraph_p${i}` : `context_p${i}`),
     );
 
@@ -116,11 +147,28 @@ describe("listCodebaseCollections metadata scroll", () => {
     const result = await listCodebaseCollections();
 
     expect(result).toContain("codegraph_p0");
-    expect(result).toContain("context_p149"); // second page
-    expect(result).toContain("context_p249"); // third page
-    expect(scrollCalls.length).toBeGreaterThan(1);
+    expect(result).toContain("context_p1499"); // second page
+    expect(result).toContain("context_p2499"); // third page
+    expect(scrollCalls).toHaveLength(3);
     // Every metadata entry, plus the one real collection from getCollections().
-    expect(result).toHaveLength(251);
+    expect(result).toHaveLength(2501);
+  });
+
+  it("skips a point whose collectionName is not a string, instead of throwing", async () => {
+    // Optional chaining guards null and undefined but not a wrong type, so a
+    // payload holding a number here reached `.startsWith` and threw — taking
+    // out a read-only listing over one malformed point.
+    metadataPoints = [
+      { id: 0, payload: { collectionName: 42 } },
+      { id: 1, payload: {} },
+      metadataPoint(2, "codegraph_good"),
+    ];
+
+    const { listCodebaseCollections } = await import("../../src/services/qdrant.js");
+    const result = await listCodebaseCollections();
+
+    expect(result).toContain("codegraph_good");
+    expect(result).toHaveLength(2); // the real collection, plus the good entry
   });
 
   it("asks only for the field it reads, not the whole payload", async () => {
@@ -137,4 +185,45 @@ describe("listCodebaseCollections metadata scroll", () => {
       expect(call.with_vector).toBe(false);
     }
   });
+  it("retries a transient page failure instead of truncating the list", async () => {
+    // Paging multiplies the requests that can fail, so one blip mid-scroll must
+    // not silently shorten a list callers read as complete. Every other scroll
+    // in qdrant.ts is wrapped in withRetry; this one is too.
+    metadataPoints = Array.from({ length: 2500 }, (_, i) => metadataPoint(i, `codegraph_p${i}`));
+    failAttempts = new Set([2]); // first attempt at the second page
+
+    const { listCodebaseCollections } = await import("../../src/services/qdrant.js");
+    const result = await listCodebaseCollections();
+
+    expect(result).toHaveLength(2501);
+    expect(result).toContain("codegraph_p2499");
+    expect(scrollCalls).toHaveLength(4); // three pages, one retried
+  }, 20_000);
+
+  it("returns what it has when a page fails for good, without throwing", async () => {
+    // Still non-fatal: the collections found before the metadata scroll stand.
+    metadataPoints = Array.from({ length: 2500 }, (_, i) => metadataPoint(i, `codegraph_p${i}`));
+    failAttempts = new Set([2, 3, 4]); // exhaust withRetry on the second page
+
+    const { listCodebaseCollections } = await import("../../src/services/qdrant.js");
+    const result = await listCodebaseCollections();
+
+    expect(result).toContain("codebase_realone");
+    expect(result).toContain("codegraph_p0"); // first page survived
+    expect(result).not.toContain("codegraph_p2499");
+  }, 20_000);
+
+  it("stops when the cursor stops advancing", async () => {
+    // An unbounded cursor loop cannot be caught — an infinite loop never throws
+    // — and auto-resume is not awaited, so this would hang with nothing logged
+    // and no project ever resumed.
+    metadataPoints = Array.from({ length: 2500 }, (_, i) => metadataPoint(i, `codegraph_p${i}`));
+    stallCursor = true;
+
+    const { listCodebaseCollections } = await import("../../src/services/qdrant.js");
+    const result = await listCodebaseCollections();
+
+    expect(scrollCalls).toHaveLength(2); // first page, then the stall is caught
+    expect(result).toContain("codegraph_p0");
+  }, 20_000);
 });

--- a/tests/unit/list-collections-metadata-scroll.test.ts
+++ b/tests/unit/list-collections-metadata-scroll.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+/**
+ * `listCodebaseCollections()` enumerates the metadata collection, and both
+ * halves of how it did so were wrong.
+ *
+ * It issued a single `limit: 100` scroll with no cursor, so a deployment with
+ * more than a hundred metadata points silently lost every entry past the
+ * hundredth — from a list the manage tools present as complete.
+ *
+ * It also asked for the whole payload to read one string. Metadata points carry
+ * the project's entire path-to-hash map, so the request scaled with the size of
+ * every indexed repository rather than with the number of projects.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface ScrollOptions {
+  limit?: number;
+  offset?: unknown;
+  with_payload?: unknown;
+  with_vector?: unknown;
+}
+
+/** Every scroll issued against the metadata collection, in order. */
+let scrollCalls: ScrollOptions[] = [];
+/** Metadata points the fake backend holds, paged out `limit` at a time. */
+let metadataPoints: Array<{ id: number; payload: Record<string, unknown> }> = [];
+
+vi.mock("../../src/services/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../src/services/qdrant-client-compat.js", () => ({
+  ensureQdrantClientCompatibility: vi.fn(),
+}));
+
+vi.mock("@qdrant/js-client-rest", () => ({
+  QdrantClient: class {
+    async getCollections() {
+      return {
+        collections: [{ name: "codebase_realone" }, { name: "socraticode_metadata" }],
+      };
+    }
+    async scroll(_name: string, opts: ScrollOptions) {
+      scrollCalls.push(opts);
+      const limit = opts.limit ?? 100;
+      const start = typeof opts.offset === "number" ? opts.offset : 0;
+      const page = metadataPoints.slice(start, start + limit);
+      const next = start + limit < metadataPoints.length ? start + limit : null;
+      // Mirror Qdrant's contract: honour the payload projection, so a test that
+      // reads a field the caller did not ask for sees it absent.
+      const include =
+        opts.with_payload && typeof opts.with_payload === "object"
+          ? ((opts.with_payload as { include?: string[] }).include ?? null)
+          : null;
+      return {
+        points: page.map((p) => ({
+          id: p.id,
+          payload:
+            include === null
+              ? p.payload
+              : Object.fromEntries(include.map((k) => [k, p.payload[k]])),
+        })),
+        next_page_offset: next,
+      };
+    }
+  },
+}));
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  vi.resetModules();
+  scrollCalls = [];
+  metadataPoints = [];
+  process.env = {
+    ...originalEnv,
+    QDRANT_MODE: "external",
+    QDRANT_URL: "http://127.0.0.1:6333",
+  };
+  delete process.env.QDRANT_COLLECTION_PREFIX;
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.clearAllMocks();
+});
+
+/** A metadata point of the shape `saveProjectMetadata` writes. */
+function metadataPoint(id: number, collectionName: string) {
+  return {
+    id,
+    payload: {
+      collectionName,
+      projectPath: `/repos/p${id}`,
+      // The field that makes the full-payload read expensive: one entry per
+      // file in the project.
+      fileHashes: Object.fromEntries(
+        Array.from({ length: 50 }, (_, i) => [`src/file${i}.ts`, `hash-${id}-${i}`]),
+      ),
+    },
+  };
+}
+
+describe("listCodebaseCollections metadata scroll", () => {
+  it("returns entries beyond the first page", async () => {
+    // 250 points against a page size of 100: entries 100..249 are only
+    // reachable by following the cursor.
+    metadataPoints = Array.from({ length: 250 }, (_, i) =>
+      metadataPoint(i, i % 2 === 0 ? `codegraph_p${i}` : `context_p${i}`),
+    );
+
+    const { listCodebaseCollections } = await import("../../src/services/qdrant.js");
+    const result = await listCodebaseCollections();
+
+    expect(result).toContain("codegraph_p0");
+    expect(result).toContain("context_p149"); // second page
+    expect(result).toContain("context_p249"); // third page
+    expect(scrollCalls.length).toBeGreaterThan(1);
+    // Every metadata entry, plus the one real collection from getCollections().
+    expect(result).toHaveLength(251);
+  });
+
+  it("asks only for the field it reads, not the whole payload", async () => {
+    // The point of the projection: metadata payloads carry a hash map per
+    // project, so a full read scales with repository size, not project count.
+    metadataPoints = [metadataPoint(0, "codegraph_p0")];
+
+    const { listCodebaseCollections } = await import("../../src/services/qdrant.js");
+    await listCodebaseCollections();
+
+    expect(scrollCalls).not.toHaveLength(0);
+    for (const call of scrollCalls) {
+      expect(call.with_payload).toEqual({ include: ["collectionName"] });
+      expect(call.with_vector).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
`listCodebaseCollections()` enumerates the metadata collection to find graph and
context entries that exist only as metadata points. Every way that enumeration
could return a short list without saying so is fixed here.

## Truncation

The scroll was a single `limit: 100` request with no cursor, so a deployment
holding more than a hundred metadata points lost every entry past the
hundredth — silently, from a list `codebase_list_projects` and the manage tools
present as complete. `startup.ts` reads it on every auto-resume.

`codebase_` collections come from `getCollections()` and were never affected, so
this is a listing defect rather than a resume defect. It is still a list that
begins lying at a threshold nobody is watching.

## Payload amplification

The same request asked for the entire payload in order to read one string. A
metadata point carries the project's whole path-to-hash map, so the transfer
scaled with the size of every indexed repository rather than the number of
projects.

Measured against a 29-project instance, same collection, one request:

| `with_payload` | transferred |
|---|---|
| `true` | 13,713,674 bytes |
| `{ include: ["collectionName"] }` | 3,041 bytes |

~4,500x, on a path that runs at every startup resume and every listing. The two
defects compound in opposite directions: paging without projecting would have
multiplied the transfer by the number of pages.

## The failure path, which the first revision left alone

Fixing the pagination made three existing weaknesses reachable in a way they had
not been, so they are fixed here rather than left as the same bug in a new place:

- **No retry.** This was the only scroll in the file not wrapped in `withRetry`.
  Paging multiplies the requests that can fail, so one transient blip mid-scroll
  silently shortened the list.
- **No requirement that the cursor advance.** An unbounded cursor loop cannot be
  caught, because an infinite loop never throws, and `autoResumeIndexedProjects()`
  is not awaited — a server handing back a non-advancing cursor would hang with
  nothing logged and no project ever resumed.
- **A page failing for good returned a partial list at `info`.** Still
  non-fatal — the collections found before the scroll stand — but now a warning
  that says the list may be incomplete.

Page size is raised to 1000, matching `listIndexedFilePaths`; 100 was chosen when
each point carried a whole hash map.

## Shared helper

The paging, retry, cursor guard and projection are stated once in
`scrollPayloadField`, and both scrolls in this file route through it, so
`listIndexedFilePaths` picks up the stall guard as well.

`symbol-graph-store.ts:1017` has a third copy with a different shape (`while
(true)`, `limit: 500`, the array payload form, no retry, a per-collection catch
and a legacy fallback). I have deliberately left it out rather than widen a
targeted fix across modules — happy to follow up separately if you want the
three unified.

## Deliberately not addressed

The reason a metadata read is expensive at all is that `saveProjectMetadata`
writes each project's entire path-to-hash map into the single shared metadata
collection, so every present and future reader has to remember to project.
Moving the hash map out of that collection would remove the hazard for all of
them, but it is a storage change with migration implications for existing
indexes and does not belong in this PR. Flagging it rather than doing it.

## Tests

`tests/unit/list-collections-metadata-scroll.test.ts`, six cases. The fake
backend honours the payload projection rather than ignoring it, so a caller
reading a field it did not request sees it absent; and it mints **opaque string
cursors**, because Qdrant's `next_page_offset` is a point id, not an index — a
fake using integers would let arithmetic that only works for numbers pass.

- 2500 points against a page size of 1000, asserting entries from the second and
  third pages are present, in exactly three requests.
- A point whose `collectionName` is a number, and one with an empty payload, are
  skipped rather than throwing.
- Every scroll asks for `{ include: ["collectionName"] }` and no vectors.
- A transient failure on page two is retried and the list stays complete.
- A page that fails for good returns what was collected, without throwing.
- A backend that keeps handing back the same cursor terminates instead of
  spinning.

Mutation-checked: restoring the original single full-payload request fails the
pagination and projection cases; dropping the retry fails the transient case;
dropping the stall guard hangs the last one.

`tsc --noEmit` and biome are clean. Unit tests 2054 passing, up by exactly the six
added here, and both Qdrant-backed integration files re-run green against a real
server since the shared helper now sits under the recovery path from #158.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed collection listing so all available collections are displayed, including those beyond the first 100.
  - Improved collection loading efficiency by retrieving only the metadata needed for listing, reducing unnecessary data transfer for larger codebases.
  - Improved reliability when loading collections and indexed file paths by retrying temporary retrieval failures.
  - Prevented invalid metadata from interrupting collection listings.
  - Added safeguards to stop stalled pagination and return available results when a retrieval failure cannot be recovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->