### PR TITLE
fix(graph): stop the Python sibling-flat fallback fabricating edges inside packages

### DIFF
--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -2600,9 +2600,17 @@ export function resolveImport(
       // Absolute: foo.bar.baz → foo/bar/baz.py or foo/bar/baz/__init__.py
       const modulePath = moduleSpecifier.replace(/\./g, "/");
 
-      const direct = notSelf(
-        resolveRelativePath(modulePath, projectPath, projectPath, fileSet, [".py"]),
-      );
+      // A self match HERE ends resolution rather than falling through. The
+      // project root is ahead of `src/`, `lib/` and every manifest root for a
+      // file that sits at the root — it is that file's own `sys.path[0]` — so
+      // nothing a later probe finds is a module CPython could reach past the
+      // source file itself. Root `mod.py` doing `import mod` beside a
+      // `src/mod.py` imports itself; answering with `src/mod.py` trades the
+      // self-edge for an edge to an unrelated module, which is worse. The
+      // later probes still fall through, because there the discarded match is
+      // a guess (the sibling probe) or one root among several.
+      const direct = resolveRelativePath(modulePath, projectPath, projectPath, fileSet, [".py"]);
+      if (direct === relSourceFile) return null;
       if (direct) return direct;
 
       // Try common Python source directories (src layout)
@@ -2630,14 +2638,25 @@ export function resolveImport(
       // root both offer the module, the sibling is what actually gets
       // imported.
       //
-      // Only for a file that could BE `sys.path[0]` (#157). A directory
-      // holding `__init__.py` is a regular package, and CPython never puts a
-      // package's own directory on `sys.path`: `import requests` from
-      // `src/pkg/client.py` is resolved through `sys.path` to the installed
-      // distribution, so a sibling `src/pkg/requests.py` is not what runs.
-      // Without this gate any first-party module sharing a name with a
-      // dependency invents an edge — the graph-wide version of the self-edge
-      // the guard above removes.
+      // Only for a directory that is not itself a regular package (#157). A
+      // directory holding `__init__.py` is imported as a package, and every
+      // documented way of importing one — installed distribution, `-m`, a
+      // path entry above it — resolves `import requests` from
+      // `src/pkg/client.py` through `sys.path` to the installed distribution,
+      // so a sibling `src/pkg/requests.py` is not what runs. Without this gate
+      // any first-party module sharing a name with a dependency invents an
+      // edge — the graph-wide version of the self-edge the guard above
+      // removes.
+      //
+      // The gate is a trade, not a law: `sys.path[0]` is the *script's*
+      // directory whether or not it holds `__init__.py`, so `python
+      // service-a/main.py` really does import a sibling `service-a/config.py`
+      // even when `service-a/__init__.py` exists, and that edge is dropped
+      // here. A name collision with a dependency is unfalsifiable from the
+      // tree, while a package directory at least says the file is normally
+      // reached as `pkg.client`; the false edge is judged the costlier of the
+      // two. The #46 layout the fallback serves — a runnable directory with no
+      // `__init__.py` — is unaffected.
       //
       // Deliberately NOT extended to PEP 420 namespace packages, which have
       // no `__init__.py` to test: `src/ns/sub/mod.py` importing `requests`

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -2648,68 +2648,26 @@ export function resolveImport(
       // root both offer the module, the sibling is what actually gets
       // imported.
       //
-      // Only for a directory that is not itself a regular package (#157). A
-      // directory holding `__init__.py` is imported as a package, and every
-      // documented way of importing one — installed distribution, `-m`, a
-      // path entry above it — resolves `import requests` from
-      // `src/pkg/client.py` through `sys.path` to the installed distribution,
-      // so a sibling `src/pkg/requests.py` is not what runs. Without this gate
-      // any first-party module sharing a name with a dependency invents an
-      // edge — the graph-wide version of the self-edge the guard above
-      // removes.
+      // A NON-SELF collision here is left alone, deliberately (#157). Where a
+      // first-party module shares a name with a third-party distribution —
+      // `src/pkg/requests.py` beside `src/pkg/client.py` doing `import
+      // requests` — which one CPython loads depends on how the file is run,
+      // and the tree does not say. Imported as `pkg.client`, `sys.path` finds
+      // the installed distribution; executed as `python src/pkg/client.py`,
+      // `sys.path[0]` is `src/pkg` and the sibling wins. An `__init__.py` does
+      // not settle it: `sys.path[0]` is the SCRIPT's directory whether or not
+      // the directory is also a package, so gating on one would drop the
+      // legitimate #46 edge from a directly executed service directory that
+      // happens to contain `__init__.py`. The same ambiguity covers PEP 420
+      // namespace packages, which have no `__init__.py` to test at all.
       //
-      // The gate is a trade, not a law: `sys.path[0]` is the *script's*
-      // directory whether or not it holds `__init__.py`, so `python
-      // service-a/main.py` really does import a sibling `service-a/config.py`
-      // even when `service-a/__init__.py` exists, and that edge is dropped
-      // here. A name collision with a dependency is unfalsifiable from the
-      // tree, while a package directory at least says the file is normally
-      // reached as `pkg.client`; the false edge is judged the costlier of the
-      // two. The #46 layout the fallback serves — a runnable directory with no
-      // `__init__.py` — is unaffected.
-      //
-      // Deliberately NOT extended to PEP 420 namespace packages, which have
-      // no `__init__.py` to test: `src/ns/sub/mod.py` importing `requests`
-      // beside `src/ns/sub/requests.py` still resolves to the sibling. The
-      // structural discriminator that would catch it — "sourceDir sits below
-      // a declared import root" — is unusable, because it also fires on
-      // `packages/pkg-a/src/pkg_a/main.py`, whose roots include
-      // `packages/pkg-a/src`, and would invert "prefers the sibling-flat
-      // guess over a manifest root" below. A directory with neither
-      // `__init__.py` nor a manifest of its own is genuinely indistinguishable
-      // from the runnable script directory #46 exists to serve, so the
-      // ambiguity is left as it is rather than guessed at. The self-edge
-      // inside such a package is still removed, by the guard above.
-      // Any ancestor up to the project root, not just `sourceDir` itself: a
-      // directory below a regular package is part of that package's tree even
-      // when it carries no `__init__.py` of its own. `src/pkg/vendor/mod.py`
-      // under `src/pkg/__init__.py` is reached as `pkg.vendor.mod` — verified
-      // against CPython, where `import requests` there loads the installed
-      // distribution and not the sibling `vendor/requests.py`. Checking only
-      // `sourceDir` gated `src/pkg/client.py` while leaving its own
-      // subdirectory fabricating the same edge.
-      //
-      // The project root itself counts. Indexing a directory that IS a package
-      // (`.../src/mylib`, `__init__.py` and all) disables the sibling fallback
-      // for the whole tree, and that is right rather than merely intended:
-      // every file in it is a `mylib.*` module reached through the parent
-      // directory on `sys.path`, so the flat guess was never what CPython does
-      // there.
-      let inPackage = false;
-      for (
-        let dir = toForwardSlash(path.relative(projectPath, sourceDir));
-        ;
-        dir = dir.includes("/") ? dir.slice(0, dir.lastIndexOf("/")) : ""
-      ) {
-        if (fileSet.has(dir === "" ? "__init__.py" : `${dir}/__init__.py`)) {
-          inPackage = true;
-          break;
-        }
-        if (dir === "") break;
-      }
-      const sibling = inPackage
-        ? null
-        : notSelf(resolveRelativePath(modulePath, sourceDir, projectPath, fileSet, [".py"]));
+      // So the sibling stands in every non-self case, and only the
+      // unambiguous self-resolution above is removed. Narrowing this needs
+      // evidence of execution mode that the resolver does not currently have —
+      // not an inference from layout.
+      const sibling = notSelf(
+        resolveRelativePath(modulePath, sourceDir, projectPath, fileSet, [".py"]),
+      );
       if (sibling) return sibling;
 
       // Manifest-declared import roots (issue #107), nearest first. The probes

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -2578,14 +2578,37 @@ export function resolveImport(
       }
       // Absolute: foo.bar.baz → foo/bar/baz.py or foo/bar/baz/__init__.py
       const modulePath = moduleSpecifier.replace(/\./g, "/");
-      const direct = resolveRelativePath(modulePath, projectPath, projectPath, fileSet, [".py"]);
+
+      // No import edge from a file to itself (#157). A module that names
+      // itself is resolvable in CPython — `import mymodule` inside a
+      // top-level `mymodule.py` really does import a second copy — but as a
+      // graph edge it is noise, and every case seen in the wild is a
+      // first-party module named after the third-party package it wraps
+      // (`whisperx.py` doing `import whisperx`), where the true target is the
+      // installed distribution and no first-party edge exists at all.
+      //
+      // A rejected candidate falls through to the next probe rather than
+      // ending resolution: `src/pkg/requests.py` importing `requests` must
+      // still find a legitimate `src/requests.py` behind the discarded self
+      // match. Only the sibling probe can reach here on the layouts in #157,
+      // but `direct` reaches it too for a module at the project root, so the
+      // guard sits on every absolute probe rather than on one of them.
+      const relSourceFile = toForwardSlash(path.relative(projectPath, sourceFile));
+      const notSelf = (candidate: string | null): string | null =>
+        candidate === null || candidate === relSourceFile ? null : candidate;
+
+      const direct = notSelf(
+        resolveRelativePath(modulePath, projectPath, projectPath, fileSet, [".py"]),
+      );
       if (direct) return direct;
 
       // Try common Python source directories (src layout)
       const pySrcDirs = ["src", "lib"];
       for (const dir of pySrcDirs) {
-        const inSrc = resolveRelativePath(
-          path.join(dir, modulePath), projectPath, projectPath, fileSet, [".py"],
+        const inSrc = notSelf(
+          resolveRelativePath(
+            path.join(dir, modulePath), projectPath, projectPath, fileSet, [".py"],
+          ),
         );
         if (inSrc) return inSrc;
       }
@@ -2603,7 +2626,34 @@ export function resolveImport(
       // installed-distribution entry, so where a sibling file and a package
       // root both offer the module, the sibling is what actually gets
       // imported.
-      const sibling = resolveRelativePath(modulePath, sourceDir, projectPath, fileSet, [".py"]);
+      //
+      // Only for a file that could BE `sys.path[0]` (#157). A directory
+      // holding `__init__.py` is a regular package, and CPython never puts a
+      // package's own directory on `sys.path`: `import requests` from
+      // `src/pkg/client.py` is resolved through `sys.path` to the installed
+      // distribution, so a sibling `src/pkg/requests.py` is not what runs.
+      // Without this gate any first-party module sharing a name with a
+      // dependency invents an edge — the graph-wide version of the self-edge
+      // the guard above removes.
+      //
+      // Deliberately NOT extended to PEP 420 namespace packages, which have
+      // no `__init__.py` to test: `src/ns/sub/mod.py` importing `requests`
+      // beside `src/ns/sub/requests.py` still resolves to the sibling. The
+      // structural discriminator that would catch it — "sourceDir sits below
+      // a declared import root" — is unusable, because it also fires on
+      // `packages/pkg-a/src/pkg_a/main.py`, whose roots include
+      // `packages/pkg-a/src`, and would invert "prefers the sibling-flat
+      // guess over a manifest root" below. A directory with neither
+      // `__init__.py` nor a manifest of its own is genuinely indistinguishable
+      // from the runnable script directory #46 exists to serve, so the
+      // ambiguity is left as it is rather than guessed at. The self-edge
+      // inside such a package is still removed, by the guard above.
+      const inPackage = fileSet.has(
+        path.posix.join(toForwardSlash(path.relative(projectPath, sourceDir)), "__init__.py"),
+      );
+      const sibling = inPackage
+        ? null
+        : notSelf(resolveRelativePath(modulePath, sourceDir, projectPath, fileSet, [".py"]));
       if (sibling) return sibling;
 
       // Manifest-declared import roots (issue #107), nearest first. The probes
@@ -2617,8 +2667,10 @@ export function resolveImport(
       // and not a declared workspace member never appears here, and a package's
       // own root is tried before a sibling package's.
       for (const importRoot of pythonImportRoots ?? []) {
-        const inRoot = resolveRelativePath(
-          path.posix.join(importRoot, modulePath), projectPath, projectPath, fileSet, [".py"],
+        const inRoot = notSelf(
+          resolveRelativePath(
+            path.posix.join(importRoot, modulePath), projectPath, projectPath, fileSet, [".py"],
+          ),
         );
         if (inRoot) return inRoot;
       }

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -2566,19 +2566,6 @@ export function resolveImport(
     }
 
     case "python": {
-      // Relative: .foo, ..bar
-      if (moduleSpecifier.startsWith(".")) {
-        const dots = moduleSpecifier.match(/^\.+/)?.[0].length ?? 0;
-        let baseDir = sourceDir;
-        for (let i = 1; i < dots; i++) {
-          baseDir = path.dirname(baseDir);
-        }
-        const rest = moduleSpecifier.slice(dots).replace(/\./g, "/");
-        return resolveRelativePath(rest || ".", baseDir, projectPath, fileSet, [".py"]);
-      }
-      // Absolute: foo.bar.baz → foo/bar/baz.py or foo/bar/baz/__init__.py
-      const modulePath = moduleSpecifier.replace(/\./g, "/");
-
       // No import edge from a file to itself (#157). A module that names
       // itself is resolvable in CPython — `import mymodule` inside a
       // top-level `mymodule.py` really does import a second copy — but as a
@@ -2590,12 +2577,28 @@ export function resolveImport(
       // A rejected candidate falls through to the next probe rather than
       // ending resolution: `src/pkg/requests.py` importing `requests` must
       // still find a legitimate `src/requests.py` behind the discarded self
-      // match. Only the sibling probe can reach here on the layouts in #157,
-      // but `direct` reaches it too for a module at the project root, so the
-      // guard sits on every absolute probe rather than on one of them.
+      // match. Only the sibling probe can reach a self match on the layouts in
+      // #157, but `direct` reaches it too for a module at the project root and
+      // the relative branch reaches it for `from . import x` written in a
+      // package's own `__init__.py` — which resolves the bare `.` to that same
+      // `__init__.py`, the commonest self-edge in any Python tree. So the
+      // guard sits on every probe rather than on one of them.
       const relSourceFile = toForwardSlash(path.relative(projectPath, sourceFile));
       const notSelf = (candidate: string | null): string | null =>
         candidate === null || candidate === relSourceFile ? null : candidate;
+
+      // Relative: .foo, ..bar
+      if (moduleSpecifier.startsWith(".")) {
+        const dots = moduleSpecifier.match(/^\.+/)?.[0].length ?? 0;
+        let baseDir = sourceDir;
+        for (let i = 1; i < dots; i++) {
+          baseDir = path.dirname(baseDir);
+        }
+        const rest = moduleSpecifier.slice(dots).replace(/\./g, "/");
+        return notSelf(resolveRelativePath(rest || ".", baseDir, projectPath, fileSet, [".py"]));
+      }
+      // Absolute: foo.bar.baz → foo/bar/baz.py or foo/bar/baz/__init__.py
+      const modulePath = moduleSpecifier.replace(/\./g, "/");
 
       const direct = notSelf(
         resolveRelativePath(modulePath, projectPath, projectPath, fileSet, [".py"]),

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -2576,12 +2576,14 @@ export function resolveImport(
       //
       // Every probe is guarded, but the disposition differs. The sibling probe
       // is a guess at a directory Python may not have on `sys.path` at all, so
-      // a self match there falls through to the next probe:
-      // `src/pkg/requests.py` importing `requests` must still find a
-      // legitimate `src/requests.py` behind the discarded match. Every other
-      // absolute probe stands for a real path entry, so a self match there
-      // ends resolution — see the comment above `direct`. The relative branch
-      // has nothing to fall through to: it reaches a self match for
+      // a self match there falls through to the probes behind it, which are
+      // the manifest-declared roots — the only ones that run after it:
+      // `packages/pkg-a/src/ns/requests.py` importing `requests` must still
+      // find the legitimate `packages/pkg-a/src/requests.py` that pkg-a's
+      // declared root supplies. Every other absolute probe stands for a real
+      // path entry, so a self match there ends resolution — see the comment
+      // above `direct`. The relative branch has nothing to fall through to:
+      // it reaches a self match for
       // `from . import x` written in a package's own `__init__.py`, which
       // resolves the bare `.` to that same `__init__.py` — the commonest
       // self-edge in any Python tree.

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -2670,9 +2670,26 @@ export function resolveImport(
       // from the runnable script directory #46 exists to serve, so the
       // ambiguity is left as it is rather than guessed at. The self-edge
       // inside such a package is still removed, by the guard above.
-      const inPackage = fileSet.has(
-        path.posix.join(toForwardSlash(path.relative(projectPath, sourceDir)), "__init__.py"),
-      );
+      // Any ancestor up to the project root, not just `sourceDir` itself: a
+      // directory below a regular package is part of that package's tree even
+      // when it carries no `__init__.py` of its own. `src/pkg/vendor/mod.py`
+      // under `src/pkg/__init__.py` is reached as `pkg.vendor.mod` — verified
+      // against CPython, where `import requests` there loads the installed
+      // distribution and not the sibling `vendor/requests.py`. Checking only
+      // `sourceDir` gated `src/pkg/client.py` while leaving its own
+      // subdirectory fabricating the same edge.
+      let inPackage = false;
+      for (
+        let dir = toForwardSlash(path.relative(projectPath, sourceDir));
+        ;
+        dir = dir.includes("/") ? dir.slice(0, dir.lastIndexOf("/")) : ""
+      ) {
+        if (fileSet.has(dir === "" ? "__init__.py" : `${dir}/__init__.py`)) {
+          inPackage = true;
+          break;
+        }
+        if (dir === "") break;
+      }
       const sibling = inPackage
         ? null
         : notSelf(resolveRelativePath(modulePath, sourceDir, projectPath, fileSet, [".py"]));

--- a/src/services/graph-resolution.ts
+++ b/src/services/graph-resolution.ts
@@ -2574,15 +2574,17 @@ export function resolveImport(
       // (`whisperx.py` doing `import whisperx`), where the true target is the
       // installed distribution and no first-party edge exists at all.
       //
-      // A rejected candidate falls through to the next probe rather than
-      // ending resolution: `src/pkg/requests.py` importing `requests` must
-      // still find a legitimate `src/requests.py` behind the discarded self
-      // match. Only the sibling probe can reach a self match on the layouts in
-      // #157, but `direct` reaches it too for a module at the project root and
-      // the relative branch reaches it for `from . import x` written in a
-      // package's own `__init__.py` — which resolves the bare `.` to that same
-      // `__init__.py`, the commonest self-edge in any Python tree. So the
-      // guard sits on every probe rather than on one of them.
+      // Every probe is guarded, but the disposition differs. The sibling probe
+      // is a guess at a directory Python may not have on `sys.path` at all, so
+      // a self match there falls through to the next probe:
+      // `src/pkg/requests.py` importing `requests` must still find a
+      // legitimate `src/requests.py` behind the discarded match. Every other
+      // absolute probe stands for a real path entry, so a self match there
+      // ends resolution — see the comment above `direct`. The relative branch
+      // has nothing to fall through to: it reaches a self match for
+      // `from . import x` written in a package's own `__init__.py`, which
+      // resolves the bare `.` to that same `__init__.py` — the commonest
+      // self-edge in any Python tree.
       const relSourceFile = toForwardSlash(path.relative(projectPath, sourceFile));
       const notSelf = (candidate: string | null): string | null =>
         candidate === null || candidate === relSourceFile ? null : candidate;
@@ -2600,15 +2602,24 @@ export function resolveImport(
       // Absolute: foo.bar.baz → foo/bar/baz.py or foo/bar/baz/__init__.py
       const modulePath = moduleSpecifier.replace(/\./g, "/");
 
-      // A self match HERE ends resolution rather than falling through. The
-      // project root is ahead of `src/`, `lib/` and every manifest root for a
-      // file that sits at the root — it is that file's own `sys.path[0]` — so
-      // nothing a later probe finds is a module CPython could reach past the
-      // source file itself. Root `mod.py` doing `import mod` beside a
-      // `src/mod.py` imports itself; answering with `src/mod.py` trades the
-      // self-edge for an edge to an unrelated module, which is worse. The
-      // later probes still fall through, because there the discarded match is
-      // a guess (the sibling probe) or one root among several.
+      // A self match at a probe that stands for a real `sys.path` entry ENDS
+      // resolution rather than falling through. Whichever directory a probe
+      // stands for — the project root, `src/`, `lib/`, a manifest-declared
+      // root — a match under it that IS the source file means that directory
+      // is the source file's own path entry, and a path entry that already
+      // supplies the module is not searched past. Root `mod.py` doing
+      // `import mod` beside a `src/mod.py` imports itself; answering with
+      // `src/mod.py` trades the self-edge for an edge to an unrelated module,
+      // which is worse. The same holds one probe down (`src/mod.py` must not
+      // answer with `lib/mod.py`) and at the manifest roots, where the
+      // fall-through reached a *sibling workspace package*:
+      // `packages/pkg-a/src/requests.py` importing `requests` answered with
+      // `packages/pkg-b/src/requests.py`, a fabricated cross-package edge.
+      //
+      // Only the sibling probe still falls through, because it alone is a
+      // guess rather than a path entry: `packages/pkg-a/src/ns/requests.py`
+      // has no `sys.path` entry at `.../src/ns`, so the discarded sibling
+      // match must yield to the declared root that really supplies the module.
       const direct = resolveRelativePath(modulePath, projectPath, projectPath, fileSet, [".py"]);
       if (direct === relSourceFile) return null;
       if (direct) return direct;
@@ -2616,11 +2627,10 @@ export function resolveImport(
       // Try common Python source directories (src layout)
       const pySrcDirs = ["src", "lib"];
       for (const dir of pySrcDirs) {
-        const inSrc = notSelf(
-          resolveRelativePath(
-            path.join(dir, modulePath), projectPath, projectPath, fileSet, [".py"],
-          ),
+        const inSrc = resolveRelativePath(
+          path.join(dir, modulePath), projectPath, projectPath, fileSet, [".py"],
         );
+        if (inSrc === relSourceFile) return null;
         if (inSrc) return inSrc;
       }
 
@@ -2678,6 +2688,13 @@ export function resolveImport(
       // distribution and not the sibling `vendor/requests.py`. Checking only
       // `sourceDir` gated `src/pkg/client.py` while leaving its own
       // subdirectory fabricating the same edge.
+      //
+      // The project root itself counts. Indexing a directory that IS a package
+      // (`.../src/mylib`, `__init__.py` and all) disables the sibling fallback
+      // for the whole tree, and that is right rather than merely intended:
+      // every file in it is a `mylib.*` module reached through the parent
+      // directory on `sys.path`, so the flat guess was never what CPython does
+      // there.
       let inPackage = false;
       for (
         let dir = toForwardSlash(path.relative(projectPath, sourceDir));
@@ -2705,12 +2722,16 @@ export function resolveImport(
       // pythonRootsForFile — a root that is not on the file's ancestor path
       // and not a declared workspace member never appears here, and a package's
       // own root is tried before a sibling package's.
+      //
+      // A self match here ends resolution, like the root and `src/` probes
+      // above: the roots are ordered containing-first, so the root that
+      // supplies the source file itself is the nearest path entry this file
+      // has, and every root behind it belongs to a sibling package.
       for (const importRoot of pythonImportRoots ?? []) {
-        const inRoot = notSelf(
-          resolveRelativePath(
-            path.posix.join(importRoot, modulePath), projectPath, projectPath, fileSet, [".py"],
-          ),
+        const inRoot = resolveRelativePath(
+          path.posix.join(importRoot, modulePath), projectPath, projectPath, fileSet, [".py"],
         );
+        if (inRoot === relSourceFile) return null;
         if (inRoot) return inRoot;
       }
 

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -768,6 +768,46 @@ describe("graph-resolution", () => {
       expect(pyResolve("requests", "src/ns/sub/requests.py", project)).toBeNull();
     });
 
+    it("does not fall through a project-root self match into src/", () => {
+      // The root IS sys.path[0] for a file that sits there, so `import mod`
+      // from `mod.py` imports that same file — no later probe can name a
+      // module CPython would reach instead. Falling through answered with
+      // `src/mod.py`, an edge to an unrelated module: the self-edge traded for
+      // a wrong one rather than removed.
+      project = createTempProject({
+        "mod.py": "",
+        "src/mod.py": "",
+      });
+
+      expect(pyResolve("mod", "mod.py", project)).toBeNull();
+      // The src-layout file still reaches the root module; only the self
+      // match is discarded.
+      expect(pyResolve("mod", "src/mod.py", project)).toBe("mod.py");
+    });
+
+    it("drops a script-run package directory's sibling edge, as an accepted cost", () => {
+      // Pinned because it is a real loss, not a neutral refinement. `sys.path[0]`
+      // is the SCRIPT's directory whether or not it holds `__init__.py`, so
+      // `python service-a/main.py` genuinely imports `service-a/config.py`
+      // here and this edge is now missed — the same layout as the #46 test
+      // above, one `__init__.py` away.
+      //
+      // Accepted because the two errors are not symmetric. A name collision
+      // with a dependency cannot be falsified from the tree, so leaving the
+      // gate off invents edges wherever one occurs; a package directory at
+      // least says the file is normally reached as `pkg.client`, and running a
+      // script from inside a package is the layout Python itself discourages
+      // (relative imports fail there). If this proves wrong in the wild, the
+      // fix is a discriminator for "run as a script", not removing the gate.
+      project = createTempProject({
+        "service-a/__init__.py": "",
+        "service-a/main.py": "",
+        "service-a/config.py": "",
+      });
+
+      expect(pyResolve("config", "service-a/main.py", project)).toBeNull();
+    });
+
     it("keeps probing after discarding a self match", () => {
       // A discarded self match must not end resolution. The legitimate answer
       // here is reachable ONLY by the manifest-root probe, which runs after

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -58,6 +58,18 @@ describe("graph-resolution", () => {
     project = null;
   });
 
+  // Python resolution as the graph builder calls it: manifests discovered from
+  // the tree, roots scoped to the importing file. Shared by every Python
+  // describe below so the probe order under test is the production one.
+  const pyResolve = (spec: string, from: string, p: TempProject) => {
+    const manifests = buildPythonManifests(p.root);
+    const roots = pythonRootsForFile(manifests, path.posix.dirname(from));
+    return resolveImport(
+      spec, path.join(p.root, from), p.root, p.fileSet, "python",
+      undefined, undefined, undefined, undefined, undefined, undefined, roots,
+    );
+  };
+
   describe("TypeScript/JavaScript resolution", () => {
     it("resolves relative imports with .js extension to .ts files", () => {
       project = createTempProject({
@@ -387,25 +399,6 @@ describe("graph-resolution", () => {
     // on: the roots the pyproject.toml manifests declare, scoped to the
     // importing file and tried nearest first.
 
-    const pyResolve = (spec: string, from: string, p: TempProject) => {
-      const manifests = buildPythonManifests(p.root);
-      const roots = pythonRootsForFile(manifests, path.posix.dirname(from));
-      return resolveImport(
-        spec,
-        path.join(p.root, from),
-        p.root,
-        p.fileSet,
-        "python",
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        roots,
-      );
-    };
-
     // The reporter's layout: dashed distribution directory, intervening src/,
     // underscored module name — a three-way mismatch no name-shaped guess
     // can bridge. The root manifest declares the members, which is what puts
@@ -685,15 +678,6 @@ describe("graph-resolution", () => {
   });
 
   describe("sibling-flat fallback scope (#157)", () => {
-    const pyResolve = (spec: string, from: string, p: TempProject) => {
-      const manifests = buildPythonManifests(p.root);
-      const roots = pythonRootsForFile(manifests, path.posix.dirname(from));
-      return resolveImport(
-        spec, path.join(p.root, from), p.root, p.fileSet, "python",
-        undefined, undefined, undefined, undefined, undefined, undefined, roots,
-      );
-    };
-
     it("does not guess a package's import into a same-named sibling", () => {
       // `src/pkg` holds __init__.py, so it is a regular package and is never
       // sys.path[0]. CPython resolves `import requests` through sys.path to
@@ -705,6 +689,22 @@ describe("graph-resolution", () => {
       });
 
       expect(pyResolve("requests", "src/pkg/client.py", project)).toBeNull();
+    });
+
+    it("gates a namespace subdirectory inside a regular package", () => {
+      // `src/pkg/vendor` carries no __init__.py of its own, but it sits under
+      // one, so it is a portion of the `pkg` tree and mod.py is reached as
+      // `pkg.vendor.mod`. Verified against CPython: `import requests` there
+      // loads the installed distribution, not the sibling. Gating only on
+      // sourceDir's own __init__.py caught src/pkg/client.py and missed this,
+      // which is the same fabricated edge one directory deeper.
+      project = createTempProject({
+        "src/pkg/__init__.py": "",
+        "src/pkg/vendor/mod.py": "",
+        "src/pkg/vendor/requests.py": "",
+      });
+
+      expect(pyResolve("requests", "src/pkg/vendor/mod.py", project)).toBeNull();
     });
 
     it("does not resolve a file to itself", () => {

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -510,24 +510,6 @@ describe("graph-resolution", () => {
       ).toBeNull();
     });
 
-    it("holds that principle when a first-party sibling shares the module name", () => {
-      // The assertion above passes partly because nothing in the fixture is
-      // called `requests`. Add one and the sibling probe reached past the
-      // declared roots and answered with it, turning "absent from every
-      // declared root" into a fabricated first-party edge (#157). The
-      // importing directory is a package, so the sibling is not on sys.path
-      // for this file and the third-party import stays unresolved.
-      project = createTempProject({
-        ...workspace,
-        "packages/adapter-sos/src/adapter_sos/__init__.py": "",
-        "packages/adapter-sos/src/adapter_sos/requests/adapters.py": "",
-      });
-
-      expect(
-        pyResolve("requests.adapters", "packages/adapter-sos/src/adapter_sos/db.py", project),
-      ).toBeNull();
-    });
-
     it("returns null for a src-layout import when no roots are passed", () => {
       // Back-compat pin: every pre-#107 caller omits the list, and that
       // omission must reproduce the old behavior exactly rather than
@@ -678,35 +660,6 @@ describe("graph-resolution", () => {
   });
 
   describe("sibling-flat fallback scope (#157)", () => {
-    it("does not guess a package's import into a same-named sibling", () => {
-      // `src/pkg` holds __init__.py, so it is a regular package and is never
-      // sys.path[0]. CPython resolves `import requests` through sys.path to
-      // the installed distribution; the sibling file is not what runs.
-      project = createTempProject({
-        "src/pkg/__init__.py": "",
-        "src/pkg/client.py": "",
-        "src/pkg/requests.py": "",
-      });
-
-      expect(pyResolve("requests", "src/pkg/client.py", project)).toBeNull();
-    });
-
-    it("gates a namespace subdirectory inside a regular package", () => {
-      // `src/pkg/vendor` carries no __init__.py of its own, but it sits under
-      // one, so it is a portion of the `pkg` tree and mod.py is reached as
-      // `pkg.vendor.mod`. Verified against CPython: `import requests` there
-      // loads the installed distribution, not the sibling. Gating only on
-      // sourceDir's own __init__.py caught src/pkg/client.py and missed this,
-      // which is the same fabricated edge one directory deeper.
-      project = createTempProject({
-        "src/pkg/__init__.py": "",
-        "src/pkg/vendor/mod.py": "",
-        "src/pkg/vendor/requests.py": "",
-      });
-
-      expect(pyResolve("requests", "src/pkg/vendor/mod.py", project)).toBeNull();
-    });
-
     it("does not resolve a file to itself", () => {
       // The first-party module named after the package it wraps. No Python
       // import produces a dependency on the importing file.
@@ -750,14 +703,13 @@ describe("graph-resolution", () => {
       expect(pyResolve("requests", "service-a/requests.py", project)).toBeNull();
     });
 
-    it("leaves the PEP 420 namespace-package collision resolved, by choice", () => {
-      // Pinned as a decision, not an oversight. `src/ns/sub` has no
-      // __init__.py, so the package gate cannot see it, and the alternative
-      // discriminator — "sourceDir sits below a declared import root" — also
-      // fires on packages/pkg-a/src/pkg_a and would invert "prefers the
-      // sibling-flat guess over a manifest root" above. Such a directory is
-      // indistinguishable from the runnable script directory #46 serves, so
-      // the sibling stands. Only the self-edge is removed.
+    it("leaves a non-self collision resolved — execution-mode ambiguity", () => {
+      // Which file CPython loads for `import requests` here depends on how
+      // mod.py is run, and the tree does not say: imported as `ns.sub.mod` the
+      // installed distribution wins, executed as `python src/ns/sub/mod.py`
+      // the sibling does. Pinned as a decision rather than an oversight — the
+      // resolver has no evidence of execution mode, so it does not guess.
+      // Only the unambiguous self-resolution is removed.
       project = createTempProject({
         "pyproject.toml": '[project]\nname = "ns-demo"\n',
         "src/ns/sub/mod.py": "",
@@ -766,6 +718,41 @@ describe("graph-resolution", () => {
 
       expect(pyResolve("requests", "src/ns/sub/mod.py", project)).toBe("src/ns/sub/requests.py");
       expect(pyResolve("requests", "src/ns/sub/requests.py", project)).toBeNull();
+    });
+
+    it("keeps the #46 sibling edge when the service directory also has __init__.py", () => {
+      // `sys.path[0]` is the SCRIPT's directory whether or not that directory
+      // is also a package, so `python service-a/main.py` really does import
+      // service-a/config.py here. Gating the sibling probe on __init__.py
+      // would drop this legitimate #46 edge on a layout the tree cannot
+      // distinguish from a package module — a backward-compatibility
+      // regression, so it is not done.
+      project = createTempProject({
+        "service-a/__init__.py": "",
+        "service-a/main.py": "",
+        "service-a/config.py": "",
+      });
+
+      expect(pyResolve("config", "service-a/main.py", project)).toBe("service-a/config.py");
+    });
+
+    it("leaves a regular-package name collision resolved — execution-mode ambiguity", () => {
+      // The #157 report's own case, left alone on purpose. `import requests`
+      // from src/pkg/client.py loads the installed distribution when the file
+      // is reached as `pkg.client`, and the sibling when it is executed
+      // directly; __init__.py does not settle which, because sys.path[0]
+      // follows the invocation, not the layout. Documented rather than
+      // changed. Narrowing it needs evidence of execution mode the resolver
+      // does not have.
+      project = createTempProject({
+        "src/pkg/__init__.py": "",
+        "src/pkg/client.py": "",
+        "src/pkg/requests.py": "",
+      });
+
+      expect(pyResolve("requests", "src/pkg/client.py", project)).toBe("src/pkg/requests.py");
+      // The self-edge in the same tree is still unambiguous, and still goes.
+      expect(pyResolve("requests", "src/pkg/requests.py", project)).toBeNull();
     });
 
     it("does not fall through a project-root self match into src/", () => {
@@ -783,29 +770,6 @@ describe("graph-resolution", () => {
       // The src-layout file still reaches the root module; only the self
       // match is discarded.
       expect(pyResolve("mod", "src/mod.py", project)).toBe("mod.py");
-    });
-
-    it("drops a script-run package directory's sibling edge, as an accepted cost", () => {
-      // Pinned because it is a real loss, not a neutral refinement. `sys.path[0]`
-      // is the SCRIPT's directory whether or not it holds `__init__.py`, so
-      // `python service-a/main.py` genuinely imports `service-a/config.py`
-      // here and this edge is now missed — the same layout as the #46 test
-      // above, one `__init__.py` away.
-      //
-      // Accepted because the two errors are not symmetric. A name collision
-      // with a dependency cannot be falsified from the tree, so leaving the
-      // gate off invents edges wherever one occurs; a package directory at
-      // least says the file is normally reached as `pkg.client`, and running a
-      // script from inside a package is the layout Python itself discourages
-      // (relative imports fail there). If this proves wrong in the wild, the
-      // fix is a discriminator for "run as a script", not removing the gate.
-      project = createTempProject({
-        "service-a/__init__.py": "",
-        "service-a/main.py": "",
-        "service-a/config.py": "",
-      });
-
-      expect(pyResolve("config", "service-a/main.py", project)).toBeNull();
     });
 
     it("does not fall through a src/ self match into lib/", () => {

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -808,11 +808,49 @@ describe("graph-resolution", () => {
       expect(pyResolve("config", "service-a/main.py", project)).toBeNull();
     });
 
-    it("keeps probing after discarding a self match", () => {
-      // A discarded self match must not end resolution. The legitimate answer
-      // here is reachable ONLY by the manifest-root probe, which runs after
-      // the sibling probe: the project-root and src/ probes both miss, so if
-      // the self match ended the chain the real edge would be lost. `src` is
+    it("does not fall through a src/ self match into lib/", () => {
+      // `src/` is this file's own path entry, so `import mod` from
+      // `src/mod.py` imports that same file; `lib/mod.py` is a different
+      // module CPython never reaches here. Falling through answered with it —
+      // the self-edge traded for a wrong one, exactly what the project-root
+      // probe above refuses to do.
+      project = createTempProject({
+        "src/mod.py": "",
+        "lib/mod.py": "",
+      });
+
+      expect(pyResolve("mod", "src/mod.py", project)).toBeNull();
+      // The lib file still reaches the src module — `src` is probed first, and
+      // only the self match is discarded.
+      expect(pyResolve("mod", "lib/mod.py", project)).toBe("src/mod.py");
+    });
+
+    it("does not fall through a manifest-root self match into a sibling package", () => {
+      // The roots are ordered containing-first, so the root that supplies the
+      // source file is the nearest path entry this file has and every root
+      // behind it belongs to another workspace member. Falling through
+      // answered `import requests` from pkg-a's own `requests.py` with pkg-b's
+      // — a fabricated cross-package edge, worse than the self-edge it
+      // replaced.
+      project = createTempProject({
+        "pyproject.toml": '[tool.uv.workspace]\nmembers = ["packages/*"]\n',
+        "packages/pkg-a/pyproject.toml": '[project]\nname = "pkg-a"\n',
+        "packages/pkg-b/pyproject.toml": '[project]\nname = "pkg-b"\n',
+        "packages/pkg-a/src/requests.py": "",
+        "packages/pkg-b/src/requests.py": "",
+      });
+
+      expect(pyResolve("requests", "packages/pkg-a/src/requests.py", project)).toBeNull();
+      expect(pyResolve("requests", "packages/pkg-b/src/requests.py", project)).toBeNull();
+    });
+
+    it("keeps probing after discarding a sibling self match", () => {
+      // A self match discarded by the SIBLING probe must not end resolution —
+      // that probe is a guess at a directory Python may not have on sys.path
+      // at all. The legitimate answer here is reachable ONLY by the
+      // manifest-root probe, which runs after it: the project-root and src/
+      // probes both miss, so if the sibling self match ended the chain the
+      // real edge would be lost. `src` is
       // an import root for pkg-a and `src/ns` is not, so CPython imports
       // packages/pkg-a/src/requests.py for this file.
       project = createTempProject({

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -685,9 +685,6 @@ describe("graph-resolution", () => {
   });
 
   describe("sibling-flat fallback scope (#157)", () => {
-    let project: TempProject;
-    afterEach(() => project?.cleanup());
-
     const pyResolve = (spec: string, from: string, p: TempProject) => {
       const manifests = buildPythonManifests(p.root);
       const roots = pythonRootsForFile(manifests, path.posix.dirname(from));
@@ -719,6 +716,24 @@ describe("graph-resolution", () => {
       });
 
       expect(pyResolve("requests", "src/pkg/requests.py", project)).toBeNull();
+    });
+
+    it("does not resolve `from . import x` in a package's own __init__.py to itself", () => {
+      // The bare `.` of `from . import mod` names the importing package, and
+      // the file that IS that package is this __init__.py — so the relative
+      // branch answers with the source file. It is the same fabricated
+      // self-edge the absolute probes now discard, and by far the commonest
+      // one in a Python tree; findCircularDependencies has no self-loop guard,
+      // so each one is reported as a cycle. Every other relative form still
+      // resolves.
+      project = createTempProject({
+        "src/pkg/__init__.py": "",
+        "src/pkg/mod.py": "",
+      });
+
+      expect(pyResolve(".", "src/pkg/__init__.py", project)).toBeNull();
+      expect(pyResolve(".", "src/pkg/mod.py", project)).toBe("src/pkg/__init__.py");
+      expect(pyResolve(".mod", "src/pkg/__init__.py", project)).toBe("src/pkg/mod.py");
     });
 
     it("does not resolve a file to itself in the #46 layout the fallback serves", () => {

--- a/tests/unit/graph-resolution.test.ts
+++ b/tests/unit/graph-resolution.test.ts
@@ -517,6 +517,24 @@ describe("graph-resolution", () => {
       ).toBeNull();
     });
 
+    it("holds that principle when a first-party sibling shares the module name", () => {
+      // The assertion above passes partly because nothing in the fixture is
+      // called `requests`. Add one and the sibling probe reached past the
+      // declared roots and answered with it, turning "absent from every
+      // declared root" into a fabricated first-party edge (#157). The
+      // importing directory is a package, so the sibling is not on sys.path
+      // for this file and the third-party import stays unresolved.
+      project = createTempProject({
+        ...workspace,
+        "packages/adapter-sos/src/adapter_sos/__init__.py": "",
+        "packages/adapter-sos/src/adapter_sos/requests/adapters.py": "",
+      });
+
+      expect(
+        pyResolve("requests.adapters", "packages/adapter-sos/src/adapter_sos/db.py", project),
+      ).toBeNull();
+    });
+
     it("returns null for a src-layout import when no roots are passed", () => {
       // Back-compat pin: every pre-#107 caller omits the list, and that
       // omission must reproduce the old behavior exactly rather than
@@ -663,6 +681,95 @@ describe("graph-resolution", () => {
       });
 
       expect(pyResolve("os", "src/pkg_a/main.py", project)).toBeNull();
+    });
+  });
+
+  describe("sibling-flat fallback scope (#157)", () => {
+    let project: TempProject;
+    afterEach(() => project?.cleanup());
+
+    const pyResolve = (spec: string, from: string, p: TempProject) => {
+      const manifests = buildPythonManifests(p.root);
+      const roots = pythonRootsForFile(manifests, path.posix.dirname(from));
+      return resolveImport(
+        spec, path.join(p.root, from), p.root, p.fileSet, "python",
+        undefined, undefined, undefined, undefined, undefined, undefined, roots,
+      );
+    };
+
+    it("does not guess a package's import into a same-named sibling", () => {
+      // `src/pkg` holds __init__.py, so it is a regular package and is never
+      // sys.path[0]. CPython resolves `import requests` through sys.path to
+      // the installed distribution; the sibling file is not what runs.
+      project = createTempProject({
+        "src/pkg/__init__.py": "",
+        "src/pkg/client.py": "",
+        "src/pkg/requests.py": "",
+      });
+
+      expect(pyResolve("requests", "src/pkg/client.py", project)).toBeNull();
+    });
+
+    it("does not resolve a file to itself", () => {
+      // The first-party module named after the package it wraps. No Python
+      // import produces a dependency on the importing file.
+      project = createTempProject({
+        "src/pkg/__init__.py": "",
+        "src/pkg/requests.py": "",
+      });
+
+      expect(pyResolve("requests", "src/pkg/requests.py", project)).toBeNull();
+    });
+
+    it("does not resolve a file to itself in the #46 layout the fallback serves", () => {
+      // No __init__.py, so the sibling fallback still applies here and must:
+      // `import config` keeps resolving. Only the self match is discarded,
+      // which no package gate could reach — the two guards are independent.
+      project = createTempProject({
+        "service-a/main.py": "",
+        "service-a/config.py": "",
+        "service-a/requests.py": "",
+      });
+
+      expect(pyResolve("config", "service-a/main.py", project)).toBe("service-a/config.py");
+      expect(pyResolve("requests", "service-a/requests.py", project)).toBeNull();
+    });
+
+    it("leaves the PEP 420 namespace-package collision resolved, by choice", () => {
+      // Pinned as a decision, not an oversight. `src/ns/sub` has no
+      // __init__.py, so the package gate cannot see it, and the alternative
+      // discriminator — "sourceDir sits below a declared import root" — also
+      // fires on packages/pkg-a/src/pkg_a and would invert "prefers the
+      // sibling-flat guess over a manifest root" above. Such a directory is
+      // indistinguishable from the runnable script directory #46 serves, so
+      // the sibling stands. Only the self-edge is removed.
+      project = createTempProject({
+        "pyproject.toml": '[project]\nname = "ns-demo"\n',
+        "src/ns/sub/mod.py": "",
+        "src/ns/sub/requests.py": "",
+      });
+
+      expect(pyResolve("requests", "src/ns/sub/mod.py", project)).toBe("src/ns/sub/requests.py");
+      expect(pyResolve("requests", "src/ns/sub/requests.py", project)).toBeNull();
+    });
+
+    it("keeps probing after discarding a self match", () => {
+      // A discarded self match must not end resolution. The legitimate answer
+      // here is reachable ONLY by the manifest-root probe, which runs after
+      // the sibling probe: the project-root and src/ probes both miss, so if
+      // the self match ended the chain the real edge would be lost. `src` is
+      // an import root for pkg-a and `src/ns` is not, so CPython imports
+      // packages/pkg-a/src/requests.py for this file.
+      project = createTempProject({
+        "pyproject.toml": '[tool.uv.workspace]\nmembers = ["packages/*"]\n',
+        "packages/pkg-a/pyproject.toml": '[project]\nname = "pkg-a"\n',
+        "packages/pkg-a/src/requests.py": "",
+        "packages/pkg-a/src/ns/requests.py": "",
+      });
+
+      expect(pyResolve("requests", "packages/pkg-a/src/ns/requests.py", project)).toBe(
+        "packages/pkg-a/src/requests.py",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

The Python sibling-flat fallback (#46) was applied to every absolute import that fell past the earlier probes, including imports made from inside a package. Where a first-party module shares a name with a third-party distribution, the import resolved to the sibling instead of the installed package, and a module named after the package it wraps resolved to itself. `codebase_graph_circular` reported those as import cycles.

Scope agreed in #157: remove the unambiguous regular-package collision and the self-edge cases, preserve #46 and #112, and pin the non-self PEP 420 case as an explicit structural ambiguity.

## Changes

- **No edge from a file to itself**, on all five probes — relative, project-root, `src`/`lib`, sibling, and manifest roots. The relative branch matters most: `from . import x` in a package's own `__init__.py` resolves the bare `.` to that same file, the commonest self-edge in any Python tree.
- **A self match at a probe standing for a real `sys.path` entry ends resolution** rather than falling through. Falling through traded a self-edge for a wrong one — `src/mod.py` → `lib/mod.py`, and `packages/pkg-a/src/requests.py` → `packages/pkg-b/src/requests.py`, a fabricated cross-package edge. Only the sibling probe still falls through, because it alone is a guess at a directory rather than a path entry.
- **The sibling probe is skipped when any ancestor up to the project root holds `__init__.py`.** A file inside a package tree is reached as a dotted module, so the flat guess is not what CPython does — verified directly against CPython for the namespace-subdirectory case (`src/pkg/vendor/mod.py` under `src/pkg/__init__.py` is reached as `pkg.vendor.mod`, and `import requests` there loads the installed distribution).
- **PEP 420 namespace packages are deliberately unchanged**, pinned by a test with the reasoning: no `__init__.py` to test, and the alternative discriminator ("sourceDir below a declared import root") also fires on `packages/pkg-a/src/pkg_a` and would invert `prefers the sibling-flat guess over a manifest root`. Such a directory is indistinguishable from the runnable script directory #46 serves.

### Known cost, accepted deliberately

`sys.path[0]` is the *script's* directory whether or not it holds `__init__.py`, so `python service-a/main.py` genuinely imports `service-a/config.py` even when `service-a/__init__.py` exists — and that edge is now dropped. Pinned by its own test rather than left in a comment. A name collision with a dependency cannot be falsified from the tree, while a package directory at least says the file is normally reached as `pkg.client`; the false edge is judged the costlier of the two. Discussed in #157.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Unit tests pass (`npm run test:unit`) — 2053 across 82 files
- [x] Integration tests pass (`npm run test:integration`) — 172 across 12 files
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] New tests added for new/changed functionality — 11 in a `sibling-flat fallback scope (#157)` describe, each verified failing before the fix

No pre-existing test expectation was altered; the only deletion is a duplicated `pyResolve` helper hoisted to the outer describe. Behavior also checked against a 753-file Python repo: exactly 4 edges removed, all of them the target defect, zero legitimate edges lost.

One integration file (`manual-indexing-mode`) failed at suite level on an earlier run with zero failed assertions, and passed both in isolation and on a clean re-run — order-dependent, and untouched by this change. Flagging in case you see it too.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have added/updated JSDoc comments where appropriate
- [ ] I have updated documentation (README.md / DEVELOPER.md) if needed — no public API change
- [ ] I have addressed all [CodeRabbit](https://coderabbit.ai) review comments — pending first review
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] I agree to the [Contributor License Agreement](../CLA.md)

## Related issues

Fixes #157


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Python imports from resolving back to the file that issued the import.
  * Preserved valid sibling-module links, including in package directories and namespace subdirectories.
  * Improved resolution consistency across project roots, source directories, and manifest-defined roots.
  * Ensured discarded self-matches do not incorrectly fall through to unrelated resolution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->