### PR TITLE
ci(release): automate MCP Registry publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npm run check:release-versions
       - run: npx biome check src/ tests/
       - run: npx tsc --noEmit
 

--- a/.github/workflows/mcp-registry-release.yml
+++ b/.github/workflows/mcp-registry-release.yml
@@ -1,0 +1,90 @@
+name: MCP Registry Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: mcp-registry-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish MCP Registry entry
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify tag and release manifests agree
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          release_version="${RELEASE_TAG#v}"
+          npm run check:release-versions -- "$release_version"
+
+      - name: Verify the exact package is available on npm
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          release_version="${RELEASE_TAG#v}"
+          error_file="$RUNNER_TEMP/npm-view-error.log"
+
+          for attempt in {1..30}; do
+            if published_version="$(npm view "socraticode@${release_version}" version 2>"$error_file")"; then
+              if [[ "$published_version" != "$release_version" ]]; then
+                echo "npm returned version '$published_version', expected '$release_version'" >&2
+                exit 1
+              fi
+              echo "Confirmed socraticode@$release_version on npm"
+              exit 0
+            fi
+
+            if [[ "$attempt" -lt 30 ]]; then
+              sleep 10
+            fi
+          done
+
+          cat "$error_file" >&2
+          echo "socraticode@$release_version was not available on npm after 5 minutes" >&2
+          exit 1
+
+      - name: Install the pinned MCP Registry publisher
+        shell: bash
+        env:
+          MCP_PUBLISHER_VERSION: "1.8.1"
+          MCP_PUBLISHER_SHA256: "a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc"
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/mcp-publisher.tar.gz"
+          install_dir="$RUNNER_TEMP/mcp-publisher"
+          mkdir -p "$install_dir"
+          curl --fail --location --retry 3 --proto '=https' --tlsv1.2 \
+            "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
+            --output "$archive"
+          echo "${MCP_PUBLISHER_SHA256}  $archive" | sha256sum --check
+          tar -xzf "$archive" -C "$install_dir" mcp-publisher
+          echo "$install_dir" >> "$GITHUB_PATH"
+
+      - name: Validate MCP Registry metadata
+        run: mcp-publisher validate server.json
+
+      - name: Authenticate to the MCP Registry
+        run: mcp-publisher login github-oidc
+
+      - name: Publish MCP Registry entry
+        run: mcp-publisher publish server.json

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -168,9 +168,16 @@ npm run release:dry
 This will automatically:
 1. Determine the version bump from your commits
 2. Update `CHANGELOG.md` with all `feat:`, `fix:`, etc. entries
-3. Bump the version in `package.json`, plugin manifests, Gemini extension manifest, and VS Code extension package files
-4. Create a git commit and tag (`v1.1.0`)
-5. Push to GitHub and create a GitHub Release
+3. Bump the version in `package.json`, plugin manifests, Gemini extension manifest, VS Code extension package files, and `server.json`
+4. Publish the npm package
+5. Create and push a git commit and tag (`v1.1.0`), then create a GitHub Release
+6. Publish matching VS Code, Open VSX, and official MCP Registry entries from the tag workflows
+
+The MCP Registry workflow verifies that the tag, root package, and every release
+manifest carry the same version, waits for that exact npm package to become
+available, validates `server.json`, and publishes with GitHub OIDC. It uses no
+long-lived Registry credential. A failure stops the Registry job and leaves the
+underlying npm and GitHub release visible for diagnosis and a workflow rerun.
 
 ---
 
@@ -1618,9 +1625,10 @@ npm run publish:all
 
 The shipped integrations track the engine version. The
 `scripts/bump-plugin-versions.mjs` `release-it` hook updates every plugin
-manifest, `gemini-extension.json`, `extension/package.json`, and both version
-fields in `extension/package-lock.json`. An engine release `vX.Y.Z` therefore
-publishes matching integration metadata.
+manifest, `gemini-extension.json`, `extension/package.json`, both version fields
+in `extension/package-lock.json`, and both the server and npm-package versions
+in `server.json`. An engine release `vX.Y.Z` therefore publishes matching
+integration and MCP Registry metadata.
 
 ### What the extension does NOT do
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "tsc && node scripts/copy-assets.mjs",
+    "check:release-versions": "node scripts/check-release-versions.mjs",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
     "lint": "biome check src/ tests/",

--- a/scripts/bump-plugin-versions.mjs
+++ b/scripts/bump-plugin-versions.mjs
@@ -3,24 +3,16 @@
 // Copyright (C) 2026 Giancarlo Erra - Altaire Limited
 //
 // release-it `after:bump` hook. Synchronises the version field across
-// every plugin / extension manifest in the repo so a single engine
-// release also bumps the Claude / Cursor / Codex plugins, the Gemini
-// extension, and the VS Code / Open VSX extension. Skips manifests that
-// don't exist.
+// every release manifest in the repo so a single engine release also bumps
+// the Claude / Cursor / Codex plugins, the Gemini extension, the VS Code /
+// Open VSX extension, and the official MCP Registry entry. Skips manifests
+// that don't exist.
 //
 // Usage: node scripts/bump-plugin-versions.mjs <version>
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-
-const MANIFESTS = [
-  ".claude-plugin/plugin.json",
-  ".cursor-plugin/plugin.json",
-  ".codex-plugin/plugin.json",
-  "gemini-extension.json",
-  "extension/package.json",
-  "extension/package-lock.json",
-];
+import { setManifestVersion, VERSIONED_MANIFESTS } from "./release-manifests.mjs";
 
 const version = process.argv[2];
 if (!version) {
@@ -29,24 +21,12 @@ if (!version) {
 }
 
 let touched = 0;
-for (const rel of MANIFESTS) {
+for (const rel of VERSIONED_MANIFESTS) {
   const path = resolve(process.cwd(), rel);
   if (!existsSync(path)) continue;
   try {
     const json = JSON.parse(readFileSync(path, "utf8"));
-    let changed = false;
-    if (json.version !== version) {
-      json.version = version;
-      changed = true;
-    }
-    if (
-      rel.endsWith("package-lock.json") &&
-      json.packages?.[""] &&
-      json.packages[""].version !== version
-    ) {
-      json.packages[""].version = version;
-      changed = true;
-    }
+    const changed = setManifestVersion(rel, json, version);
     if (!changed) continue;
     writeFileSync(path, `${JSON.stringify(json, null, 2)}\n`);
     console.log(`bumped ${rel} -> ${version}`);

--- a/scripts/check-release-versions.mjs
+++ b/scripts/check-release-versions.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { manifestVersionFields, VERSIONED_MANIFESTS } from "./release-manifests.mjs";
+
+function readJson(relativePath) {
+  const path = resolve(process.cwd(), relativePath);
+  if (!existsSync(path)) throw new Error(`missing release manifest: ${relativePath}`);
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+try {
+  const packageManifest = readJson("package.json");
+  const expectedVersion = process.argv[2] ?? packageManifest.version;
+  if (packageManifest.version !== expectedVersion) {
+    throw new Error(
+      `package.json.version is ${JSON.stringify(packageManifest.version)}, expected ${JSON.stringify(expectedVersion)}`,
+    );
+  }
+
+  const mismatches = [];
+  for (const relativePath of VERSIONED_MANIFESTS) {
+    const manifest = readJson(relativePath);
+    for (const field of manifestVersionFields(relativePath, manifest)) {
+      if (field.value !== expectedVersion) {
+        mismatches.push(
+          `${field.label} is ${JSON.stringify(field.value)}, expected ${JSON.stringify(expectedVersion)}`,
+        );
+      }
+    }
+
+    if (relativePath === "server.json") {
+      if (manifest.name !== packageManifest.mcpName) {
+        mismatches.push(
+          `server.json.name is ${JSON.stringify(manifest.name)}, expected package.json.mcpName ${JSON.stringify(packageManifest.mcpName)}`,
+        );
+      }
+      const npmPackage = manifest.packages?.find((pkg) => pkg.registryType === "npm");
+      if (npmPackage?.identifier !== packageManifest.name) {
+        mismatches.push(
+          `server.json npm identifier is ${JSON.stringify(npmPackage?.identifier)}, expected package.json.name ${JSON.stringify(packageManifest.name)}`,
+        );
+      }
+    }
+  }
+
+  if (mismatches.length > 0) {
+    throw new Error(`release manifest mismatch:\n- ${mismatches.join("\n- ")}`);
+  }
+
+  console.log(`release manifests match ${expectedVersion}`);
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/release-manifests.mjs
+++ b/scripts/release-manifests.mjs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+/** Manifests whose release version must match the root package version. */
+export const VERSIONED_MANIFESTS = [
+  ".claude-plugin/plugin.json",
+  ".cursor-plugin/plugin.json",
+  ".codex-plugin/plugin.json",
+  "gemini-extension.json",
+  "extension/package.json",
+  "extension/package-lock.json",
+  "server.json",
+];
+
+const VERSIONED_REGISTRY_TYPES = new Set(["npm", "pypi", "nuget"]);
+
+function hasPackageLockRoot(manifest) {
+  return (
+    manifest.packages !== null &&
+    typeof manifest.packages === "object" &&
+    Object.prototype.hasOwnProperty.call(manifest.packages, "")
+  );
+}
+
+/** Return every version-bearing field that must match for one manifest. */
+export function manifestVersionFields(relativePath, manifest) {
+  const fields = [{ label: `${relativePath}.version`, value: manifest.version }];
+
+  if (relativePath.endsWith("package-lock.json") && hasPackageLockRoot(manifest)) {
+    fields.push({
+      label: `${relativePath}.packages[\"\"].version`,
+      value: manifest.packages?.[""]?.version,
+    });
+  }
+
+  if (relativePath === "server.json") {
+    if (!Array.isArray(manifest.packages) || manifest.packages.length === 0) {
+      fields.push({ label: "server.json.packages", value: undefined });
+    } else {
+      manifest.packages.forEach((pkg, index) => {
+        if (VERSIONED_REGISTRY_TYPES.has(pkg?.registryType)) {
+          fields.push({
+            label: `server.json.packages[${index}].version`,
+            value: pkg.version,
+          });
+        }
+      });
+    }
+  }
+
+  return fields;
+}
+
+/** Update every release-coupled version field in one parsed manifest. */
+export function setManifestVersion(relativePath, manifest, version) {
+  const fields = manifestVersionFields(relativePath, manifest);
+  const missing = fields.filter((field) => typeof field.value !== "string");
+  if (missing.length > 0) {
+    throw new Error(`missing version field(s): ${missing.map((field) => field.label).join(", ")}`);
+  }
+
+  let changed = false;
+  if (manifest.version !== version) {
+    manifest.version = version;
+    changed = true;
+  }
+
+  if (
+    relativePath.endsWith("package-lock.json") &&
+    hasPackageLockRoot(manifest) &&
+    manifest.packages[""].version !== version
+  ) {
+    manifest.packages[""].version = version;
+    changed = true;
+  }
+
+  if (relativePath === "server.json") {
+    for (const pkg of manifest.packages) {
+      if (VERSIONED_REGISTRY_TYPES.has(pkg.registryType) && pkg.version !== version) {
+        pkg.version = version;
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}

--- a/server.json
+++ b/server.json
@@ -6,19 +6,19 @@
     "url": "https://github.com/giancarloerra/socraticode",
     "source": "github"
   },
-  "version": "1.0.1",
+  "version": "1.13.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "socraticode",
-      "version": "1.0.1",
+      "version": "1.13.2",
       "transport": {
         "type": "stdio"
       },
       "environmentVariables": [
         {
           "name": "EMBEDDING_PROVIDER",
-          "description": "Embedding provider to use: ollama (default), openai, or google",
+          "description": "Embedding provider to use: ollama (default), openai, google, lmstudio, or litellm",
           "isRequired": false,
           "format": "string",
           "isSecret": false
@@ -46,7 +46,70 @@
         },
         {
           "name": "EMBEDDING_MODEL",
-          "description": "Embedding model name (defaults per provider: nomic-embed-text for ollama, text-embedding-3-small for openai, gemini-embedding-001 for google)",
+          "description": "Embedding model name (defaults per provider; required for lmstudio and litellm)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "EMBEDDING_DIMENSIONS",
+          "description": "Embedding vector dimensions (defaults per provider; required for lmstudio and litellm)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "OLLAMA_MODE",
+          "description": "Ollama mode: auto (default), docker, or external",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "OLLAMA_API_KEY",
+          "description": "Optional API key for authenticated Ollama proxies",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "LMSTUDIO_URL",
+          "description": "LM Studio OpenAI-compatible base URL (default: http://localhost:1234/v1)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "LMSTUDIO_API_KEY",
+          "description": "Optional API key when LM Studio authentication is enabled",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "LMSTUDIO_ALLOW_MISSING_MODEL_LISTING",
+          "description": "Allow compatible embedding servers without a models endpoint to be probed directly",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "LITELLM_URL",
+          "description": "LiteLLM OpenAI-compatible base URL (default: http://localhost:4000/v1)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "LITELLM_API_KEY",
+          "description": "LiteLLM master or virtual API key (required when EMBEDDING_PROVIDER=litellm)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "LITELLM_SEND_DIMENSIONS",
+          "description": "Forward the dimensions parameter through LiteLLM when explicitly enabled",
           "isRequired": false,
           "format": "string",
           "isSecret": false

--- a/tests/unit/release-manifests.test.ts
+++ b/tests/unit/release-manifests.test.ts
@@ -1,0 +1,126 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const bumpScript = fileURLToPath(
+  new URL("../../scripts/bump-plugin-versions.mjs", import.meta.url),
+);
+const checkScript = fileURLToPath(
+  new URL("../../scripts/check-release-versions.mjs", import.meta.url),
+);
+
+const roots: string[] = [];
+
+function writeJson(root: string, relativePath: string, value: unknown): void {
+  const filePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJson<T>(root: string, relativePath: string): T {
+  return JSON.parse(readFileSync(path.join(root, relativePath), "utf8")) as T;
+}
+
+function createReleaseFixture(version: string): string {
+  const root = mkdtempSync(path.join(tmpdir(), "socraticode-release-manifests-"));
+  roots.push(root);
+
+  writeJson(root, "package.json", {
+    name: "socraticode",
+    mcpName: "io.github.giancarloerra/socraticode",
+    version,
+  });
+  for (const relativePath of [
+    ".claude-plugin/plugin.json",
+    ".cursor-plugin/plugin.json",
+    ".codex-plugin/plugin.json",
+    "gemini-extension.json",
+    "extension/package.json",
+  ]) {
+    writeJson(root, relativePath, { version: "0.0.1" });
+  }
+  writeJson(root, "extension/package-lock.json", {
+    version: "0.0.1",
+    packages: { "": { version: "0.0.1" } },
+  });
+  writeJson(root, "server.json", {
+    name: "io.github.giancarloerra/socraticode",
+    version: "0.0.1",
+    packages: [{ registryType: "npm", identifier: "socraticode", version: "0.0.1" }],
+  });
+
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("release manifest versioning", () => {
+  it("bumps plugin, extension, lockfile, and MCP Registry versions together", () => {
+    const root = createReleaseFixture("2.4.0");
+
+    execFileSync(process.execPath, [bumpScript, "2.4.0"], { cwd: root });
+
+    expect(readJson<{ version: string }>(root, ".codex-plugin/plugin.json").version).toBe(
+      "2.4.0",
+    );
+    expect(
+      readJson<{ packages: { "": { version: string } } }>(
+        root,
+        "extension/package-lock.json",
+      ).packages[""].version,
+    ).toBe("2.4.0");
+    const server = readJson<{
+      version: string;
+      packages: Array<{ version: string }>;
+    }>(root, "server.json");
+    expect(server.version).toBe("2.4.0");
+    expect(server.packages[0].version).toBe("2.4.0");
+
+    expect(() =>
+      execFileSync(process.execPath, [checkScript, "2.4.0"], { cwd: root }),
+    ).not.toThrow();
+  });
+
+  it("fails when a nested MCP Registry package version drifts", () => {
+    const root = createReleaseFixture("2.4.0");
+    execFileSync(process.execPath, [bumpScript, "2.4.0"], { cwd: root });
+
+    const server = readJson<{
+      version: string;
+      packages: Array<{ registryType: string; identifier: string; version: string }>;
+    }>(root, "server.json");
+    server.packages[0].version = "2.3.9";
+    writeJson(root, "server.json", server);
+
+    const result = spawnSync(process.execPath, [checkScript, "2.4.0"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('server.json.packages[0].version is "2.3.9"');
+  });
+
+  it("rejects a modern lockfile whose root package has no version", () => {
+    const root = createReleaseFixture("2.4.0");
+    writeJson(root, "extension/package-lock.json", {
+      version: "0.0.1",
+      packages: { "": {} },
+    });
+
+    const result = spawnSync(process.execPath, [bumpScript, "2.4.0"], {
+      cwd: root,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'missing version field(s): extension/package-lock.json.packages[""].version',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- synchronize `server.json` with every engine release alongside the existing plugin and extension manifests
- publish each `v*` tag to the official MCP Registry after confirming that the exact npm version is available
- authenticate with GitHub OIDC, pin and checksum the Registry publisher, and fail visibly on any version, download, validation, authentication, or publication error
- refresh the Registry metadata for the currently supported embedding providers
- enforce release-manifest consistency in CI

The workflow does not publish from this pull request. It starts with the next release tag.

## Backward compatibility

- no runtime, index, data, installation, or existing release workflow behavior changes
- npm v1 lockfiles without a `packages` map remain supported
- incomplete modern lockfiles and drifted Registry package versions now fail before release

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm test` (2,107 passed; 181 conditional skips)
- `npm run build`
- `npm pack --dry-run --json`
- Node 18.17 execution and focused release-manifest regressions
- `npm run check:release-versions`
- `mcp-publisher validate server.json`
- Actionlint 1.7.12
- `release-it patch --dry-run --ci --verbose` (selects `1.13.3`)
- CodeRabbit local review: 0 findings on the final commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Releases now publish matching entries to the VS Code Marketplace, Open VSX, and MCP Registry.
  - Added MCP Registry publishing with version validation, package availability checks, and authenticated release handling.
  - Added embedding configuration options for LM Studio, LiteLLM, Ollama modes, authentication, and embedding dimensions.

- **Bug Fixes**
  - Release checks now detect inconsistent versions across packages, manifests, lockfiles, and server metadata.

- **Documentation**
  - Updated release guidance and embedding provider documentation with supported options and requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->