### PR TITLE
fix(config): warn when branch-aware mode is ignored by an explicit project id

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ On VS Code's 2.45M‑line codebase, SocratiCode answers architectural questions 
 - **Parallel processing** — Files are scanned and chunked in parallel batches (50 at a time) for fast I/O, while embedding generation and upserts are batched separately for optimal throughput.
 - **Multi-project** — Index multiple projects simultaneously. Each gets its own isolated collection with full project path tracking.
 - **Cross-project search** — Search across multiple related projects in a single query. Link projects via `.socraticode.json` or the `SOCRATICODE_LINKED_PROJECTS` env var, then set `includeLinked: true` on `codebase_search`. Results are tagged with project labels and ranked by cosine similarity, which is comparable across projects of very different sizes (falling back to rank fusion when a cosine is unavailable for any hit).
-- **Branch-aware indexing** — Maintain separate indexes per git branch by setting `SOCRATICODE_BRANCH_AWARE=true`. Each branch gets its own Qdrant collections, so switching branches instantly switches to the correct index. Ideal for CI/CD pipelines and PR review workflows.
+- **Branch-aware indexing** — Maintain separate indexes per git branch by setting `SOCRATICODE_BRANCH_AWARE=true`. Each branch gets its own Qdrant collections, so switching branches instantly switches to the correct index. Ideal for CI/CD pipelines and PR review workflows. Requires a path-derived project id: an explicit id (`SOCRATICODE_PROJECT_ID`, or `projectId` in `.socraticode.json`) is treated as a stable identity and is never suffixed, so branch-aware mode does not apply to those projects.
 - **Respects ignore rules** — Honors all `.gitignore` files (root + nested), plus an optional `.socraticodeignore` for additional exclusions. Includes sensible built-in defaults. `.gitignore` processing can be disabled via `RESPECT_GITIGNORE=false`. Dot-directories (e.g. `.agent`) can be included via `INCLUDE_DOT_FILES=true`.
 - **Custom file extensions** — Projects with non-standard extensions (e.g. `.tpl`, `.blade`) can be included via `EXTRA_EXTENSIONS` env var or `extraExtensions` tool parameter. Such files are indexed as plaintext and appear as leaf nodes in the code graph (no AST chunking or symbols). To instead treat a custom extension as a real language (full AST chunking, symbols, call graph), map it with `EXTENSION_LANGUAGE_MAP` (e.g. `.inc:php`).
 - **Configurable infrastructure** — All ports, hosts, and API keys are configurable via environment variables. Qdrant API key support for enterprise deployments.
@@ -1117,6 +1117,16 @@ SOCRATICODE_BRANCH_AWARE=true
 ```
 
 With this enabled, collection names include the branch name (e.g. `codebase_abc123__main`, `codebase_abc123__feat_my-feature`). Each branch maintains its own independent index, code graph, and context artifacts.
+
+> **Only applies to path-derived project ids.** If the project pins an id — via
+> `SOCRATICODE_PROJECT_ID` or `projectId` in `.socraticode.json` — that id is
+> treated as a stable identity and is never given a branch suffix, so every
+> branch continues to share one index. This is deliberate: suffixing an explicit
+> id would change the collection names an existing installation already uses and
+> make its indexes appear missing. SocratiCode logs a warning once per project
+> when branch-aware mode is enabled but ignored for this reason. To get
+> per-branch collections, remove the explicit id so the path-derived id can carry
+> the suffix, or set a branch-specific `SOCRATICODE_PROJECT_ID` deliberately.
 
 **When to use:**
 - CI/CD pipelines that index each branch/PR separately

--- a/README.md
+++ b/README.md
@@ -1118,6 +1118,11 @@ SOCRATICODE_BRANCH_AWARE=true
 
 With this enabled, collection names include the branch name (e.g. `codebase_abc123__main`, `codebase_abc123__feat_my-feature`). Each branch maintains its own independent index, code graph, and context artifacts.
 
+> **Also requires a usable branch name.** Branch names are sanitized for use in
+> collection names, so a branch made only of separators (e.g. `___`) reduces to
+> an empty suffix and no per-branch collection is created. Where that happens,
+> set a branch-specific `SOCRATICODE_PROJECT_ID` instead.
+
 > **Only applies to path-derived project ids.** If the project pins an id — via
 > `SOCRATICODE_PROJECT_ID` or `projectId` in `.socraticode.json` — that id is
 > treated as a stable identity and is never given a branch suffix, so every

--- a/extension/README.md
+++ b/extension/README.md
@@ -51,7 +51,10 @@ their own MCP configuration.
   architecture docs alongside code. The AI sees the schema your team
   designed, not what it guessed from filenames.
 - **Branch-aware indexing**: every branch gets its own index, so PR
-  reviews see the code actually being reviewed.
+  reviews see the code actually being reviewed. Applies only to
+  path-derived project IDs: a project that sets `SOCRATICODE_PROJECT_ID`
+  or `projectId` in `.socraticode.json` keeps one index shared by every
+  branch, and SocratiCode logs a warning saying so.
 
 ## Built for real-world big teams and projects
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,6 +117,26 @@ export function projectIdFromPath(folderPath: string): string {
   return id;
 }
 
+/**
+ * What the user would actually have to do to get per-branch collections.
+ *
+ * Three states, not two. A branch existing is not enough: `sanitizeBranchName`
+ * strips every character that cannot appear in a collection name, so a legal
+ * branch such as `___` reduces to the empty string and `projectIdFromPath`
+ * returns the unsuffixed id anyway. Advising removal of the explicit id there
+ * would change the project's identity and still produce no per-branch index.
+ */
+function perBranchAdvice(branch: string | null): string {
+  if (!branch) {
+    return "this project has no detectable git branch (not a repository, or a detached HEAD), so branch-aware mode would produce no suffix here even without an explicit id";
+  }
+  const suffix = sanitizeBranchName(branch);
+  if (!suffix) {
+    return `the branch "${branch}" contains no characters usable in a collection name, so it would produce no suffix even without an explicit id — set a branch-specific SOCRATICODE_PROJECT_ID instead`;
+  }
+  return `remove the explicit project id so the path-derived id can carry the "${suffix}" suffix, or set a branch-specific SOCRATICODE_PROJECT_ID deliberately`;
+}
+
 /** The two ways a project can pin an id, named for the diagnostic below. */
 type ExplicitIdSource = "SOCRATICODE_PROJECT_ID" | ".socraticode.json projectId";
 
@@ -162,9 +182,7 @@ function warnBranchAwareIgnored(
       projectId,
       explicitIdFrom: source,
       branch: branch ?? "(none detected)",
-      howToGetPerBranchIndexes: branch
-        ? `remove the explicit project id so the path-derived id can carry the "${sanitizeBranchName(branch)}" suffix, or set a branch-specific SOCRATICODE_PROJECT_ID deliberately`
-        : "this project has no detectable git branch (not a repository, or a detached HEAD), so branch-aware mode would produce no suffix here even without an explicit id",
+      howToGetPerBranchIndexes: perBranchAdvice(branch),
     },
   );
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,6 +87,39 @@ function readProjectIdFromConfigFile(folderPath: string): string | null {
  * appended to the hash, producing a separate set of collections per
  * branch.
  */
+export function projectIdFromPath(folderPath: string): string {
+  const envExplicit = process.env.SOCRATICODE_PROJECT_ID?.trim();
+  if (envExplicit) {
+    assertValidProjectId(envExplicit, "SOCRATICODE_PROJECT_ID");
+    warnBranchAwareIgnored(envExplicit, "SOCRATICODE_PROJECT_ID", folderPath);
+    return envExplicit;
+  }
+
+  const fileExplicit = readProjectIdFromConfigFile(folderPath);
+  if (fileExplicit) {
+    warnBranchAwareIgnored(fileExplicit, ".socraticode.json projectId", folderPath);
+    return fileExplicit;
+  }
+
+  let id = coreProjectId(folderPath);
+
+  // Branch-aware mode: append sanitized branch name to isolate per-branch indexes
+  if (process.env.SOCRATICODE_BRANCH_AWARE === "true") {
+    const branch = detectGitBranch(path.resolve(folderPath));
+    if (branch) {
+      const sanitized = sanitizeBranchName(branch);
+      if (sanitized) {
+        id = `${id}__${sanitized}`;
+      }
+    }
+  }
+
+  return id;
+}
+
+/** The two ways a project can pin an id, named for the diagnostic below. */
+type ExplicitIdSource = "SOCRATICODE_PROJECT_ID" | ".socraticode.json projectId";
+
 /**
  * Projects already warned that their branch-aware setting is being ignored.
  *
@@ -106,50 +139,34 @@ const branchAwareIgnoredWarned = new Set<string>();
  * the collections of every existing installation and make their indexes look
  * missing. What was wrong was doing it silently — the setting is accepted and
  * simply does nothing, so the only way to find out was to read this file.
+ *
+ * The branch is resolved here rather than by the caller because this runs once
+ * per affected project: it costs one git invocation per project, not one per id
+ * resolution. It is needed for the advice to be true — where no branch can be
+ * detected, removing the explicit id would change the project's identity and
+ * still produce no suffix.
  */
-function warnBranchAwareIgnored(projectId: string, source: string): void {
+function warnBranchAwareIgnored(
+  projectId: string,
+  source: ExplicitIdSource,
+  folderPath: string,
+): void {
   if (process.env.SOCRATICODE_BRANCH_AWARE !== "true") return;
   if (branchAwareIgnoredWarned.has(projectId)) return;
   branchAwareIgnoredWarned.add(projectId);
+
+  const branch = detectGitBranch(folderPath);
   logger.warn(
     "SOCRATICODE_BRANCH_AWARE is ignored for this project because an explicit project id takes precedence — every branch shares one index",
     {
       projectId,
       explicitIdFrom: source,
-      howToGetPerBranchIndexes:
-        "remove the explicit project id so the path-derived id can carry a branch suffix, or set a branch-specific SOCRATICODE_PROJECT_ID deliberately",
+      branch: branch ?? "(none detected)",
+      howToGetPerBranchIndexes: branch
+        ? `remove the explicit project id so the path-derived id can carry the "${sanitizeBranchName(branch)}" suffix, or set a branch-specific SOCRATICODE_PROJECT_ID deliberately`
+        : "this project has no detectable git branch (not a repository, or a detached HEAD), so branch-aware mode would produce no suffix here even without an explicit id",
     },
   );
-}
-
-export function projectIdFromPath(folderPath: string): string {
-  const envExplicit = process.env.SOCRATICODE_PROJECT_ID?.trim();
-  if (envExplicit) {
-    assertValidProjectId(envExplicit, "SOCRATICODE_PROJECT_ID");
-    warnBranchAwareIgnored(envExplicit, "SOCRATICODE_PROJECT_ID");
-    return envExplicit;
-  }
-
-  const fileExplicit = readProjectIdFromConfigFile(folderPath);
-  if (fileExplicit) {
-    warnBranchAwareIgnored(fileExplicit, ".socraticode.json projectId");
-    return fileExplicit;
-  }
-
-  let id = coreProjectId(folderPath);
-
-  // Branch-aware mode: append sanitized branch name to isolate per-branch indexes
-  if (process.env.SOCRATICODE_BRANCH_AWARE === "true") {
-    const branch = detectGitBranch(path.resolve(folderPath));
-    if (branch) {
-      const sanitized = sanitizeBranchName(branch);
-      if (sanitized) {
-        id = `${id}__${sanitized}`;
-      }
-    }
-  }
-
-  return id;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { QDRANT_COLLECTION_PREFIX } from "./constants.js";
+import { logger } from "./services/logger.js";
 
 // ── Branch detection ─────────────────────────────────────────────────────
 
@@ -86,15 +87,52 @@ function readProjectIdFromConfigFile(folderPath: string): string | null {
  * appended to the hash, producing a separate set of collections per
  * branch.
  */
+/**
+ * Projects already warned that their branch-aware setting is being ignored.
+ *
+ * `projectIdFromPath` runs on essentially every tool call, so without this the
+ * warning would repeat for the life of the process. Keyed by the resolved id
+ * rather than the path, because the whole point of an explicit id is that
+ * several paths share one.
+ */
+const branchAwareIgnoredWarned = new Set<string>();
+
+/**
+ * Warn once when `SOCRATICODE_BRANCH_AWARE=true` has no effect because an
+ * explicit project id won.
+ *
+ * The precedence itself is deliberate and documented: an explicit id is a
+ * stable identity and is not augmented per branch. Suffixing it would rename
+ * the collections of every existing installation and make their indexes look
+ * missing. What was wrong was doing it silently — the setting is accepted and
+ * simply does nothing, so the only way to find out was to read this file.
+ */
+function warnBranchAwareIgnored(projectId: string, source: string): void {
+  if (process.env.SOCRATICODE_BRANCH_AWARE !== "true") return;
+  if (branchAwareIgnoredWarned.has(projectId)) return;
+  branchAwareIgnoredWarned.add(projectId);
+  logger.warn(
+    "SOCRATICODE_BRANCH_AWARE is ignored for this project because an explicit project id takes precedence — every branch shares one index",
+    {
+      projectId,
+      explicitIdFrom: source,
+      howToGetPerBranchIndexes:
+        "remove the explicit project id so the path-derived id can carry a branch suffix, or set a branch-specific SOCRATICODE_PROJECT_ID deliberately",
+    },
+  );
+}
+
 export function projectIdFromPath(folderPath: string): string {
   const envExplicit = process.env.SOCRATICODE_PROJECT_ID?.trim();
   if (envExplicit) {
     assertValidProjectId(envExplicit, "SOCRATICODE_PROJECT_ID");
+    warnBranchAwareIgnored(envExplicit, "SOCRATICODE_PROJECT_ID");
     return envExplicit;
   }
 
   const fileExplicit = readProjectIdFromConfigFile(folderPath);
   if (fileExplicit) {
+    warnBranchAwareIgnored(fileExplicit, ".socraticode.json projectId");
     return fileExplicit;
   }
 

--- a/tests/unit/branch-aware-explicit-id-warning.test.ts
+++ b/tests/unit/branch-aware-explicit-id-warning.test.ts
@@ -48,6 +48,10 @@ function makeGitProject(name: string, branch: string, config?: Record<string, un
   execFileSync("git", ["init", "-b", branch, dir], { stdio: ["pipe", "pipe", "pipe"] });
   git("config", "user.name", "test");
   git("config", "user.email", "test@test.com");
+  // A developer's global config commonly has commit.gpgsign=true, which fails
+  // in a throwaway repo with no signing key. config.test.ts does the same.
+  git("config", "commit.gpgsign", "false");
+  git("config", "tag.gpgsign", "false");
   fs.writeFileSync(path.join(dir, "a.txt"), "x\n");
   git("add", "-A");
   git("commit", "-m", "init");
@@ -124,6 +128,21 @@ describe("branch-aware ignored because an explicit id won", () => {
     const ctx = warn.mock.calls[0][1] as Record<string, string>;
     expect(ctx.branch).toBe("(none detected)");
     expect(ctx.howToGetPerBranchIndexes).toMatch(/no detectable git branch/);
+    expect(ctx.howToGetPerBranchIndexes).not.toMatch(/remove the explicit project id/);
+  });
+
+it("does not advise removing the id when the branch sanitizes to nothing", async () => {
+    // `___` is a legal branch name and sanitizeBranchName strips it to "", so
+    // projectIdFromPath returns the unsuffixed id — removing the explicit id
+    // would change identity and still produce no per-branch index.
+    process.env.SOCRATICODE_PROJECT_ID = "pinned";
+    process.env.SOCRATICODE_BRANCH_AWARE = "true";
+    const { projectIdFromPath } = await import("../../src/config.js");
+    projectIdFromPath(makeGitProject("c-unusable", "___"));
+
+    const ctx = warn.mock.calls[0][1] as Record<string, string>;
+    expect(ctx.branch).toBe("___");
+    expect(ctx.howToGetPerBranchIndexes).toMatch(/no characters usable/);
     expect(ctx.howToGetPerBranchIndexes).not.toMatch(/remove the explicit project id/);
   });
 

--- a/tests/unit/branch-aware-explicit-id-warning.test.ts
+++ b/tests/unit/branch-aware-explicit-id-warning.test.ts
@@ -19,7 +19,9 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const warn = vi.fn();
+// vi.mock factories are hoisted above surrounding declarations, so the spy has
+// to be created inside vi.hoisted rather than closed over from a plain const.
+const { warn } = vi.hoisted(() => ({ warn: vi.fn() }));
 
 vi.mock("../../src/services/logger.js", () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
@@ -35,6 +37,20 @@ function makeProject(name: string, config?: Record<string, unknown>): string {
   if (config) {
     fs.writeFileSync(path.join(dir, ".socraticode.json"), JSON.stringify(config));
   }
+  return dir;
+}
+
+/** A project on a real, born branch — `rev-parse HEAD` throws until there is a commit. */
+function makeGitProject(name: string, branch: string, config?: Record<string, unknown>): string {
+  const dir = makeProject(name, config);
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: dir, stdio: ["pipe", "pipe", "pipe"] });
+  execFileSync("git", ["init", "-b", branch, dir], { stdio: ["pipe", "pipe", "pipe"] });
+  git("config", "user.name", "test");
+  git("config", "user.email", "test@test.com");
+  fs.writeFileSync(path.join(dir, "a.txt"), "x\n");
+  git("add", "-A");
+  git("commit", "-m", "init");
   return dir;
 }
 
@@ -82,17 +98,44 @@ describe("branch-aware ignored because an explicit id won", () => {
     expect(warn.mock.calls[0][1]).toMatchObject({ explicitIdFrom: ".socraticode.json projectId" });
   });
 
-  it("says how to actually get per-branch collections", async () => {
+  it("says how to actually get per-branch collections, naming the branch", async () => {
     // A diagnostic that only says "ignored" leaves the reader where they
     // started; the whole complaint was that the setting gave no guidance.
     process.env.SOCRATICODE_PROJECT_ID = "pinned";
     process.env.SOCRATICODE_BRANCH_AWARE = "true";
     const { projectIdFromPath } = await import("../../src/config.js");
-    projectIdFromPath(makeProject("c"));
+    projectIdFromPath(makeGitProject("c", "feat/thing"));
 
-    expect(String(JSON.stringify(warn.mock.calls[0][1]))).toMatch(
-      /remove the explicit project id|branch-specific SOCRATICODE_PROJECT_ID/,
-    );
+    const ctx = warn.mock.calls[0][1] as Record<string, string>;
+    expect(ctx.branch).toBe("feat/thing");
+    expect(ctx.howToGetPerBranchIndexes).toMatch(/remove the explicit project id/);
+    // The suffix it would actually receive, not the raw branch name.
+    expect(ctx.howToGetPerBranchIndexes).toContain("feat_thing");
+  });
+
+  it("does not advise removing the id when no branch could be detected", async () => {
+    // Following that advice in a non-git project would change the project's
+    // identity, orphan its collection, and still produce no suffix.
+    process.env.SOCRATICODE_PROJECT_ID = "pinned";
+    process.env.SOCRATICODE_BRANCH_AWARE = "true";
+    const { projectIdFromPath } = await import("../../src/config.js");
+    projectIdFromPath(makeProject("c-nogit"));
+
+    const ctx = warn.mock.calls[0][1] as Record<string, string>;
+    expect(ctx.branch).toBe("(none detected)");
+    expect(ctx.howToGetPerBranchIndexes).toMatch(/no detectable git branch/);
+    expect(ctx.howToGetPerBranchIndexes).not.toMatch(/remove the explicit project id/);
+  });
+
+  it("rejects an invalid explicit id before warning about it", async () => {
+    // assertValidProjectId runs first, so an id the process is about to refuse
+    // is never entered into the dedupe set nor logged as a live project id.
+    process.env.SOCRATICODE_PROJECT_ID = "not a valid id!";
+    process.env.SOCRATICODE_BRANCH_AWARE = "true";
+    const { projectIdFromPath } = await import("../../src/config.js");
+
+    expect(() => projectIdFromPath(makeProject("c-invalid"))).toThrow();
+    expect(warnings()).toHaveLength(0);
   });
 
   it("warns once per project, not once per call", async () => {
@@ -149,19 +192,7 @@ describe("nothing about resolution changed", () => {
     // is legitimately absent, and this would pass either way.
     process.env.SOCRATICODE_BRANCH_AWARE = "true";
     const { projectIdFromPath } = await import("../../src/config.js");
-    const repo = makeProject("i");
-    const git = (...args: string[]) =>
-      execFileSync("git", args, { cwd: repo, stdio: ["pipe", "pipe", "pipe"] });
-    execFileSync("git", ["init", "-b", "feat/my-feature", repo], {
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    // `rev-parse --abbrev-ref HEAD` throws while the branch is unborn, so the
-    // detector would answer null and the suffix would be legitimately absent.
-    git("config", "user.name", "test");
-    git("config", "user.email", "test@test.com");
-    fs.writeFileSync(path.join(repo, "a.txt"), "x\n");
-    git("add", "-A");
-    git("commit", "-m", "init");
+    const repo = makeGitProject("i", "feat/my-feature");
 
     const id = projectIdFromPath(repo);
 

--- a/tests/unit/branch-aware-explicit-id-warning.test.ts
+++ b/tests/unit/branch-aware-explicit-id-warning.test.ts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Giancarlo Erra - Altaire Limited
+
+/**
+ * `SOCRATICODE_BRANCH_AWARE=true` is ignored when a project pins an id, and
+ * that precedence is deliberate: an explicit id is a stable identity, and
+ * suffixing it would rename the collections an existing installation already
+ * uses and make its indexes appear missing.
+ *
+ * What was wrong was the silence. The setting was accepted and did nothing, so
+ * the only way to discover it was to read `config.ts`. These tests pin the
+ * diagnostic, and — just as importantly — pin that nothing about the resolved
+ * ids or the linked-project dedup changed alongside it.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const warn = vi.fn();
+
+vi.mock("../../src/services/logger.js", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+}));
+
+const originalEnv = { ...process.env };
+let tmp = "";
+
+/** A project directory, optionally pinning an id in `.socraticode.json`. */
+function makeProject(name: string, config?: Record<string, unknown>): string {
+  const dir = path.join(tmp, name);
+  fs.mkdirSync(dir, { recursive: true });
+  if (config) {
+    fs.writeFileSync(path.join(dir, ".socraticode.json"), JSON.stringify(config));
+  }
+  return dir;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  warn.mockClear();
+  process.env = { ...originalEnv };
+  delete process.env.SOCRATICODE_PROJECT_ID;
+  delete process.env.SOCRATICODE_BRANCH_AWARE;
+  delete process.env.SOCRATICODE_LINKED_PROJECTS;
+  delete process.env.QDRANT_COLLECTION_PREFIX;
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "socraticode-branchaware-"));
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/** Every warning message emitted, for readable assertions. */
+function warnings(): string[] {
+  return warn.mock.calls.map((c) => String(c[0]));
+}
+
+describe("branch-aware ignored because an explicit id won", () => {
+  it("warns when the id comes from SOCRATICODE_PROJECT_ID", async () => {
+    process.env.SOCRATICODE_PROJECT_ID = "pinned_by_env";
+    process.env.SOCRATICODE_BRANCH_AWARE = "true";
+    const { projectIdFromPath } = await import("../../src/config.js");
+
+    expect(projectIdFromPath(makeProject("a"))).toBe("pinned_by_env");
+    expect(warnings()).toHaveLength(1);
+    expect(warnings()[0]).toMatch(/BRANCH_AWARE is ignored/);
+    expect(warn.mock.calls[0][1]).toMatchObject({ explicitIdFrom: "SOCRATICODE_PROJECT_ID" });
+  });
+
+  it("warns when the id comes from .socraticode.json", async () => {
+    process.env.SOCRATICODE_BRANCH_AWARE = "true";
+    const { projectIdFromPath } = await import("../../src/config.js");
+
+    expect(projectIdFromPath(makeProject("b", { projectId: "pinned_by_file" }))).toBe(
+      "pinned_by_file",
+    );
+    expect(warnings()).toHaveLength(1);
+    expect(warn.mock.calls[0][1]).toMatchObject({ explicitIdFrom: ".socraticode.json projectId" });
+  });
+
+  it("says how to actually get per-branch collections", async () => {
+    // A diagnostic that only says "ignored" leaves the reader where they
+    // started; the whole complaint was that the setting gave no guidance.
+    process.env.SOCRATICODE_PROJECT_ID = "pinned";
+    process.env.SOCRATICODE_BRANCH_AWARE = "true";
+    const { projectIdFromPath } = await import("../../src/config.js");
+    projectIdFromPath(makeProject("c"));
+
+    expect(String(JSON.stringify(warn.mock.calls[0][1]))).toMatch(
+      /remove the explicit project id|branch-specific SOCRATICODE_PROJECT_ID/,
+    );
+  });
+
+  it("warns once per project, not once per call", async () => {
+    // projectIdFromPath runs on essentially every tool call, so a warning that
+    // repeated would be worse than the silence it replaces.
+    process.env.SOCRATICODE_PROJECT_ID = "pinned";
+    process.env.SOCRATICODE_BRANCH_AWARE = "true";
+    const { projectIdFromPath } = await import("../../src/config.js");
+    const project = makeProject("d");
+
+    for (let i = 0; i < 25; i++) projectIdFromPath(project);
+
+    expect(warnings()).toHaveLength(1);
+  });
+
+  it("warns for each distinct project, since each is separately affected", async () => {
+    process.env.SOCRATICODE_BRANCH_AWARE = "true";
+    const { projectIdFromPath } = await import("../../src/config.js");
+
+    projectIdFromPath(makeProject("e", { projectId: "first" }));
+    projectIdFromPath(makeProject("f", { projectId: "second" }));
+    projectIdFromPath(makeProject("e2", { projectId: "first" })); // same id again
+
+    expect(warnings()).toHaveLength(2);
+  });
+
+  it("stays silent when branch-aware mode is off", async () => {
+    process.env.SOCRATICODE_PROJECT_ID = "pinned";
+    const { projectIdFromPath } = await import("../../src/config.js");
+    projectIdFromPath(makeProject("g"));
+
+    expect(warnings()).toHaveLength(0);
+  });
+});
+
+describe("nothing about resolution changed", () => {
+  it("returns the same ids and collection names as before the warning existed", async () => {
+    process.env.SOCRATICODE_BRANCH_AWARE = "true";
+    const { collectionName, projectIdFromPath } = await import("../../src/config.js");
+
+    const fromFile = makeProject("h", { projectId: "stable_id" });
+    expect(projectIdFromPath(fromFile)).toBe("stable_id");
+    expect(collectionName(projectIdFromPath(fromFile))).toBe("codebase_stable_id");
+
+    process.env.SOCRATICODE_PROJECT_ID = "env_id";
+    expect(projectIdFromPath(fromFile)).toBe("env_id");
+    expect(collectionName(projectIdFromPath(fromFile))).toBe("codebase_env_id");
+  });
+
+  it("still appends the branch suffix when the id is path-derived", async () => {
+    // The feature itself must keep working where it applies, or this change
+    // would have quietly turned branch-aware mode off everywhere. A real git
+    // repo is required: without one the branch cannot be detected, the suffix
+    // is legitimately absent, and this would pass either way.
+    process.env.SOCRATICODE_BRANCH_AWARE = "true";
+    const { projectIdFromPath } = await import("../../src/config.js");
+    const repo = makeProject("i");
+    const git = (...args: string[]) =>
+      execFileSync("git", args, { cwd: repo, stdio: ["pipe", "pipe", "pipe"] });
+    execFileSync("git", ["init", "-b", "feat/my-feature", repo], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    // `rev-parse --abbrev-ref HEAD` throws while the branch is unborn, so the
+    // detector would answer null and the suffix would be legitimately absent.
+    git("config", "user.name", "test");
+    git("config", "user.email", "test@test.com");
+    fs.writeFileSync(path.join(repo, "a.txt"), "x\n");
+    git("add", "-A");
+    git("commit", "-m", "init");
+
+    const id = projectIdFromPath(repo);
+
+    expect(warnings()).toHaveLength(0);
+    expect(id).toMatch(/^[0-9a-f]{12}__feat_my-feature$/);
+  });
+
+  it("leaves linked-project deduplication alone", async () => {
+    // resolveLinkedCollections compares an id from projectIdFromPath against
+    // ids derived differently for linked projects. The warning must not touch
+    // that comparison — it only logs.
+    const { resolveLinkedCollections } = await import("../../src/config.js");
+    const main = makeProject("j", { projectId: "shared", linkedProjects: ["../j-linked"] });
+    makeProject("j-linked", { projectId: "shared" });
+
+    process.env.SOCRATICODE_BRANCH_AWARE = "true";
+    const collections = resolveLinkedCollections(main);
+
+    // The linked project resolves to the same id, so it is deduped away and
+    // only the current project's collection remains.
+    expect(collections.map((c) => c.name)).toEqual(["codebase_shared"]);
+  });
+});


### PR DESCRIPTION
Closes #165.

`SOCRATICODE_BRANCH_AWARE=true` has no effect when a project pins an id, because
`projectIdFromPath` returns on both explicit paths before the branch-aware branch
is reached. The precedence is deliberate and already stated in the environment
variable table and `DEVELOPER.md`; what was wrong was that it happened silently,
so the only way to find out was to read `config.ts`.

## Resolution is unchanged

Both explicit sources return exactly what they returned before, and the only
new behaviour is a log line. As you said on the issue, suffixing an existing
explicit id would rename the collections an installation already uses and make
its indexes appear missing — so no existing index changes and no re-indexing is
required.

## The warning

Emitted once per affected project, keyed by the resolved id. `projectIdFromPath`
runs on essentially every tool call, so an undeduplicated warning would be worse
than the silence it replaces.

It names both ways to actually get per-branch collections — and only when they
are true. The branch is resolved at warn time rather than by the caller, which
costs one `git` invocation per affected project rather than one per resolution,
and it matters for correctness of the advice: in a project that is not a git
repository, or on a detached HEAD, no suffix would be produced regardless, so
telling the user to remove their explicit id would change their project's
identity and orphan its collection for nothing. In that case the message says so
instead.

## Documentation

The feature bullet and the "Branch-Aware Indexing" section both promised
per-branch isolation with no caveat. The env-var table and `DEVELOPER.md` were
already correct and are untouched.

## Tests

Eleven cases: both explicit sources; the guidance naming the sanitized suffix the
project would actually receive; the non-git case not advising removal; one
warning across 25 repeated calls; one warning per distinct project; silence when
the mode is off; an invalid explicit id rejected before it can be warned about or
entered into the dedupe set; unchanged ids and collection names; unchanged
linked-project deduplication; and a path-derived id still receiving its suffix,
against a real repo with a commit — `rev-parse --abbrev-ref HEAD` throws while
HEAD is unborn, so that assertion would otherwise pass either way.

Mutation-checked in both directions. Notably, mutating the code to suffix the
explicit id — the change you ruled out — fails the collection-name and
linked-dedup cases, so those two regressions actively defend that decision.

`tsc --noEmit` and biome clean; 2089 unit tests pass, up eleven.

## One thing deliberately left alone

`SOCRATICODE_BRANCH_AWARE=TRUE`, `1` or `yes` is still silently ignored — the
guard is an exact `=== "true"` match, while `INCLUDE_DOT_FILES` lowercases and
`embedding-config.ts` accepts `true`/`1`/`yes`. I did not touch it: loosening the
resolution check would newly enable branch-aware mode for anyone using a
near-miss value and rename their collections, which is the hazard you rejected;
and loosening only the warning would blame explicit-id precedence when that is
not the reason the mode is off. Happy to follow up separately if you want the
parsing made consistent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that branch-aware indexing applies only to project IDs derived from the project path.
  - Documented that explicitly configured project IDs remain shared across branches.
  - Added guidance for configuring separate per-branch indexes, including branches whose names produce no usable suffix.

- **Bug Fixes**
  - Added a one-time warning when branch-aware indexing is enabled but an explicit project ID prevents per-branch indexing.
  - The warning provides guidance based on whether a usable branch suffix is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->